### PR TITLE
✨ Update Claude model catalog and add 1M context support

### DIFF
--- a/internal/llm/anthropic/catalog.go
+++ b/internal/llm/anthropic/catalog.go
@@ -23,13 +23,43 @@ type catalogEntry struct {
 
 var anthropicCatalog = []catalogEntry{
 	{
+		match:            matchAnyPrefix("claude-opus-4-7"),
+		info:             newModelInfo("claude-opus-4-7", "Claude Opus 4.7", "Claude Opus 4.7 (Most Capable)", 200000),
+		supportsThinking: true,
+	},
+	{
+		match:            matchAnyPrefix("claude-opus-4-6[1m]"),
+		info:             newModelInfo("claude-opus-4-6[1m]", "Claude Opus 4.6 (1M)", "Claude Opus 4.6 (1M Context)", 1000000),
+		supportsThinking: true,
+	},
+	{
+		match:            matchAnyPrefix("claude-opus-4-6"),
+		info:             newModelInfo("claude-opus-4-6", "Claude Opus 4.6", "Claude Opus 4.6", 200000),
+		supportsThinking: true,
+	},
+	{
+		match:            matchAnyPrefix("claude-opus-4-5"),
+		info:             newModelInfo("claude-opus-4-5-20251101", "Claude Opus 4.5", "Claude Opus 4.5", 200000),
+		supportsThinking: true,
+	},
+	{
 		match:            matchAnyPrefix("claude-opus-4-1"),
-		info:             newModelInfo("claude-opus-4-1-20250805", "Claude Opus 4.1", "Claude Opus 4.1 (Most Capable)", 200000),
+		info:             newModelInfo("claude-opus-4-1-20250805", "Claude Opus 4.1", "Claude Opus 4.1", 200000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4"),
 		info:             newModelInfo("claude-opus-4-20250514", "Claude Opus 4", "Claude Opus 4", 200000),
+		supportsThinking: true,
+	},
+	{
+		match:            matchAnyPrefix("claude-sonnet-4-6"),
+		info:             newModelInfo("claude-sonnet-4-6", "Claude Sonnet 4.6", "Claude Sonnet 4.6", 200000),
+		supportsThinking: true,
+	},
+	{
+		match:            matchAnyPrefix("claude-sonnet-4-5"),
+		info:             newModelInfo("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "Claude Sonnet 4.5", 200000),
 		supportsThinking: true,
 	},
 	{
@@ -43,12 +73,12 @@ var anthropicCatalog = []catalogEntry{
 		supportsThinking: true,
 	},
 	{
-		match: matchAnyPrefix("claude-3-5-haiku"),
-		info:  newModelInfo("claude-3-5-haiku-20241022", "Claude Haiku 3.5", "Claude Haiku 3.5 (Fast)", 200000),
+		match: matchAnyPrefix("claude-haiku-4-5"),
+		info:  newModelInfo("claude-haiku-4-5-20251001", "Claude Haiku 4.5", "Claude Haiku 4.5 (Fast)", 200000),
 	},
 	{
-		match: matchAnyPrefix("claude-3-haiku"),
-		info:  newModelInfo("claude-3-haiku-20240307", "Claude Haiku 3", "Claude Haiku 3", 200000),
+		match: matchAnyPrefix("claude-3-5-haiku"),
+		info:  newModelInfo("claude-3-5-haiku-20241022", "Claude Haiku 3.5", "Claude Haiku 3.5", 200000),
 	},
 }
 

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 
 	"github.com/genai-io/gen-code/internal/core"
 	"github.com/genai-io/gen-code/internal/llm"
@@ -164,8 +165,10 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 			maxTokens = thinkingBudget + 8192 // leave room for the actual response
 		}
 
+		modelID, reqOpts := resolveModelOpts(opts.Model)
+
 		params := anthropic.MessageNewParams{
-			Model:     anthropic.Model(opts.Model),
+			Model:     anthropic.Model(modelID),
 			MaxTokens: maxTokens,
 			Messages:  anthropicMsgs,
 		}
@@ -193,7 +196,7 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 		log.LogRequestCtx(ctx, c.name, opts.Model, opts)
 
 		// Create streaming request
-		stream := c.client.Messages.NewStreaming(ctx, params)
+		stream := c.client.Messages.NewStreaming(ctx, params, reqOpts...)
 
 		state := streamutil.NewState(c.name)
 
@@ -385,6 +388,15 @@ func sanitizeToolResults(msgs []core.Message) []core.Message {
 	}
 
 	return result
+}
+
+const extendedContextSuffix = "[1m]"
+
+func resolveModelOpts(model string) (string, []option.RequestOption) {
+	if base, ok := strings.CutSuffix(model, extendedContextSuffix); ok {
+		return base, []option.RequestOption{option.WithHeader("anthropic-beta", "context-1m-2025-08-07")}
+	}
+	return model, nil
 }
 
 func anthropicThinkingBudget(model, effort string) int {

--- a/internal/llm/anthropic/vertex.go
+++ b/internal/llm/anthropic/vertex.go
@@ -27,12 +27,18 @@ var VertexMeta = llm.Meta{
 // Note: Vertex AI does not provide a stable Anthropic Models API, so we use a
 // static list and refresh it when Anthropic/Vertex documentation changes.
 var vertexModels = []llm.ModelInfo{
-	newVertexModel("claude-opus-4-1@20250805", "Claude Opus 4.1", "Claude Opus 4.1 (Most Capable)"),
+	newVertexModel("claude-opus-4-7", "Claude Opus 4.7", "Claude Opus 4.7 (Most Capable)"),
+	newVertexModel("claude-opus-4-6[1m]", "Claude Opus 4.6 (1M)", "Claude Opus 4.6 (1M Context)"),
+	newVertexModel("claude-opus-4-6", "Claude Opus 4.6", "Claude Opus 4.6"),
+	newVertexModel("claude-opus-4-5", "Claude Opus 4.5", "Claude Opus 4.5"),
+	newVertexModel("claude-opus-4-1@20250805", "Claude Opus 4.1", "Claude Opus 4.1"),
 	newVertexModel("claude-opus-4@20250514", "Claude Opus 4", "Claude Opus 4"),
+	newVertexModel("claude-sonnet-4-6", "Claude Sonnet 4.6", "Claude Sonnet 4.6"),
+	newVertexModel("claude-sonnet-4-5", "Claude Sonnet 4.5", "Claude Sonnet 4.5"),
 	newVertexModel("claude-sonnet-4@20250514", "Claude Sonnet 4", "Claude Sonnet 4"),
 	newVertexModel("claude-3-7-sonnet@20250219", "Claude Sonnet 3.7", "Claude Sonnet 3.7"),
-	newVertexModel("claude-3-5-haiku@20241022", "Claude Haiku 3.5", "Claude Haiku 3.5 (Fast)"),
-	newVertexModel("claude-3-haiku@20240307", "Claude Haiku 3", "Claude Haiku 3"),
+	newVertexModel("claude-haiku-4-5", "Claude Haiku 4.5", "Claude Haiku 4.5 (Fast)"),
+	newVertexModel("claude-3-5-haiku@20241022", "Claude Haiku 3.5", "Claude Haiku 3.5"),
 }
 
 // VertexClient wraps the standard Client with Vertex-specific behavior


### PR DESCRIPTION
## Summary

- Add latest Claude models to both Anthropic API and Vertex AI catalogs: Opus 4.7, 4.6, 4.5, Sonnet 4.6, 4.5, and Haiku 4.5
- Add separate Opus 4.6 (1M Context) variant that strips the `[1m]` suffix from the model ID and sends the `anthropic-beta: context-1m-2025-08-07` header to enable the 1M context window
- Remove deprecated Claude 3 Haiku entry and move "Most Capable" label to Opus 4.7

## Test plan

- [ ] Run `make build` and verify build succeeds
- [ ] Clear model cache (`rm ~/.gen/providers.json`) and restart
- [ ] Open `/model` and verify all new models appear in the list
- [ ] Select `Claude Opus 4.6 (1M Context)` via Vertex AI and verify it connects without `400 Bad Request`
- [ ] Select regular `Claude Opus 4.6` and verify it still works with default 200K context

Assisted by Claude