### PR TITLE
fix: remove /provider alias, use /model as canonical command

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -175,8 +175,7 @@ Keybindings:
   Ctrl+C       Clear input / Quit
 
 Slash Commands:
-  /provider    Select and connect to a provider
-  /model       Select a model
+  /model       Select model and manage provider connections
   /clear       Clear chat history
   /help        Show help
 

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -89,7 +89,6 @@ func NewCommandController(deps CommandDeps) CommandController {
 func builtinCommandHandlers() map[string]commandHandler {
 	return map[string]commandHandler{
 		"model":          (*CommandController).handleModelCommand,
-		"provider":       (*CommandController).handleModelCommand,
 		"clear":          (*CommandController).handleClearCommand,
 		"fork":           (*CommandController).handleForkCommand,
 		"resume":         (*CommandController).handleResumeCommand,
@@ -627,7 +626,7 @@ func (c *CommandController) handleTokenLimitCommand(_ context.Context, args stri
 
 func (c *CommandController) handleCompactCommand(_ context.Context, args string) (string, tea.Cmd, error) {
 	if c.deps.LLMProvider == nil {
-		return "No provider connected. Use /provider to connect.", nil, nil
+		return "No provider connected. Use /model to connect.", nil, nil
 	}
 	if len(c.deps.Conversation.Messages) == 0 {
 		return "No active LLM session. Send a message first to initialize the client.", nil, nil

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -89,6 +89,7 @@ func NewCommandController(deps CommandDeps) CommandController {
 func builtinCommandHandlers() map[string]commandHandler {
 	return map[string]commandHandler{
 		"model":          (*CommandController).handleModelCommand,
+		"provider":       (*CommandController).handleModelCommand,
 		"clear":          (*CommandController).handleClearCommand,
 		"fork":           (*CommandController).handleForkCommand,
 		"resume":         (*CommandController).handleResumeCommand,

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -151,7 +151,7 @@ func runPrint(userMessage string) error {
 	}
 
 	if llmProvider == nil {
-		return fmt.Errorf("no provider connected. Run 'gen' and use /provider to connect")
+		return fmt.Errorf("no provider connected. Run 'gen' and use /model to connect")
 	}
 
 	completionOpts := llm.CompletionOptions{

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -134,7 +134,7 @@ func runPrint(userMessage string) error {
 	if current != nil {
 		p, err := llm.GetProvider(ctx, current.Provider, current.AuthMethod)
 		if err != nil {
-			return fmt.Errorf("provider %s (%s) not available: %w. Run 'gen' and use /provider to connect",
+			return fmt.Errorf("provider %s (%s) not available: %w. Run 'gen' and use /model to connect",
 				current.Provider, current.AuthMethod, err)
 		}
 		llmProvider = p

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -464,7 +464,7 @@ func (m *model) StartProviderTurn(content string) tea.Cmd {
 	if m.env.LLMProvider == nil {
 		m.conv.Append(core.ChatMessage{
 			Role:    core.RoleNotice,
-			Content: "No provider connected. Use /provider to connect.",
+			Content: "No provider connected. Use /model to connect.",
 		})
 		return tea.Batch(m.CommitMessages()...)
 	}
@@ -689,7 +689,7 @@ func (m *model) cancelRemainingToolCalls(startIdx int) {
 
 func (m *model) HandleSkillInvocation() tea.Cmd {
 	if m.env.LLMProvider == nil {
-		m.conv.AddNotice("No provider connected. Use /provider to connect.")
+		m.conv.AddNotice("No provider connected. Use /model to connect.")
 		m.userInput.Skill.ClearPending()
 		return tea.Batch(m.CommitMessages()...)
 	}

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -26,6 +26,7 @@ type Info struct {
 func builtinCommands() []Info {
 	return []Info{
 		{Name: "model", Description: "Select model and manage provider connections"},
+		{Name: "provider", Description: "Select model and manage provider connections"},
 		{Name: "clear", Description: "Clear chat history"},
 		{Name: "fork", Description: "Fork current conversation into a new session"},
 		{Name: "resume", Description: "Resume a previous session (opens session selector)"},

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -26,7 +26,6 @@ type Info struct {
 func builtinCommands() []Info {
 	return []Info{
 		{Name: "model", Description: "Select model and manage provider connections"},
-		{Name: "provider", Description: "Select model and manage provider connections"},
 		{Name: "clear", Description: "Clear chat history"},
 		{Name: "fork", Description: "Fork current conversation into a new session"},
 		{Name: "resume", Description: "Resume a previous session (opens session selector)"},


### PR DESCRIPTION
## Summary
- Remove `/provider` as an alias for `/model` slash command
- Update all "Use /provider to connect" messages to "/model"
- `/model` is now the single canonical command for managing provider connections

## Related issue(s)
N/A

---
🤖 Generated with Claude Code