### PR TITLE
feat: transcript tracing pipeline + gen trace viewer

### DIFF
--- a/cmd/gen/trace.go
+++ b/cmd/gen/trace.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/genai-io/gen-code/internal/session"
+	"github.com/genai-io/gen-code/internal/trace"
+)
+
+var (
+	traceAddr   string
+	traceNoOpen bool
+)
+
+func init() {
+	traceCmd.Flags().StringVar(&traceAddr, "addr", "127.0.0.1:0", "Bind address (127.0.0.1 only; do not expose externally)")
+	traceCmd.Flags().BoolVar(&traceNoOpen, "no-open", false, "Print the URL but don't launch the browser")
+	rootCmd.AddCommand(traceCmd)
+}
+
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Open the local trace viewer for this project's sessions",
+	Long: `Launch a localhost web server that visualizes session transcripts
+recorded under ~/.gen/projects/<encoded-cwd>/transcripts/. The viewer is
+read-only and runs until Ctrl-C.
+
+By default the server binds 127.0.0.1 on a random port and opens the page
+in your default browser. Use --no-open to skip the browser launch and
+--addr to pin a port (e.g. --addr 127.0.0.1:38080).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		projectDir := projectDirFor(cwd)
+
+		// Sanity: warn if no transcripts have been recorded yet but still serve.
+		txDir := filepath.Join(projectDir, "transcripts")
+		if _, err := os.Stat(txDir); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Note: no transcripts found at %s — start a gen session to populate it.\n", txDir)
+		}
+
+		// Refuse to bind to anything that isn't loopback — guards against a
+		// fat-fingered --addr that would expose conversation history.
+		if err := requireLoopback(traceAddr); err != nil {
+			return err
+		}
+
+		ln, err := net.Listen("tcp", traceAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", traceAddr, err)
+		}
+		url := fmt.Sprintf("http://%s", ln.Addr().String())
+
+		srv := &http.Server{Handler: trace.New(projectDir).Handler()}
+
+		// Shutdown on SIGINT/SIGTERM.
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		go func() {
+			<-ctx.Done()
+			shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutCtx)
+		}()
+
+		fmt.Printf("gen trace: serving %s\n  project: %s\n", url, projectDir)
+		if !traceNoOpen {
+			openBrowser(url)
+		}
+
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	},
+}
+
+// projectDirFor returns ~/.gen/projects/<encoded-cwd>. Mirrors
+// session.encodePath without importing internals.
+func projectDirFor(cwd string) string {
+	home, _ := os.UserHomeDir()
+	encoded := session.EncodePath(cwd)
+	return filepath.Join(home, ".gen", "projects", encoded)
+}
+
+// requireLoopback rejects any bind address whose host isn't 127.0.0.1/::1.
+// Localhost-only is the security model — the trace contains everything the
+// model saw, including any secrets in tool inputs.
+func requireLoopback(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid --addr %q: %w", addr, err)
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	switch host {
+	case "127.0.0.1", "::1", "localhost":
+		return nil
+	}
+	return fmt.Errorf("--addr %q is not loopback; only 127.0.0.1, ::1, or localhost are allowed", addr)
+}
+
+func openBrowser(url string) {
+	var bin string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		bin, args = "open", []string{url}
+	case "linux":
+		bin, args = "xdg-open", []string{url}
+	case "windows":
+		bin, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return
+	}
+	_ = exec.Command(bin, args...).Start()
+}

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,679 @@
+# Tracing
+
+How `gencode` records every input that reaches the model, every decision the
+harness makes around that input, and every response that comes back — into a
+single append-only log that doubles as the session's source of truth, a debug
+trace, and a replayable history.
+
+This doc is a first-principles description of what belongs in the trace, the
+naming convention each record follows, and how it gets surfaced through
+`gen trace`. Storage layout and resume mechanics are covered separately in
+[transcriptstore.md](transcriptstore.md); this doc focuses on the *event
+model* and the *viewer*.
+
+## First principles
+
+> **Given only the JSONL file, we must be able to reconstruct — byte for byte
+> — what the model saw, what it produced, and why the inputs were what they
+> were, at every turn.**
+
+That single requirement implies three rules:
+
+1. **Capture causes, not effects.** When something mutates an input
+   (system-prompt section, tool registry, model selection, message stream),
+   record the mutation. Don't capture only the post-mutation snapshot — that
+   loses the chain of "who changed what, in what order."
+2. **Record before commit.** The event that changed inputs must be appended
+   *before* the `inference.requested` that consumed those inputs. Order in
+   the file equals causal order.
+3. **Snapshots are derived.** Any "current state" view (current system
+   prompt, current tool list, current message chain) is reconstructed by
+   replaying records. Snapshots in the file exist only as integrity checks,
+   not as primary state.
+
+A trace that follows these rules is also a usable log: every meaningful event
+in the system shows up exactly once, in causal order, with full payload.
+
+## Invariants
+
+- **Append-only.** Records never mutate after being written. Compaction and
+  fork are themselves recorded as events, not in-place rewrites.
+- **One file per session.** `~/.gen/projects/<encoded-cwd>/transcripts/<sessionId>.jsonl`.
+  Subagent sessions are separate files linked by `parentId`.
+- **Self-contained.** Replaying the JSONL reconstructs everything the agent
+  ran with, with one exception: external mutable state (files on disk, time)
+  is not recorded — only the fact that a tool read it is.
+- **Stable record IDs.** Every record has an `id` derived from `(sessionId,
+  monotonic counter or messageId)` so consumers can dedupe and reference
+  records across forks.
+
+## Naming convention
+
+Every record type follows one rule:
+
+```
+<entity>[.<sub-entity>].<past-tense-verb>
+```
+
+- **Lowercase, dot-separated, at most three segments.**
+- **Entity is a singular noun** referring to the thing the event is about
+  (`session`, `message`, `tool`, `hook`, …).
+- **Verb is past tense.** Records are immutable facts about events that
+  already happened: `started`, `added`, `removed`, `changed`, `appended`,
+  `invoked`, `completed`, `fired`, `decided`, `requested`, `responded`.
+- **Pairs are symmetric.** Start/end uses one consistent pair throughout:
+  `requested`/`responded`, `invoked`/`completed`, `started`/`ended`.
+- **Plural entity ⇒ batch event.** `tools.added` carries an array because
+  tools register in batches; `system.section.added` is singular because
+  sections mutate one at a time.
+
+The same rule applies to envelope fields and payload keys: lowercase,
+camelCase JSON, no abbreviations except universally accepted ones
+(`id`, `cwd`).
+
+## Record envelope
+
+Every line in the JSONL shares the same outer shape:
+
+```jsonc
+{
+  "id":          "<sessionId>:<recordKey>",  // stable, dedupable
+  "sessionId":   "<sessionId>",
+  "time":        "2026-05-14T22:00:00.123Z", // RFC3339Nano, UTC
+  "type":        "<see taxonomy below>",
+  "parentId":    "<id of causally preceding record>",  // optional
+  "agentId":     "<subagent id>",            // optional
+  "isSidechain": false,
+  "cwd":         "/abs/path",                // process cwd at write time
+  "gitBranch":   "main",                     // optional
+  "version":     "1",                        // bumped only on breaking change
+
+  // Exactly one payload object, keyed by the first segment of `type`.
+  // E.g. type=session.started → "session": {...}
+  //      type=system.section.added → "system": {...}
+  //      type=message.appended → "message": {...}
+  "<group>": { ... }
+}
+```
+
+Payload field name **always equals the first segment of `type`**. No
+exceptions, no compound payload keys, no `lifecycle`/`elide` aliases. This
+is what "elegant" means here: one rule, no special cases.
+
+## Event taxonomy
+
+Eighteen record types, six groups. Past tense throughout.
+
+| Group | Type | Purpose |
+|---|---|---|
+| Lifecycle | `session.started` | Session opened; initial provider, model, cwd, entrypoint. |
+| Lifecycle | `session.forked` | Forked from another session at a given message. |
+| Lifecycle | `session.compacted` | Compaction boundary inserted; older messages outside the active chain. |
+| Inputs | `system.section.added` | Named section was inserted or replaced in the system prompt. |
+| Inputs | `system.section.removed` | Section was removed. |
+| Inputs | `tools.added` | One or more tools became available. |
+| Inputs | `tools.removed` | Tools were unregistered. |
+| Inputs | `model.changed` | Provider/model swapped mid-session. |
+| Inputs | `params.changed` | Inference params (max_tokens, temperature, top_p) changed. |
+| Conversation | `message.appended` | A user/assistant/tool message entered the active chain. |
+| Conversation | `message.elided` | Messages were dropped/truncated before being sent. |
+| Tooling | `tool.invoked` | Harness started executing a tool the model requested. |
+| Tooling | `tool.completed` | Tool finished; durationMs, success, error. |
+| Harness | `hook.fired` | A hook ran; event, cmd, exitCode, head of stdout/stderr. |
+| Harness | `permission.decided` | A permission prompt was resolved. |
+| Harness | `permission.mode.changed` | Permission mode changed (auto/plan/denyAll). |
+| Integrity | `inference.requested` | Wraps a single LLM call with digests of system/tools/messages. |
+| Integrity | `inference.responded` | Counterpart with usage, stop_reason, latency, requestId. |
+| State | `state.patched` | Projected UI state: title, lastPrompt, tag, mode, tasks, worktree. |
+
+Today's transcript only writes five of these (`session.started` —
+historically named `transcript.started` —, `message.appended`,
+`state.patched`, `session.compacted`, `session.forked`). The rename and the
+remaining thirteen are the surface area added by this design.
+
+## Payload shapes
+
+Each subsection shows the payload object that sits under the group key.
+
+### Session
+
+```jsonc
+// session.started
+"session": {
+  "provider":   "anthropic",
+  "model":      "claude-opus-4-7",
+  "parentId":   "<source session id if forked or subagent>",  // optional
+  "entrypoint": "tui" | "print" | "subagent"
+}
+
+// session.forked
+"session": { "sourceSessionId": "<id>", "atMessageId": "<id>" }
+
+// session.compacted
+"session": {
+  "boundaryId":       "<messageId at boundary>",
+  "summaryMessageId": "<id of the assistant message holding the summary>",
+  "droppedCount":     42
+}
+```
+
+### System sections
+
+```jsonc
+// system.section.added
+"system": {
+  "name":    "identity",
+  "slot":    0,
+  "content": "You are Gen Code...",
+  "caller":  "command:/identity",
+  "digest":  "sha256:..."
+}
+
+// system.section.removed
+"system": { "name": "identity", "caller": "subagent:exit" }
+```
+
+Replay rule: maintain `map[name] -> {slot, content, firstInsertedAt}`;
+render-order is `(slot asc, firstInsertedAt asc)`, joined by `\n\n`.
+
+### Tools
+
+```jsonc
+// tools.added
+"tools": {
+  "added": [
+    { "name": "Read",  "description": "...", "inputSchema": {...} },
+    { "name": "Write", "description": "...", "inputSchema": {...} }
+  ],
+  "caller": "agent:init"
+}
+
+// tools.removed
+"tools": { "removed": ["Read", "Write"], "caller": "mode:plan" }
+```
+
+### Model & params
+
+```jsonc
+// model.changed
+"model": { "provider": "anthropic", "model": "claude-sonnet-4-6", "caller": "command:/model" }
+
+// params.changed
+"params": { "maxTokens": 16384, "temperature": 0.0, "topP": 1.0, "caller": "config" }
+```
+
+### Message
+
+```jsonc
+// message.appended
+"message": {
+  "messageId": "...",
+  "parentId":  "<previous message id, or empty>",
+  "role":      "user" | "assistant" | "tool",
+  "content":   [ ContentBlock, ... ]
+}
+
+// message.elided
+"message": {
+  "reason":      "tokenBudget" | "compact" | "toolResultTruncated",
+  "messageIds":  ["...", "..."],
+  "bytesDropped": 184320
+}
+```
+
+`ContentBlock` mirrors the Anthropic shape (text, thinking, tool_use,
+tool_result, image) and adds a **`source`** field for provenance:
+
+```jsonc
+{
+  "type":   "text",
+  "text":   "...",
+  "source": "user"
+            | "hook:UserPromptSubmit:reminders"
+            | "command:/identity"
+            | "reminder:system-reminder"
+            | "compact:summary"
+            | "toolTruncated"
+}
+```
+
+Without `source`, the trace cannot answer "was that paragraph user-typed or
+hook-injected?". With it, every byte the model saw is attributable.
+
+### Tool execution
+
+```jsonc
+// tool.invoked
+"tool": {
+  "toolCallId": "toolu_01...",
+  "name":       "Read",
+  "input":      { "filePath": "/foo.go" },
+  "permission": "auto" | "asked" | "denied"
+}
+
+// tool.completed
+"tool": {
+  "toolCallId": "toolu_01...",
+  "durationMs": 12,
+  "success":    true,
+  "bytes":      4096,
+  "error":      ""
+}
+```
+
+The tool *result* rides on the next `message.appended` (role=tool) so the
+content stream stays linear. `tool.invoked`/`tool.completed` are pure
+telemetry around it.
+
+### Hook & permission
+
+```jsonc
+// hook.fired
+"hook": {
+  "event":      "PostToolUse",
+  "name":       "<hook name from settings>",
+  "cmd":        "<command line>",
+  "exitCode":   0,
+  "stdoutHead": "first 1KB...",
+  "stderrHead": "first 1KB...",
+  "durationMs": 23
+}
+
+// permission.decided
+"permission": {
+  "tool":      "Bash",
+  "input":     "{...}",
+  "decision":  "allow" | "deny",
+  "scope":     "once" | "session" | "always",
+  "by":        "user" | "autoRule" | "config",
+  "rationale": "matched allow-rule: Bash(git status)"
+}
+
+// permission.mode.changed
+"permission": { "mode": "auto" | "plan" | "denyAll", "caller": "command:/permission" }
+```
+
+### Inference
+
+`inference.requested` and `inference.responded` are the only records that
+hold *snapshots* — and they hold digests, not full payloads, because the
+full payloads are reconstructible from the events that preceded them.
+
+```jsonc
+// inference.requested
+"inference": {
+  "turn":         7,
+  "agentTurn":    "main-007",                // or "main-005:explore-002"
+  "provider":     "anthropic",
+  "model":        "claude-opus-4-7",
+  "maxTokens":    16384,
+  "temperature":  0.0,
+  "systemDigest": "sha256:...",
+  "toolsDigest":  "sha256:...",
+  "messageIds":   ["m1", "m3", "m7"]
+}
+
+// inference.responded
+"inference": {
+  "turn":       7,
+  "stopReason": "tool_use",
+  "latencyMs":  1820,
+  "requestId":  "req_011...",
+  "usage": {
+    "inputTokens":              4321,
+    "cacheReadInputTokens":     1024,
+    "cacheCreationInputTokens": 256,
+    "outputTokens":             512
+  }
+}
+```
+
+If `systemDigest` doesn't match the digest reconstructed by replaying
+preceding `system.section.*` records, the trace has an integrity bug — that's
+the signal something was sent to the model without being recorded. Same for
+`toolsDigest`.
+
+## Replay
+
+To reconstruct exact inference inputs at record N:
+
+```
+state = {
+  sections: map[name]{slot, content, firstInsertedAt},
+  tools:    ordered list,
+  model:    {provider, model},
+  params:   {maxTokens, temperature, topP},
+  messages: ordered list,
+}
+
+for rec in records[0..N]:
+  switch rec.type:
+    case "system.section.added":    state.sections[rec.system.name] = ...
+    case "system.section.removed":  delete state.sections[rec.system.name]
+    case "tools.added":              state.tools += rec.tools.added
+    case "tools.removed":            state.tools -= rec.tools.removed
+    case "model.changed":            state.model = rec.model
+    case "params.changed":           state.params = rec.params
+    case "message.appended":         state.messages += rec.message
+    case "message.elided":           state.messages -= rec.message.messageIds
+    case "session.compacted":        state.messages = chainFrom(rec.session.boundaryId)
+    case "inference.requested":
+      assert digest(render(state.sections))     == rec.inference.systemDigest
+      assert digest(canonicalize(state.tools))  == rec.inference.toolsDigest
+      assert state.messages.ids()               == rec.inference.messageIds
+```
+
+Render order for sections: sort by `(slot asc, firstInsertedAt asc)`, join
+non-empty renders with `\n\n`. Mirrors `core/system_impl.go:build`.
+
+## Consumers
+
+The trace is meant to serve three uses without modification:
+
+1. **Session resume** — what `transcriptstore` already does. New record
+   types project as no-ops on the legacy reader; the rename of
+   `transcript.*` → `session.*` is the only forward-incompatible change and
+   is handled by the migration note below.
+2. **`gen trace`** — the web viewer described in the next section.
+3. **Log / grep target** — every event has a stable `type` and structured
+   payload, so `jq` over the JSONL is enough for ad-hoc analysis.
+
+### Troubleshooting recipes
+
+**Why was section X in the system prompt at turn N?**
+
+```bash
+jq 'select(.type|startswith("system.section."))' <session>.jsonl \
+  | jq 'select(.system.name=="identity")'
+```
+
+Walks every mutation of `identity` with its `caller`.
+
+**Why did the model not see tool X at turn N?**
+
+```bash
+jq 'select(.type=="tools.added" or .type=="tools.removed")' <session>.jsonl
+```
+
+Cross-reference against the turn's `inference.requested.toolsDigest`.
+
+**Which hook injected this text into my user message?**
+
+Find the `message.appended` for that message, locate the `ContentBlock`
+containing the text, read its `source` field.
+
+**Why did this tool call run without asking?**
+
+```bash
+jq 'select(.type=="permission.decided")' <session>.jsonl
+```
+
+The matching record has `by` and `rationale` fields.
+
+**What changed between turn N-1 and N?**
+
+Diff the two adjacent `inference.requested` digests. Any difference points
+to a recorded mutation between them.
+
+## `gen trace` — the web viewer
+
+A local web app that renders the JSONL into an interactive timeline, with
+live updates while a session runs. Zero-config: random port, localhost-only,
+single binary (assets embedded).
+
+### Command surface
+
+```text
+gen trace                          # start viewer, open browser, list sessions in current project
+gen trace --port 38080             # pin port; default is auto-allocated
+gen trace --no-open                # print URL only, don't shell out to open the browser
+gen trace --all                    # include sessions from other project dirs
+gen trace export <id> -o out.html  # write a self-contained, offline HTML for one session
+gen --trace                        # run a session as normal AND start the viewer in-process
+```
+
+`gen --trace` is the live mode: when launching a session it boots the viewer
+on a random localhost port, prints the URL, and shuts the server down on
+session exit. The viewer auto-selects the currently running session and
+follows it in real time.
+
+### Architecture
+
+```
+┌──────────────────┐
+│  browser (SPA)   │
+│  - timeline      │   HTTP + SSE
+│  - detail panel  │ ◀─────────────┐
+│  - replay state  │               │
+└──────────────────┘               │
+                                   │
+                          ┌────────┴─────────┐
+                          │ gen trace server │
+                          │ - net/http       │
+                          │ - fsnotify       │
+                          │ - embed.FS UI    │
+                          └────────┬─────────┘
+                                   │ read-only
+                          ┌────────┴─────────┐
+                          │ ~/.gen/projects/ │
+                          │ <cwd>/transcripts│
+                          └──────────────────┘
+```
+
+### HTTP surface
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/` | SPA shell (single HTML file from `embed.FS`) |
+| GET | `/api/sessions` | List `[{id, title, model, messageCount, createdAt, updatedAt, branch, parentId}]` |
+| GET | `/api/sessions/{id}/records?after=<id>&limit=K` | Paginated records; raw JSONL records, no reshaping |
+| GET | `/api/sessions/{id}/stream` | SSE stream; emits each new record as it's appended |
+| GET | `/api/sessions/{id}/state/{recordId}` | Replay result: reconstructed `{sections, tools, model, params, messages}` at that point |
+| GET | `/api/sessions/{id}/integrity` | Runs digest checks; returns `{ok, mismatches:[{recordId, expected, got}]}` |
+
+The records endpoint returns the bytes of the JSONL untouched (no
+re-serialization). The wire format **is** the file format. This collapses
+two schemas into one and means a browser cache of records is byte-identical
+to the file on disk.
+
+### Live updates
+
+Backend watches `~/.gen/projects/<encoded-cwd>/transcripts/` with
+`fsnotify`:
+
+- File size grew → read new lines, parse, fan out to every SSE subscriber
+  for that session.
+- New `.jsonl` appeared → push a "session appeared" event to the
+  all-sessions SSE channel.
+- File renamed/removed → push a "session closed" event.
+
+SSE is preferred over WebSocket: one-way push is all that's needed, plain
+`EventSource` works, no framing layer.
+
+### UI
+
+```
+┌──────────────────┬──────────────────────────────────────┐
+│  Sessions        │  ▶ session 5319a6e1   live ●         │
+│  ───────         │  ─────────────────────────────────── │
+│  ● running       │  Timeline                Detail      │
+│    5319a6e1     │  ───────                 ──────       │
+│  ○ resumed      │  T1 session.started ⚑    role: user   │
+│    184d4011     │  T2 system.section ⚙ →   text:        │
+│  ○ forked       │  T3 system.section ⚙ →   "explain..." │
+│    77386800     │  T4 tools.added 🔧 →     source: user │
+│                  │  T5 message ← user 💬                  │
+│  [+ all projects]│  T6 inference ▶                       │
+│                  │  T7 message ← assist 💬                │
+│  Filters:        │  T8 tool.invoked 🛠                    │
+│  ☑ message       │  T9 tool.completed ✓                  │
+│  ☑ system        │  T10 message ← tool                   │
+│  ☑ inference     │  T11 inference ◀                      │
+│  ☑ tool          │  T12 hook.fired 🪝                    │
+│  ☑ hook          │  T13 permission 🛡                    │
+│  ☐ state.patched │  ▶ live tail                          │
+└──────────────────┴──────────────────────────────────────┘
+```
+
+UI principles:
+
+- **No build step.** Vanilla JS or htmx + light JS, served from `embed.FS`.
+  No bundler, no transpile. A future redesign can swap in a framework
+  without touching the server.
+- **Group-colored rows.** Each record group has one color/icon; record type
+  shown as a small label. Quick visual scan = quick triage.
+- **Filters per group.** Default filter hides `state.patched` (UI noise).
+  User toggles to surface anything.
+- **"Show only changed system" mode.** Collapses the timeline to just
+  `system.section.*` records — instant prompt-evolution view.
+- **Click row → full payload + state snapshot.** Detail panel shows the raw
+  record JSON and the replayed state at that point (so you can see "what
+  the model saw at turn 7" without leaving the page).
+- **Diff mode.** Pick two `inference.requested` records, get a side-by-side
+  diff of system prompt, tools, and message tail.
+- **Live badge.** When SSE is connected and the session is being written
+  to, show a "live ●" indicator and auto-scroll. Pause auto-scroll on user
+  scroll-up; resume on jump-to-bottom.
+
+### `gen trace export`
+
+Produces a single HTML file with the JSONL inlined as a JS literal plus the
+SPA assets. Open it in any browser, no server needed. Use for:
+
+- attaching to bug reports
+- archiving a debugging session
+- sharing with someone who doesn't have `gencode` installed
+
+Export is **read-only** and **offline**: no fetches, no SSE — just the
+static snapshot.
+
+### Security & operational notes
+
+- **Bind 127.0.0.1 only.** Never 0.0.0.0. The trace contains everything the
+  model saw, including any secrets the user pasted.
+- **No auth.** Localhost trusts the OS user. Same posture as `gen` itself.
+- **Read-only API.** No endpoint mutates the JSONL.
+- **Process lifecycle.**
+  - `gen trace` runs until Ctrl-C.
+  - `gen --trace` runs the server for the lifetime of the session it
+    started, shuts it down on session exit, prints the URL once on start.
+- **Port discovery.** On `gen --trace`, write the chosen port to
+  `~/.gen/projects/<cwd>/.trace-port` so external tooling (editors,
+  bookmarklets) can pick it up. Delete on exit.
+
+### Why this design
+
+- **SSE over WebSocket.** Push-only fits the data flow; no framing protocol
+  needed.
+- **JSONL as the wire format.** One schema, not two. The client renders
+  the same shape that's on disk.
+- **fsnotify, not polling.** Live updates are immediate; idle viewer costs
+  nothing.
+- **Embedded assets.** Single binary, no asset directory to install.
+- **Localhost + random port.** No firewall surface, no auth complexity.
+
+## Implementation gap
+
+Listed in dependency order.
+
+### 1. Schema additions & rename
+
+- `internal/session/transcript/records.go`:
+  - Add new `RecordType` constants for all eighteen types.
+  - Add typed payload structs (`SessionRecord`, `SystemRecord` is reused,
+    `ToolsRecord`, `ModelRecord`, `ParamsRecord`, `ToolRecord`,
+    `HookRecord`, `PermissionRecord`, `InferenceRecord`,
+    `ElideRecord`-as-MessageRecord-variant, etc.). Wire them onto `Record`.
+  - Rename `Record.TranscriptID` JSON tag `transcriptId` → `sessionId`.
+- `internal/session/transcript/projector.go`:
+  - Accept both old (`transcript.started/forked/compacted`) and new
+    (`session.*`) type strings during a deprecation window. New writes use
+    `session.*`.
+  - `applyStatePatch` falls through unknown patch paths with
+    `default: continue`.
+  - Project new record types onto a richer `Transcript` view
+    (`Transcript.SectionsTimeline`, `Transcript.ToolsTimeline`, etc.).
+
+### 2. ContentBlock provenance
+
+- `internal/session/transcript/records.go`: add `Source string` to
+  `ContentBlock`. Default empty (treated as `"user"`).
+- Producers that inject content tag it at write time:
+  - `internal/reminder/` → `reminder:<name>`
+  - `internal/hook/` UserPromptSubmit / SessionStart additionalContext
+    paths → `hook:<event>:<name>`
+  - `internal/command/` slash command expansion → `command:<name>`
+  - compact summary insertion → `compact:summary`
+  - tool result truncation marker → `toolTruncated`
+
+### 3. Event bus reuse
+
+The agent already has an event outbox (`internal/core/agent_impl.go:465`).
+Extend `core.Event` with new variants for `SystemSectionChanged`,
+`ToolsChanged`, `ModelChanged`, `ParamsChanged`, `ToolInvoked`,
+`ToolCompleted`. The existing session subscriber translates them into
+transcript records — no new `Recorder` interface threaded across packages.
+
+Subsystems outside `core.Agent` (hooks, permission, slash commands) get a
+lightweight `EventSink func(Event)` injected from
+`internal/app/services.go`. Same sink, different entry points.
+
+### 4. System / tools instrumentation
+
+- `internal/core/system_impl.go`: in `Use`/`Drop`, after mutating
+  `s.sections`, emit `SystemSectionChanged{name, slot, content, caller}`.
+  `caller` is plumbed via an explicit parameter on `Use`/`Drop` (more
+  honest than a hidden context value).
+- `internal/core/tools/...`: emit `ToolsChanged` on Register/Unregister.
+- `internal/core/agent_impl.go:streamInfer`: after rendering, compute
+  digests and emit `InferenceRequested`. After the stream finishes, emit
+  `InferenceResponded`.
+
+### 5. Tool / hook / permission instrumentation
+
+- Wrap tool execution with `ToolInvoked` / `ToolCompleted` at the call site.
+- `internal/hook/`: emit `HookFired` after each hook returns, with head of
+  stdout/stderr capped at 1KB.
+- Permission bridge: emit `PermissionDecided` when a request resolves;
+  emit `PermissionModeChanged` on mode swap.
+
+### 6. `gen trace` package
+
+- New `internal/trace/` package: HTTP server, fsnotify watcher, SSE
+  fan-out, integrity replay.
+- New `internal/trace/ui/`: static SPA assets, embedded via `embed.FS`.
+- New `cmd/gen` subcommand `trace` with subcommands `serve` (default),
+  `export`. Top-level `--trace` flag wires the server into session
+  startup.
+
+### 7. Retire the parallel `DEV_DIR` path
+
+Once `inference.requested`/`inference.responded` are written into the
+transcript with digests, `internal/log/devdir.go` per-turn JSON files
+become redundant. Remove them in a follow-up; `GEN_DEBUG` still controls
+human-readable log lines, but no longer writes a second copy of the
+inference payload.
+
+### 8. Schema versioning
+
+Add `version: "1"` to every new record. Bump only on incompatible change
+(field meaning changes, required record removed). Adding new record types
+is backward-compatible and does not bump the version.
+
+## Open questions
+
+- **Section caller plumbing.** Threading `caller` through every
+  `system.Use/Drop` is noisy. Acceptable to leave it empty for paths that
+  don't know, or do we hard-require?
+- **Tool input redaction.** `tool.invoked.input` may contain secrets if a
+  user pastes credentials into a Bash command. Same risk as today's
+  `message.appended` but worth a redaction policy decision before this
+  ships — particularly because `gen trace export` produces a shareable
+  artifact.
+- **Digest canonicalization.** Tool schemas come from third-party MCP
+  servers and may not be deterministic JSON. Decide once: canonical JSON
+  (sorted keys, no whitespace) before hashing.
+- **Multi-writer safety.** Today's `FileStore` uses a per-process mutex.
+  Two concurrent `gen` invocations on the same session would interleave
+  records. Out of scope for this doc, but the trace model assumes one
+  writer at a time. The `gen trace` viewer is a reader and unaffected.

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -39,6 +39,10 @@ type BuildParams struct {
 	PermissionDecider PermDecisionFunc
 	InteractionFunc   tool.InteractionFunc
 	ToolProgress      func(toolCallID string, msg string)
+
+	// OnEvent observes every agent lifecycle event synchronously, alongside
+	// outbox delivery. Used by the trace recorder; nil leaves recording off.
+	OnEvent func(core.Event)
 }
 
 func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
@@ -87,7 +91,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 	}))
 	tools := tool.AdaptToolRegistry(schemas, cwdFunc, adaptOpts...)
 	for _, t := range p.MCPTools {
-		tools.Add(t)
+		tools.Add(t, "mcp:"+t.Name())
 	}
 
 	compactClient := client
@@ -111,6 +115,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 		Tools:       tool.WithPermission(tools, pb.PermissionFunc()),
 		CompactFunc: compactFunc,
 		CWD:         p.CWD,
+		OnEvent:     p.OnEvent,
 	})
 
 	return ag, pb, nil

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -61,11 +61,18 @@ func (m *model) buildAgentParams() agent.BuildParams {
 		mcpTools = mcp.AsCoreTools(schemas, mcpCaller)
 	}
 
+	maxTokens := kit.GetMaxTokens(m.services.LLM.Store(), m.env.CurrentModel, setting.DefaultMaxTokens)
+	var onEvent func(core.Event)
+	if rec := m.services.Session.NewRecorder("main", m.env.LLMProvider.Name(), m.env.GetModelID(), maxTokens); rec != nil {
+		onEvent = rec.OnAgentEvent
+	}
+
 	return agent.BuildParams{
 		Provider:       m.env.LLMProvider,
 		ModelID:        m.env.GetModelID(),
-		MaxTokens:      kit.GetMaxTokens(m.services.LLM.Store(), m.env.CurrentModel, setting.DefaultMaxTokens),
+		MaxTokens:      maxTokens,
 		ThinkingEffort: m.env.EffectiveThinkingEffort(),
+		OnEvent:        onEvent,
 
 		CWD:     m.env.CWD,
 		CWDFunc: func() string { return m.env.CWD },

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -133,7 +133,7 @@ func NewAgent(cfg Config) Agent {
 		outbox = make(chan Event, cfg.OutboxBuf)
 	}
 
-	return &agent{
+	a := &agent{
 		id:                cfg.ID,
 		agentType:         cfg.AgentType,
 		color:             cfg.Color,
@@ -148,6 +148,16 @@ func NewAgent(cfg Config) Agent {
 		outbox:            outbox,
 		onEvent:           cfg.OnEvent,
 	}
+	// Mirror system + tools mutations onto the event bus. Attach after
+	// construction so each registry replays its initial members back to the
+	// observer — the recorder sees a complete event chain from t0.
+	cfg.System.SetObserver(func(c SystemChange) {
+		a.emitTelemetry(SystemChangeEvent(a.id, c))
+	})
+	cfg.Tools.SetObserver(func(c ToolsChange) {
+		a.emitTelemetry(ToolsChangeEvent(a.id, c))
+	})
+	return a
 }
 
 // Result represents the outcome of one completed turn (end_turn).
@@ -178,6 +188,15 @@ const (
 	OnMessage EventType = "Message"    // message received on inbox (Message in Data)
 	OnTurn    EventType = "Turn"       // think+act cycle completed (Result in Data)
 	OnCompact EventType = "Compact"    // conversation compacted (CompactInfo in Data)
+
+	// OnSystemChange fires when a system-prompt section is added, replaced,
+	// or removed. Data is SystemChange. Non-critical telemetry — never blocks
+	// the outbox on backpressure.
+	OnSystemChange EventType = "SystemChange"
+
+	// OnToolsChange fires when a tool is registered or unregistered. Data is
+	// ToolsChange. Like OnSystemChange, non-blocking telemetry.
+	OnToolsChange EventType = "ToolsChange"
 )
 
 // Event carries context for an agent lifecycle point.
@@ -205,6 +224,50 @@ type CompactInfo struct {
 	OriginalCount int
 }
 
+// InferenceContext is the PreInfer payload — what was about to be sent to the
+// LLM, expressed as content-addressed digests so consumers (trace recorder,
+// debug logger) can reference inputs without copying them on every turn.
+type InferenceContext struct {
+	SystemDigest string   // sha256 of rendered system prompt
+	ToolsDigest  string   // sha256 of canonicalized tool schemas
+	MessageIDs   []string // active chain at request time, in send order
+}
+
+func (e Event) InferenceContext() (InferenceContext, bool) {
+	ic, ok := e.Data.(InferenceContext)
+	return ic, ok
+}
+
+// SystemChange describes one mutation to the system prompt's section map.
+// Emitted on Use/Drop. The recorder translates these into
+// system.section.added / system.section.removed records.
+type SystemChange struct {
+	Name    string // section name (stable across mutations)
+	Slot    int    // render slot
+	Content string // rendered content; empty when Removed
+	Removed bool   // true on Drop, false on Use
+	Caller  string // who triggered the mutation (e.g. "system:init", "command:/identity")
+}
+
+func (e Event) SystemChange() (SystemChange, bool) {
+	c, ok := e.Data.(SystemChange)
+	return c, ok
+}
+
+// ToolsChange describes one mutation to the tool registry. On removal,
+// Schema.Name carries the dropped tool's name and other fields are zero.
+type ToolsChange struct {
+	Schema  ToolSchema // populated on Add (zero on Remove)
+	Name    string     // populated on Remove (empty on Add)
+	Removed bool       // true on Remove, false on Add
+	Caller  string     // who triggered the mutation
+}
+
+func (e Event) ToolsChange() (ToolsChange, bool) {
+	c, ok := e.Data.(ToolsChange)
+	return c, ok
+}
+
 // Typed event constructors — enforce correct Data types at construction.
 
 func StartEvent(agentID string) Event { return Event{Type: OnStart, Source: agentID} }
@@ -214,7 +277,9 @@ func StopEvent(agentID string, err error) Event {
 func ChunkEvent(agentID string, c Chunk) Event { return Event{Type: OnChunk, Source: agentID, Data: c} }
 func MessageEvent(msg Message) Event           { return Event{Type: OnMessage, Source: msg.From, Data: msg} }
 func TurnEvent(agentID string, r Result) Event { return Event{Type: OnTurn, Source: agentID, Data: r} }
-func PreInferEvent(agentID string) Event       { return Event{Type: PreInfer, Source: agentID} }
+func PreInferEvent(agentID string, ctx InferenceContext) Event {
+	return Event{Type: PreInfer, Source: agentID, Data: ctx}
+}
 func PostInferEvent(agentID string, r *InferResponse) Event {
 	return Event{Type: PostInfer, Source: agentID, Data: r}
 }
@@ -222,4 +287,12 @@ func PreToolEvent(tc ToolCall) Event    { return Event{Type: PreTool, Source: tc
 func PostToolEvent(tr ToolResult) Event { return Event{Type: PostTool, Source: tr.ToolName, Data: tr} }
 func CompactEvent(agentID string, info CompactInfo) Event {
 	return Event{Type: OnCompact, Source: agentID, Data: info}
+}
+
+func SystemChangeEvent(agentID string, c SystemChange) Event {
+	return Event{Type: OnSystemChange, Source: agentID, Data: c}
+}
+
+func ToolsChangeEvent(agentID string, c ToolsChange) Event {
+	return Event{Type: OnToolsChange, Source: agentID, Data: c}
 }

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -210,8 +210,6 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 			}
 		}
 
-		a.emit(ctx, PreInferEvent(a.id))
-
 		resp, err := a.streamInfer(ctx)
 		if err != nil {
 			// Reactive compaction: if prompt too long, compact and retry
@@ -424,11 +422,24 @@ func ToolCallIDFromContext(ctx context.Context) string {
 // --- internals ---
 
 // streamInfer calls the LLM, streams chunks to outbox, returns the final response.
+//
+// Emits PreInferEvent (with input digests) before the LLM call so observers
+// can record exactly what was sent without copying the bytes on every turn.
 func (a *agent) streamInfer(ctx context.Context) (*InferResponse, error) {
+	sys := a.system.Prompt()
+	msgs := a.snapshot()
+	tools := a.tools.Schemas()
+
+	a.emit(ctx, PreInferEvent(a.id, InferenceContext{
+		SystemDigest: sha256Hex([]byte(sys)),
+		ToolsDigest:  toolsDigest(tools),
+		MessageIDs:   messageIDs(msgs),
+	}))
+
 	chunks, err := a.llm.Infer(ctx, InferRequest{
-		System:   a.system.Prompt(),
-		Messages: a.snapshot(),
-		Tools:    a.tools.Schemas(),
+		System:   sys,
+		Messages: msgs,
+		Tools:    tools,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("infer: %w", err)
@@ -472,6 +483,23 @@ func (a *agent) emit(ctx context.Context, event Event) {
 	select {
 	case a.outbox <- event:
 	case <-ctx.Done():
+	}
+}
+
+// emitTelemetry delivers a fire-and-forget event: synchronously to onEvent,
+// non-blocking to the outbox (dropped if full). Used for events whose
+// consumers tolerate misses (system changes, hot-path tracing) and which can
+// fire from goroutines without a useful ctx (e.g. system observer callbacks).
+func (a *agent) emitTelemetry(event Event) {
+	if a.onEvent != nil {
+		a.onEvent(event)
+	}
+	if a.outbox == nil || a.closed.Load() {
+		return
+	}
+	select {
+	case a.outbox <- event:
+	default:
 	}
 }
 

--- a/internal/core/digest.go
+++ b/internal/core/digest.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+)
+
+// sha256Hex returns "sha256:" + lowercase hex of the SHA-256 sum of b.
+// The prefix makes algorithm choice explicit on the wire.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// toolsDigest canonicalizes a tool schema list (sort by Name, marshal each)
+// and returns its sha256. Stable across runs as long as schemas are stable.
+func toolsDigest(schemas []ToolSchema) string {
+	if len(schemas) == 0 {
+		return sha256Hex(nil)
+	}
+	sorted := make([]ToolSchema, len(schemas))
+	copy(sorted, schemas)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	b, err := json.Marshal(sorted)
+	if err != nil {
+		// Marshal can only fail on unsupported types; ToolSchema fields are
+		// JSON-safe. Fall back to a digest of the names so the value is still
+		// stable rather than empty.
+		names := make([]string, len(sorted))
+		for i, s := range sorted {
+			names[i] = s.Name
+		}
+		b, _ = json.Marshal(names)
+	}
+	return sha256Hex(b)
+}
+
+// messageIDs extracts non-empty message IDs from the conversation snapshot,
+// in send order. Empty IDs (legacy data) are skipped rather than padded.
+func messageIDs(msgs []Message) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		if m.ID != "" {
+			out = append(out, m.ID)
+		}
+	}
+	return out
+}

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -19,13 +19,26 @@ type System interface {
 	// invalidated only when sections change.
 	Prompt() string
 
-	// Use registers or replaces a section by Name.
-	Use(Section)
+	// Use registers or replaces a section by Name. Caller is a short tag
+	// describing what triggered the mutation (e.g. "system:init",
+	// "command:/identity") and surfaces in the trace.
+	Use(sec Section, caller string)
 
 	// Drop removes a section by Name. No-op if absent.
-	Drop(name string)
+	Drop(name, caller string)
 
 	// Refresh marks one section's rendered output stale. Use after the
 	// section's underlying state changed but the Section value did not.
-	Refresh(name string)
+	Refresh(name, caller string)
+
+	// Sections returns a snapshot of currently registered sections in
+	// render order (slot ascending, insertion order ascending). Used by
+	// observers that attach after construction to replay the existing state.
+	Sections() []Section
+
+	// SetObserver installs a callback invoked synchronously on every
+	// subsequent mutation. Attaching also replays existing sections as
+	// "added" events so the observer sees a complete history starting
+	// from the moment of attachment.
+	SetObserver(fn func(SystemChange))
 }

--- a/internal/core/system/builder_test.go
+++ b/internal/core/system/builder_test.go
@@ -188,13 +188,13 @@ func TestSystemUseDropRefresh(t *testing.T) {
 	sys.Use(core.Section{
 		Slot: core.SlotEnvironment, Name: "test-section", Source: core.Dynamic,
 		Render: func() string { return "TEST_SECTION_BODY" },
-	})
+	}, "test")
 	if !strings.Contains(sys.Prompt(), "TEST_SECTION_BODY") {
 		t.Error("Use should add a new section's content to Prompt()")
 	}
 
 	// Drop: remove it.
-	sys.Drop("test-section")
+	sys.Drop("test-section", "test")
 	if strings.Contains(sys.Prompt(), "TEST_SECTION_BODY") {
 		t.Error("Drop should remove the section from Prompt()")
 	}

--- a/internal/core/system/catalog.go
+++ b/internal/core/system/catalog.go
@@ -57,13 +57,14 @@ func loadEmbedOptional(path string) string {
 // applyDefaults registers the always-on sections for a Scope.
 // Options passed to Build can override identity by Name.
 func applyDefaults(sys core.System, scope core.Scope) {
-	sys.Use(defaultIdentity())
-	sys.Use(policy())
-	sys.Use(guidelines("tools", cachedTools))
+	const caller = "system:init"
+	sys.Use(defaultIdentity(), caller)
+	sys.Use(policy(), caller)
+	sys.Use(guidelines("tools", cachedTools), caller)
 	if scope == core.ScopeMain {
 		// Task tracking + interactive questions are main-agent behaviors.
-		sys.Use(guidelines("tasks", cachedTasks))
-		sys.Use(guidelines("questions", cachedQuestions))
+		sys.Use(guidelines("tasks", cachedTasks), caller)
+		sys.Use(guidelines("questions", cachedQuestions), caller)
 	}
 }
 
@@ -139,7 +140,7 @@ func WithIdentity(text string) Option {
 		if text == "" {
 			return
 		}
-		sys.Use(identitySection(text))
+		sys.Use(identitySection(text), "system:init")
 	}
 }
 
@@ -148,10 +149,10 @@ func WithIdentity(text string) Option {
 func SwapIdentity(sys core.System, text string) {
 	text = strings.TrimSpace(text)
 	if text == "" {
-		sys.Use(defaultIdentity())
+		sys.Use(defaultIdentity(), "command:identity")
 		return
 	}
-	sys.Use(identitySection(text))
+	sys.Use(identitySection(text), "command:identity")
 }
 
 // identitySection builds the slot-0 identity Section for a user-defined persona.
@@ -178,7 +179,7 @@ func WithProvider(name string) Option {
 			Render: func() string {
 				return wrap("provider", map[string]string{"name": name}, body)
 			},
-		})
+		}, "system:init")
 	}
 }
 
@@ -188,7 +189,7 @@ func WithGitGuidelines(isGit bool) Option {
 		if !isGit {
 			return
 		}
-		sys.Use(guidelines("git", cachedGit))
+		sys.Use(guidelines("git", cachedGit), "system:init")
 	}
 }
 
@@ -216,7 +217,7 @@ func WithSubagentIdentity(b SubagentBrief) Option {
 		sys.Use(core.Section{
 			Slot: core.SlotIdentity, Name: "identity", Source: core.Injected,
 			Render: func() string { return renderSubagentIdentity(b) },
-		})
+		}, "subagent:init")
 	}
 }
 
@@ -278,7 +279,7 @@ func WithEnvironment(env Environment) Option {
 		sys.Use(core.Section{
 			Slot: core.SlotEnvironment, Name: "environment", Source: core.Dynamic,
 			Render: func() string { return renderEnvironment(env) },
-		})
+		}, "system:init")
 	}
 }
 

--- a/internal/core/system_impl.go
+++ b/internal/core/system_impl.go
@@ -21,6 +21,11 @@ type system struct {
 	counter  int // monotonic insertion sequence
 	cached   string
 	dirty    bool
+
+	// observer is invoked synchronously on every Use/Drop after the mutation
+	// applies. Set via SetObserver; nil until then. Reads happen on the same
+	// goroutine that mutated, so no extra locking around the call.
+	observer func(SystemChange)
 }
 
 type sectionEntry struct {
@@ -57,9 +62,8 @@ func (s *system) Prompt() string {
 	return s.cached
 }
 
-func (s *system) Use(sec Section) {
+func (s *system) Use(sec Section, caller string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if e, ok := s.sections[sec.Name]; ok {
 		// Replacing an existing section: preserve its insertion order so
 		// position in the prompt does not jump around on hot updates.
@@ -70,24 +74,102 @@ func (s *system) Use(sec Section) {
 		s.sections[sec.Name] = &sectionEntry{def: sec, inserted: s.counter}
 	}
 	s.dirty = true
+	obs := s.observer
+	s.mu.Unlock()
+
+	if obs != nil {
+		obs(SystemChange{
+			Name:    sec.Name,
+			Slot:    int(sec.Slot),
+			Content: renderSection(sec),
+			Caller:  caller,
+		})
+	}
 }
 
-func (s *system) Drop(name string) {
+func (s *system) Drop(name, caller string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.sections[name]; ok {
+	_, existed := s.sections[name]
+	if existed {
 		delete(s.sections, name)
 		s.dirty = true
 	}
+	obs := s.observer
+	s.mu.Unlock()
+
+	if existed && obs != nil {
+		obs(SystemChange{Name: name, Removed: true, Caller: caller})
+	}
 }
 
-func (s *system) Refresh(name string) {
+func (s *system) Refresh(name, caller string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	var (
+		obs     func(SystemChange)
+		changed bool
+		sec     Section
+	)
 	if e, ok := s.sections[name]; ok {
 		e.fresh = false
 		s.dirty = true
+		changed = true
+		sec = e.def
+		obs = s.observer
 	}
+	s.mu.Unlock()
+
+	if changed && obs != nil {
+		obs(SystemChange{
+			Name:    sec.Name,
+			Slot:    int(sec.Slot),
+			Content: renderSection(sec),
+			Caller:  caller,
+		})
+	}
+}
+
+// Sections returns a snapshot of currently registered sections in render order.
+func (s *system) Sections() []Section {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entries := s.sortedEntries()
+	out := make([]Section, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.def)
+	}
+	return out
+}
+
+// SetObserver attaches an observer for section mutations. On attach, the
+// existing sections are replayed as synthetic "added" events so the observer
+// sees a complete history starting from this moment.
+func (s *system) SetObserver(fn func(SystemChange)) {
+	s.mu.Lock()
+	s.observer = fn
+	entries := s.sortedEntries()
+	s.mu.Unlock()
+
+	if fn == nil {
+		return
+	}
+	for _, e := range entries {
+		fn(SystemChange{
+			Name:    e.def.Name,
+			Slot:    int(e.def.Slot),
+			Content: renderSection(e.def),
+			Caller:  "system:init",
+		})
+	}
+}
+
+// renderSection invokes a Section's Render func once, returning "" on nil.
+// Used by observers that need the rendered content without going through the
+// cached-Prompt path (which joins all sections).
+func renderSection(sec Section) string {
+	if sec.Render == nil {
+		return ""
+	}
+	return sec.Render()
 }
 
 // sortedEntries returns entries in render order (Slot, insertion order).

--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -34,7 +34,15 @@ type ToolSchema struct {
 type Tools interface {
 	Get(name string) Tool
 	All() []Tool
-	Add(tool Tool)
-	Remove(name string)
+	// Add registers (or replaces) a tool. Caller tags the mutation source
+	// (e.g. "mcp:weather", "agent:init") for trace records.
+	Add(tool Tool, caller string)
+	// Remove unregisters a tool by name. No-op if absent.
+	Remove(name, caller string)
 	Schemas() []ToolSchema
+
+	// SetObserver installs a callback invoked synchronously on every
+	// subsequent Add/Remove. Attaching also replays existing tools as
+	// synthetic Add events so the observer sees the full registry from t0.
+	SetObserver(fn func(ToolsChange))
 }

--- a/internal/core/tool_impl.go
+++ b/internal/core/tool_impl.go
@@ -13,6 +13,8 @@ type toolSet struct {
 	tools map[string]Tool
 	dirty bool         // true when schemas cache needs rebuild
 	cache []ToolSchema // cached schemas
+
+	observer func(ToolsChange) // invoked after Add/Remove; nil until SetObserver
 }
 
 // NewTools creates an empty tool set.
@@ -44,19 +46,51 @@ func (s *toolSet) All() []Tool {
 	return out
 }
 
-func (s *toolSet) Add(tool Tool) {
+func (s *toolSet) Add(tool Tool, caller string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.tools[tool.Name()] = tool
 	s.dirty = true
+	obs := s.observer
+	s.mu.Unlock()
+
+	if obs != nil {
+		obs(ToolsChange{Schema: tool.Schema(), Caller: caller})
+	}
 }
 
-func (s *toolSet) Remove(name string) {
+func (s *toolSet) Remove(name, caller string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.tools[name]; ok {
+	_, existed := s.tools[name]
+	if existed {
 		delete(s.tools, name)
 		s.dirty = true
+	}
+	obs := s.observer
+	s.mu.Unlock()
+
+	if existed && obs != nil {
+		obs(ToolsChange{Name: name, Removed: true, Caller: caller})
+	}
+}
+
+// SetObserver attaches a callback invoked on every Add/Remove. On attach,
+// existing tools are replayed as Add events with caller="tools:init".
+func (s *toolSet) SetObserver(fn func(ToolsChange)) {
+	s.mu.Lock()
+	s.observer = fn
+	snapshot := make([]Tool, 0, len(s.tools))
+	for _, t := range s.tools {
+		snapshot = append(snapshot, t)
+	}
+	s.mu.Unlock()
+
+	if fn == nil {
+		return
+	}
+	// Stable order so replay is reproducible across processes.
+	sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].Name() < snapshot[j].Name() })
+	for _, t := range snapshot {
+		fn(ToolsChange{Schema: t.Schema(), Caller: "tools:init"})
 	}
 }
 

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -13,6 +13,47 @@ import (
 
 var inlineImageTokenPattern = regexp.MustCompile(`\[Image #(\d+)\]`)
 
+// systemReminderRe matches a complete <system-reminder>...</system-reminder>
+// block including tags. Reminders are appended verbatim by reminder.AttachToContent
+// and hook UserPromptSubmit additionalContext flows through the same path, so
+// recognizing the wrapper suffices to mark harness-injected content.
+var systemReminderRe = regexp.MustCompile(`(?s)<system-reminder>.*?</system-reminder>`)
+
+const SourceReminder = "reminder"
+
+// splitTextByProvenance returns ContentBlocks that together preserve the input
+// byte-for-byte, marking <system-reminder> blocks with Source="reminder" so
+// traces can distinguish user-typed text from harness-injected reminders /
+// hook additionalContext. Empty input returns nil.
+//
+// The function never trims whitespace — concatenating all returned Text fields
+// in order reproduces the original input. This keeps the read path
+// (extractUserContent, which joins text blocks) round-trip safe.
+func splitTextByProvenance(text string) []ContentBlock {
+	if text == "" {
+		return nil
+	}
+	matches := systemReminderRe.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return []ContentBlock{{Type: "text", Text: text}}
+	}
+
+	blocks := make([]ContentBlock, 0, 2*len(matches)+1)
+	cursor := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if start > cursor {
+			blocks = append(blocks, ContentBlock{Type: "text", Text: text[cursor:start]})
+		}
+		blocks = append(blocks, ContentBlock{Type: "text", Text: text[start:end], Source: SourceReminder})
+		cursor = end
+	}
+	if cursor < len(text) {
+		blocks = append(blocks, ContentBlock{Type: "text", Text: text[cursor:]})
+	}
+	return blocks
+}
+
 func messagesToEntries(msgs []core.Message) []Entry {
 	entries := make([]Entry, 0, len(msgs))
 	var prevUUID string
@@ -102,13 +143,11 @@ func userContentToBlocks(content, displayContent string, images []core.Image) []
 	var blocks []ContentBlock
 	for _, img := range images {
 		blocks = append(blocks, ContentBlock{
-			Type:   "image",
-			Source: &ImageSource{Type: "base64", MediaType: img.MediaType, Data: img.Data},
+			Type:        "image",
+			ImageSource: &ImageSource{Type: "base64", MediaType: img.MediaType, Data: img.Data},
 		})
 	}
-	if content != "" {
-		blocks = append(blocks, ContentBlock{Type: "text", Text: content})
-	}
+	blocks = append(blocks, splitTextByProvenance(content)...)
 	return blocks
 }
 
@@ -123,9 +162,8 @@ func interleavedUserContentToBlocks(content, displayContent string, images []cor
 		start, end := match[0], match[1]
 		idStart, idEnd := match[2], match[3]
 
-		textPart := displayContent[last:start]
-		if textPart != "" {
-			blocks = append(blocks, ContentBlock{Type: "text", Text: textPart})
+		if textPart := displayContent[last:start]; textPart != "" {
+			blocks = append(blocks, splitTextByProvenance(textPart)...)
 		}
 
 		id, err := strconv.Atoi(displayContent[idStart:idEnd])
@@ -134,7 +172,7 @@ func interleavedUserContentToBlocks(content, displayContent string, images []cor
 				img := images[idx]
 				blocks = append(blocks, ContentBlock{
 					Type:   "image",
-					Source: &ImageSource{Type: "base64", MediaType: img.MediaType, Data: img.Data},
+					ImageSource: &ImageSource{Type: "base64", MediaType: img.MediaType, Data: img.Data},
 				})
 			}
 		}
@@ -143,11 +181,11 @@ func interleavedUserContentToBlocks(content, displayContent string, images []cor
 	}
 
 	if tail := displayContent[last:]; tail != "" {
-		blocks = append(blocks, ContentBlock{Type: "text", Text: tail})
+		blocks = append(blocks, splitTextByProvenance(tail)...)
 	}
 
 	if len(blocks) == 0 && content != "" {
-		blocks = append(blocks, ContentBlock{Type: "text", Text: content})
+		blocks = append(blocks, splitTextByProvenance(content)...)
 	}
 
 	return blocks
@@ -199,8 +237,8 @@ func extractUserContent(blocks []ContentBlock, msg *core.Message) {
 			content.WriteString(block.Text)
 			display.WriteString(block.Text)
 		case "image":
-			if block.Source != nil {
-				msg.Images = append(msg.Images, core.Image{MediaType: block.Source.MediaType, Data: block.Source.Data})
+			if block.ImageSource != nil {
+				msg.Images = append(msg.Images, core.Image{MediaType: block.ImageSource.MediaType, Data: block.ImageSource.Data})
 				imageCount++
 				display.WriteString(fmt.Sprintf("[Image #%d]", imageCount))
 			}

--- a/internal/session/message_convert_test.go
+++ b/internal/session/message_convert_test.go
@@ -1,10 +1,60 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/genai-io/gen-code/internal/core"
 )
+
+// A user message that contains harness-injected <system-reminder> blocks must
+// be persisted as multiple ContentBlocks: user-typed text with empty Source,
+// reminder text with Source="reminder". Concatenating the text fields must
+// reproduce the input byte-for-byte (round-trip safety for read path).
+func Test_userContentToBlocks_splitsByProvenance(t *testing.T) {
+	const reminder1 = "<system-reminder>\nskills directory\n</system-reminder>"
+	const reminder2 = "<system-reminder>\nuser memory\n</system-reminder>"
+	input := "hello\n\n" + reminder1 + "\n\n" + reminder2
+
+	blocks := userContentToBlocks(input, "", nil)
+
+	var sb strings.Builder
+	var reminderCount, userCount int
+	for _, b := range blocks {
+		if b.Type != "text" {
+			t.Fatalf("unexpected block type: %q", b.Type)
+		}
+		sb.WriteString(b.Text)
+		switch b.Source {
+		case SourceReminder:
+			reminderCount++
+			if !strings.HasPrefix(b.Text, "<system-reminder>") {
+				t.Errorf("reminder block missing wrapper: %q", b.Text)
+			}
+		case "":
+			userCount++
+		default:
+			t.Fatalf("unexpected Source: %q", b.Source)
+		}
+	}
+	if sb.String() != input {
+		t.Fatalf("round-trip mismatch:\n got: %q\nwant: %q", sb.String(), input)
+	}
+	if reminderCount != 2 {
+		t.Fatalf("reminder block count = %d, want 2", reminderCount)
+	}
+	if userCount == 0 {
+		t.Fatalf("expected at least one user block, got %d", userCount)
+	}
+}
+
+// Plain user content with no reminders produces exactly one user-text block.
+func Test_userContentToBlocks_plainTextOneBlock(t *testing.T) {
+	blocks := userContentToBlocks("just a question", "", nil)
+	if len(blocks) != 1 || blocks[0].Type != "text" || blocks[0].Source != "" {
+		t.Fatalf("expected 1 user-text block, got %+v", blocks)
+	}
+}
 
 func Test_messagesToEntries_roundtrip(t *testing.T) {
 	// Test that messagesToEntries -> EntriesToMessages roundtrips correctly.
@@ -82,7 +132,7 @@ func Test_extractUserContent_restoresDisplayContent(t *testing.T) {
 			Role: "user",
 			Content: []ContentBlock{
 				{Type: "text", Text: "前面 "},
-				{Type: "image", Source: &ImageSource{Type: "base64", MediaType: "image/png", Data: "abc"}},
+				{Type: "image", ImageSource: &ImageSource{Type: "base64", MediaType: "image/png", Data: "abc"}},
 				{Type: "text", Text: " 后面"},
 			},
 		},

--- a/internal/session/metadata.go
+++ b/internal/session/metadata.go
@@ -1,11 +1,6 @@
 package session
 
-import (
-	"time"
-
-	"github.com/genai-io/gen-code/internal/session/transcript"
-	"github.com/genai-io/gen-code/internal/task/tracker"
-)
+import "time"
 
 func NormalizeMetadata(meta *SessionMetadata, entries []Entry, defaultCwd string, now time.Time) {
 	for i := range entries {
@@ -29,25 +24,5 @@ func NormalizeMetadata(meta *SessionMetadata, entries []Entry, defaultCwd string
 	}
 	if meta.Title == "" {
 		meta.Title = GenerateTitle(entries)
-	}
-}
-
-func TranscriptFromSnapshot(sess *Snapshot, nodes []transcript.Node, tasks []tracker.Task) transcript.Transcript {
-	return transcript.Transcript{
-		ID:        sess.Metadata.ID,
-		ParentID:  sess.Metadata.ParentSessionID,
-		Cwd:       sess.Metadata.Cwd,
-		CreatedAt: sess.Metadata.CreatedAt,
-		UpdatedAt: sess.Metadata.UpdatedAt,
-		Provider:  sess.Metadata.Provider,
-		Model:     sess.Metadata.Model,
-		Messages:  nodes,
-		State: transcript.State{
-			Title:      sess.Metadata.Title,
-			LastPrompt: sess.Metadata.LastPrompt,
-			Tag:        sess.Metadata.Tag,
-			Mode:       sess.Metadata.Mode,
-			Tasks:      transcript.TrackerTaskViewsFromTasks(tasks),
-		},
 	}
 }

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -1,0 +1,233 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/genai-io/gen-code/internal/core"
+	"github.com/genai-io/gen-code/internal/log"
+	"github.com/genai-io/gen-code/internal/session/transcript"
+)
+
+// Recorder turns core.Agent lifecycle events into transcript records.
+//
+// One Recorder is bound to one (sessionID, agentID) pair. The OnAgentEvent
+// method is meant to be passed as core.Config.OnEvent — it's called
+// synchronously from the agent goroutine, so handlers stay fast.
+//
+// The recorder is additive: existing code paths (Store.Save) keep persisting
+// messages and state. The recorder writes only event-driven records
+// (inference.requested / inference.responded) that the snapshot path can't
+// observe.
+type Recorder struct {
+	fs        *transcript.FileStore
+	sessionID string
+	agentID   string
+	provider  string
+	model     string
+	maxTokens int
+
+	turn atomic.Int64
+
+	mu          sync.Mutex
+	lastRequest *requestState
+}
+
+type requestState struct {
+	turn       int
+	startedAt  time.Time
+	messageIDs []string
+}
+
+// RecorderOptions configures a Recorder. provider/model/maxTokens are captured
+// at construction time and stamped on every inference record. Mid-session
+// model swaps will be handled by a future model.changed event, not by mutating
+// the recorder.
+type RecorderOptions struct {
+	FileStore *transcript.FileStore
+	SessionID string
+	AgentID   string
+	Provider  string
+	Model     string
+	MaxTokens int
+}
+
+func NewRecorder(opts RecorderOptions) *Recorder {
+	return &Recorder{
+		fs:        opts.FileStore,
+		sessionID: opts.SessionID,
+		agentID:   opts.AgentID,
+		provider:  opts.Provider,
+		model:     opts.Model,
+		maxTokens: opts.MaxTokens,
+	}
+}
+
+// OnAgentEvent is the core.Config.OnEvent callback. It dispatches by event
+// type and writes the corresponding transcript record. Errors are logged
+// rather than propagated — failing to record telemetry must not break the
+// running session.
+func (r *Recorder) OnAgentEvent(ev core.Event) {
+	if r == nil || r.fs == nil || r.sessionID == "" {
+		return
+	}
+	switch ev.Type {
+	case core.PreInfer:
+		r.onPreInfer(ev)
+	case core.PostInfer:
+		r.onPostInfer(ev)
+	case core.OnSystemChange:
+		r.onSystemChange(ev)
+	case core.OnToolsChange:
+		r.onToolsChange(ev)
+	}
+}
+
+func (r *Recorder) onToolsChange(ev core.Event) {
+	c, ok := ev.ToolsChange()
+	if !ok {
+		return
+	}
+	typ := transcript.ToolsAdded
+	payload := transcript.ToolsRecord{Caller: c.Caller}
+	if c.Removed {
+		typ = transcript.ToolsRemoved
+		payload.Name = c.Name
+	} else {
+		payload.Schema = toolSchemaView(c.Schema)
+	}
+	err := r.fs.AppendTools(context.Background(), transcript.AppendToolsCommand{
+		SessionID: r.sessionID,
+		AgentID:   r.agentID,
+		Time:      time.Now(),
+		Type:      typ,
+		Record:    payload,
+	})
+	if err != nil {
+		log.Logger().Warn("recorder: append tools change failed", zap.Error(err))
+	}
+}
+
+func toolSchemaView(s core.ToolSchema) *transcript.ToolSchemaView {
+	view := &transcript.ToolSchemaView{
+		Name:        s.Name,
+		Description: s.Description,
+	}
+	if s.Parameters != nil {
+		if data, err := json.Marshal(s.Parameters); err == nil {
+			view.Parameters = data
+		}
+	}
+	return view
+}
+
+func (r *Recorder) onSystemChange(ev core.Event) {
+	c, ok := ev.SystemChange()
+	if !ok {
+		return
+	}
+	typ := transcript.SystemSectionAdded
+	if c.Removed {
+		typ = transcript.SystemSectionRemoved
+	}
+	err := r.fs.AppendSystemSection(context.Background(), transcript.AppendSystemSectionCommand{
+		SessionID: r.sessionID,
+		AgentID:   r.agentID,
+		Time:      time.Now(),
+		Type:      typ,
+		Record: transcript.SystemSectionRecord{
+			Name:    c.Name,
+			Slot:    c.Slot,
+			Content: c.Content,
+			Caller:  c.Caller,
+		},
+	})
+	if err != nil {
+		log.Logger().Warn("recorder: append system section failed", zap.Error(err))
+	}
+}
+
+func (r *Recorder) onPreInfer(ev core.Event) {
+	ic, ok := ev.InferenceContext()
+	if !ok {
+		return
+	}
+
+	turn := int(r.turn.Add(1))
+	now := time.Now()
+
+	r.mu.Lock()
+	r.lastRequest = &requestState{
+		turn:       turn,
+		startedAt:  now,
+		messageIDs: ic.MessageIDs,
+	}
+	r.mu.Unlock()
+
+	err := r.fs.AppendInference(context.Background(), transcript.AppendInferenceCommand{
+		SessionID: r.sessionID,
+		AgentID:   r.agentID,
+		Time:      now,
+		Type:      transcript.InferenceRequested,
+		Record: transcript.InferenceRecord{
+			Turn:         turn,
+			Provider:     r.provider,
+			Model:        r.model,
+			MaxTokens:    r.maxTokens,
+			SystemDigest: ic.SystemDigest,
+			ToolsDigest:  ic.ToolsDigest,
+			MessageIDs:   ic.MessageIDs,
+		},
+	})
+	if err != nil {
+		log.Logger().Warn("recorder: append inference.requested failed", zap.Error(err))
+	}
+}
+
+func (r *Recorder) onPostInfer(ev core.Event) {
+	resp, ok := ev.Response()
+	if !ok || resp == nil {
+		return
+	}
+
+	r.mu.Lock()
+	prev := r.lastRequest
+	r.lastRequest = nil
+	r.mu.Unlock()
+
+	now := time.Now()
+	var turn int
+	var latencyMs int64
+	if prev != nil {
+		turn = prev.turn
+		latencyMs = now.Sub(prev.startedAt).Milliseconds()
+	}
+
+	err := r.fs.AppendInference(context.Background(), transcript.AppendInferenceCommand{
+		SessionID: r.sessionID,
+		AgentID:   r.agentID,
+		Time:      now,
+		Type:      transcript.InferenceResponded,
+		Record: transcript.InferenceRecord{
+			Turn:       turn,
+			Provider:   r.provider,
+			Model:      r.model,
+			StopReason: string(resp.StopReason),
+			LatencyMs:  latencyMs,
+			Usage: &transcript.InferenceUsage{
+				InputTokens:       resp.TokensIn,
+				OutputTokens:      resp.TokensOut,
+				CacheCreateTokens: resp.CacheCreateTokens,
+				CacheReadTokens:   resp.CacheReadTokens,
+			},
+		},
+	})
+	if err != nil {
+		log.Logger().Warn("recorder: append inference.responded failed", zap.Error(err))
+	}
+}

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -1,0 +1,250 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/genai-io/gen-code/internal/core"
+	"github.com/genai-io/gen-code/internal/session/transcript"
+)
+
+// One turn through PreInfer + PostInfer must produce one inference.requested
+// and one inference.responded record, with the request's MessageIDs/digests
+// preserved and the response's usage/stop_reason populated. The turn counter
+// links the pair.
+func TestRecorderWritesRequestedAndRespondedPerTurn(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := transcript.NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := fs.Start(context.Background(), transcript.StartCommand{
+		SessionID: "sess-1", Cwd: "/tmp", Provider: "anthropic", Model: "claude-x", Time: time.Now(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	rec := NewRecorder(RecorderOptions{
+		FileStore: fs, SessionID: "sess-1", AgentID: "main",
+		Provider: "anthropic", Model: "claude-x", MaxTokens: 4096,
+	})
+
+	rec.OnAgentEvent(core.Event{Type: core.PreInfer, Source: "main", Data: core.InferenceContext{
+		SystemDigest: "sha256:sys", ToolsDigest: "sha256:tools", MessageIDs: []string{"m1", "m2"},
+	}})
+	rec.OnAgentEvent(core.Event{Type: core.PostInfer, Source: "main", Data: &core.InferResponse{
+		StopReason: core.StopEndTurn, TokensIn: 42, TokensOut: 8, CacheReadTokens: 10,
+	}})
+
+	tx, err := fs.Load(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Project() flattens to messages; inspect raw records via a re-load instead.
+	// Easiest path: read the file directly via Load and look at the messages —
+	// but inference records aren't messages. Use the file to read raw records.
+	_ = tx
+
+	// Read raw records from disk to assert on inference records.
+	records := readAllRecords(t, dir, "sess-1")
+
+	var reqs, resps []transcript.Record
+	for _, r := range records {
+		switch r.Type {
+		case transcript.InferenceRequested:
+			reqs = append(reqs, r)
+		case transcript.InferenceResponded:
+			resps = append(resps, r)
+		}
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("inference.requested count = %d, want 1", len(reqs))
+	}
+	if len(resps) != 1 {
+		t.Fatalf("inference.responded count = %d, want 1", len(resps))
+	}
+
+	req := reqs[0].Inference
+	if req == nil {
+		t.Fatal("request record missing Inference payload")
+	}
+	if req.Turn != 1 {
+		t.Fatalf("requested.Turn = %d, want 1", req.Turn)
+	}
+	if req.SystemDigest != "sha256:sys" || req.ToolsDigest != "sha256:tools" {
+		t.Fatalf("requested digests = %+v", req)
+	}
+	if len(req.MessageIDs) != 2 || req.MessageIDs[0] != "m1" {
+		t.Fatalf("requested.MessageIDs = %+v", req.MessageIDs)
+	}
+
+	resp := resps[0].Inference
+	if resp == nil {
+		t.Fatal("response record missing Inference payload")
+	}
+	if resp.Turn != 1 {
+		t.Fatalf("responded.Turn = %d, want 1 (must match request)", resp.Turn)
+	}
+	if resp.StopReason != string(core.StopEndTurn) {
+		t.Fatalf("responded.StopReason = %q", resp.StopReason)
+	}
+	if resp.Usage == nil || resp.Usage.InputTokens != 42 || resp.Usage.OutputTokens != 8 || resp.Usage.CacheReadTokens != 10 {
+		t.Fatalf("responded.Usage = %+v", resp.Usage)
+	}
+}
+
+// System mutations must produce one system.section.added per added/replaced
+// section and one system.section.removed per dropped section. Caller info is
+// preserved verbatim so trace consumers can answer "who changed this?".
+func TestRecorderWritesSystemSectionEvents(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := transcript.NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := fs.Start(context.Background(), transcript.StartCommand{
+		SessionID: "sess-sys", Cwd: "/tmp", Provider: "p", Model: "m", Time: time.Now(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	rec := NewRecorder(RecorderOptions{
+		FileStore: fs, SessionID: "sess-sys", AgentID: "main",
+		Provider: "p", Model: "m", MaxTokens: 1,
+	})
+
+	rec.OnAgentEvent(core.Event{Type: core.OnSystemChange, Data: core.SystemChange{
+		Name: "identity", Slot: 0, Content: "You are X", Caller: "system:init",
+	}})
+	rec.OnAgentEvent(core.Event{Type: core.OnSystemChange, Data: core.SystemChange{
+		Name: "identity", Slot: 0, Content: "You are Y", Caller: "command:/identity",
+	}})
+	rec.OnAgentEvent(core.Event{Type: core.OnSystemChange, Data: core.SystemChange{
+		Name: "policy", Removed: true, Caller: "test:teardown",
+	}})
+
+	records := readAllRecords(t, dir, "sess-sys")
+	var added, removed []transcript.Record
+	for _, r := range records {
+		switch r.Type {
+		case transcript.SystemSectionAdded:
+			added = append(added, r)
+		case transcript.SystemSectionRemoved:
+			removed = append(removed, r)
+		}
+	}
+	if len(added) != 2 {
+		t.Fatalf("system.section.added count = %d, want 2", len(added))
+	}
+	if len(removed) != 1 {
+		t.Fatalf("system.section.removed count = %d, want 1", len(removed))
+	}
+	if added[1].System.Caller != "command:/identity" || added[1].System.Content != "You are Y" {
+		t.Fatalf("replaced section payload = %+v", added[1].System)
+	}
+	if removed[0].System.Name != "policy" || removed[0].System.Caller != "test:teardown" {
+		t.Fatalf("removed section payload = %+v", removed[0].System)
+	}
+}
+
+// Tool registry changes must produce one tools.added per Add and one
+// tools.removed per Remove. Schema/Name and Caller are preserved.
+func TestRecorderWritesToolsChangeEvents(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := transcript.NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := fs.Start(context.Background(), transcript.StartCommand{
+		SessionID: "sess-tools", Cwd: "/tmp", Provider: "p", Model: "m", Time: time.Now(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	rec := NewRecorder(RecorderOptions{
+		FileStore: fs, SessionID: "sess-tools", AgentID: "main",
+		Provider: "p", Model: "m", MaxTokens: 1,
+	})
+
+	rec.OnAgentEvent(core.Event{Type: core.OnToolsChange, Data: core.ToolsChange{
+		Schema: core.ToolSchema{Name: "Read", Description: "read a file"},
+		Caller: "tools:init",
+	}})
+	rec.OnAgentEvent(core.Event{Type: core.OnToolsChange, Data: core.ToolsChange{
+		Schema: core.ToolSchema{Name: "Bash", Description: "run shell"},
+		Caller: "mcp:Bash",
+	}})
+	rec.OnAgentEvent(core.Event{Type: core.OnToolsChange, Data: core.ToolsChange{
+		Name: "Bash", Removed: true, Caller: "mode:plan",
+	}})
+
+	records := readAllRecords(t, dir, "sess-tools")
+	var added, removed []transcript.Record
+	for _, r := range records {
+		switch r.Type {
+		case transcript.ToolsAdded:
+			added = append(added, r)
+		case transcript.ToolsRemoved:
+			removed = append(removed, r)
+		}
+	}
+	if len(added) != 2 {
+		t.Fatalf("tools.added count = %d, want 2", len(added))
+	}
+	if len(removed) != 1 {
+		t.Fatalf("tools.removed count = %d, want 1", len(removed))
+	}
+	if added[0].Tools.Schema == nil || added[0].Tools.Schema.Name != "Read" || added[0].Tools.Caller != "tools:init" {
+		t.Fatalf("first added record = %+v", added[0].Tools)
+	}
+	if removed[0].Tools.Name != "Bash" || removed[0].Tools.Caller != "mode:plan" {
+		t.Fatalf("removed record = %+v", removed[0].Tools)
+	}
+}
+
+// A nil-safe recorder (no FileStore) must accept events without panicking.
+func TestRecorderNilSafe(t *testing.T) {
+	var rec *Recorder
+	rec.OnAgentEvent(core.Event{Type: core.PreInfer})
+
+	empty := NewRecorder(RecorderOptions{})
+	empty.OnAgentEvent(core.Event{Type: core.PreInfer})
+}
+
+func readAllRecords(t *testing.T, baseDir, sessionID string) []transcript.Record {
+	t.Helper()
+	fs, err := transcript.NewFileStore(baseDir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore (reread): %v", err)
+	}
+	path := fs.TranscriptPath(sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer f.Close()
+
+	var out []transcript.Record
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var r transcript.Record
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("decode record: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan transcript: %v", err)
+	}
+	return out
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -26,6 +26,9 @@ type Service interface {
 	LoadLatest() (*Snapshot, error)
 	List() ([]*SessionMetadata, error)
 	Fork(id string) (*Snapshot, error)
+
+	// tracing
+	NewRecorder(agentID, provider, model string, maxTokens int) *Recorder
 }
 
 // Compile-time check: *Setup implements Service.

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -134,3 +134,25 @@ func (s *Setup) Fork(id string) (*Snapshot, error) {
 	}
 	return st.Fork(id)
 }
+
+// NewRecorder binds a Recorder to the current session and transcript store.
+// Returns nil if the store is not initialized — callers can pass the nil
+// result through to core.Config.OnEvent safely because Recorder.OnAgentEvent
+// is nil-safe.
+func (s *Setup) NewRecorder(agentID, provider, model string, maxTokens int) *Recorder {
+	s.mu.RLock()
+	st := s.Store
+	sessionID := s.SessionID
+	s.mu.RUnlock()
+	if st == nil || st.transcriptStore == nil || sessionID == "" {
+		return nil
+	}
+	return NewRecorder(RecorderOptions{
+		FileStore: st.transcriptStore,
+		SessionID: sessionID,
+		AgentID:   agentID,
+		Provider:  provider,
+		Model:     model,
+		MaxTokens: maxTokens,
+	})
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -129,6 +129,14 @@ func (s *Store) Load(id string) (*Snapshot, error) {
 	return sess, nil
 }
 
+// Save persists the snapshot via append-only writes:
+//
+//  1. Start (idempotent; no-op if the transcript already exists)
+//  2. AppendMessage per entry (deduped by message ID — cheap re-saves)
+//  3. PatchState with the full projected state (last-wins on read)
+//
+// No file rewrites; each call writes only the records that didn't already
+// exist plus a single state-patch record.
 func (s *Store) Save(sess *Snapshot) error {
 	if sess == nil {
 		return fmt.Errorf("session is nil")
@@ -148,8 +156,48 @@ func (s *Store) Save(sess *Snapshot) error {
 	NormalizeMetadata(&sess.Metadata, sess.Entries, s.cwd, now)
 	nodes := EntriesToNodes(sess.Entries, sess.Metadata.ID, sess.Metadata.Cwd, sess.Metadata.CreatedAt, gitBranch)
 
-	return s.transcriptStore.Replace(context.Background(), transcript.ReplaceCommand{
-		Transcript: TranscriptFromSnapshot(sess, nodes, sess.Tasks),
+	ctx := context.Background()
+	id := sess.Metadata.ID
+
+	if err := s.transcriptStore.Start(ctx, transcript.StartCommand{
+		SessionID: id,
+		ProjectID: s.projectID,
+		Cwd:       sess.Metadata.Cwd,
+		Provider:  sess.Metadata.Provider,
+		Model:     sess.Metadata.Model,
+		ParentID:  sess.Metadata.ParentSessionID,
+		Time:      sess.Metadata.CreatedAt,
+	}); err != nil {
+		return err
+	}
+
+	for _, n := range nodes {
+		if err := s.transcriptStore.AppendMessage(ctx, transcript.AppendMessageCommand{
+			SessionID:   id,
+			MessageID:   n.ID,
+			ParentID:    n.ParentID,
+			Time:        n.Time,
+			Cwd:         n.Cwd,
+			GitBranch:   n.GitBranch,
+			AgentID:     n.AgentID,
+			IsSidechain: n.IsSidechain,
+			Role:        n.Role,
+			Content:     n.Content,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return s.transcriptStore.PatchState(ctx, transcript.PatchStateCommand{
+		SessionID: id,
+		Time:      now,
+		Ops: transcript.StateOpsFor(transcript.State{
+			Title:      sess.Metadata.Title,
+			LastPrompt: sess.Metadata.LastPrompt,
+			Tag:        sess.Metadata.Tag,
+			Mode:       sess.Metadata.Mode,
+			Tasks:      transcript.TrackerTaskViewsFromTasks(sess.Tasks),
+		}),
 	})
 }
 
@@ -159,9 +207,9 @@ func (s *Store) Fork(sourceID string) (*Snapshot, error) {
 
 	newID := generateSessionID()
 	if err := s.transcriptStore.Fork(context.Background(), transcript.ForkCommand{
-		SourceTranscriptID: sourceID,
-		NewTranscriptID:    newID,
-		Time:               time.Now(),
+		SourceSessionID: sourceID,
+		NewSessionID:    newID,
+		Time:            time.Now(),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -19,6 +19,11 @@ type FileStore struct {
 	mu        sync.RWMutex
 	baseDir   string
 	projectID string
+
+	// persistedIDs caches the set of message IDs already written per transcript.
+	// Lazily populated on first access; replaces O(N) file scans on every append
+	// with O(1) lookups after the initial scan.
+	persistedIDs map[string]map[string]struct{}
 }
 
 type fileIndex struct {
@@ -28,7 +33,7 @@ type fileIndex struct {
 }
 
 type fileIndexEntry struct {
-	TranscriptID string    `json:"transcriptId"`
+	SessionID    string    `json:"sessionId"`
 	FullPath     string    `json:"fullPath"`
 	CreatedAt    time.Time `json:"createdAt"`
 	UpdatedAt    time.Time `json:"updatedAt"`
@@ -54,7 +59,7 @@ func (s *FileStore) Start(ctx context.Context, cmd StartCommand) error {
 		return err
 	}
 
-	path := s.transcriptPath(cmd.TranscriptID)
+	path := s.transcriptPath(cmd.SessionID)
 	exists, err := fileExists(path)
 	if err != nil {
 		return err
@@ -64,21 +69,21 @@ func (s *FileStore) Start(ctx context.Context, cmd StartCommand) error {
 	}
 
 	rec := Record{
-		ID:           cmd.TranscriptID + ":start",
-		TranscriptID: cmd.TranscriptID,
-		Time:         cmd.Time,
-		Type:         RecordStarted,
-		Cwd:          cmd.Cwd,
-		System: &SystemRecord{
+		ID:        cmd.SessionID + ":start",
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      SessionStarted,
+		Cwd:       cmd.Cwd,
+		Session: &SessionRecord{
 			Provider: cmd.Provider,
 			Model:    cmd.Model,
 			ParentID: cmd.ParentID,
 		},
 	}
-	if err := s.appendRecord(path, rec); err != nil {
+	if err := s.appendRecord(path, rec, true); err != nil {
 		return err
 	}
-	return s.refreshIndexLocked(cmd.TranscriptID)
+	return s.refreshIndexLocked(cmd.SessionID)
 }
 
 func (s *FileStore) AppendMessage(ctx context.Context, cmd AppendMessageCommand) error {
@@ -89,35 +94,36 @@ func (s *FileStore) AppendMessage(ctx context.Context, cmd AppendMessageCommand)
 		return err
 	}
 
-	path := s.transcriptPath(cmd.TranscriptID)
-	exists, err := s.messageExistsLocked(path, cmd.MessageID)
+	path := s.transcriptPath(cmd.SessionID)
+	seen, err := s.persistedIDsLocked(cmd.SessionID)
 	if err != nil {
 		return err
 	}
-	if exists {
+	if _, ok := seen[cmd.MessageID]; ok {
 		return nil
 	}
 
 	rec := Record{
-		ID:           cmd.TranscriptID + ":" + cmd.MessageID,
-		TranscriptID: cmd.TranscriptID,
-		Time:         cmd.Time,
-		Type:         RecordMessageAppended,
-		ParentID:     cmd.ParentID,
-		Cwd:          cmd.Cwd,
-		GitBranch:    cmd.GitBranch,
-		AgentID:      cmd.AgentID,
-		IsSidechain:  cmd.IsSidechain,
+		ID:          cmd.SessionID + ":" + cmd.MessageID,
+		SessionID:   cmd.SessionID,
+		Time:        cmd.Time,
+		Type:        MessageAppended,
+		ParentID:    cmd.ParentID,
+		Cwd:         cmd.Cwd,
+		GitBranch:   cmd.GitBranch,
+		AgentID:     cmd.AgentID,
+		IsSidechain: cmd.IsSidechain,
 		Message: &MessageRecord{
 			MessageID: cmd.MessageID,
 			Role:      cmd.Role,
 			Content:   append([]ContentBlock(nil), cmd.Content...),
 		},
 	}
-	if err := s.appendRecord(path, rec); err != nil {
+	if err := s.appendRecord(path, rec, true); err != nil {
 		return err
 	}
-	return s.refreshIndexLocked(cmd.TranscriptID)
+	seen[cmd.MessageID] = struct{}{}
+	return s.refreshIndexLocked(cmd.SessionID)
 }
 
 func (s *FileStore) PatchState(ctx context.Context, cmd PatchStateCommand) error {
@@ -129,18 +135,90 @@ func (s *FileStore) PatchState(ctx context.Context, cmd PatchStateCommand) error
 	}
 
 	rec := Record{
-		ID:           fmt.Sprintf("%s:state:%d", cmd.TranscriptID, cmd.Time.UnixNano()),
-		TranscriptID: cmd.TranscriptID,
-		Time:         cmd.Time,
-		Type:         RecordStatePatched,
+		ID:        fmt.Sprintf("%s:state:%d", cmd.SessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      StatePatched,
 		State: &StateRecord{
 			Ops: append([]PatchOp(nil), cmd.Ops...),
 		},
 	}
-	if err := s.appendRecord(s.transcriptPath(cmd.TranscriptID), rec); err != nil {
+	if err := s.appendRecord(s.transcriptPath(cmd.SessionID), rec, false); err != nil {
 		return err
 	}
-	return s.refreshIndexLocked(cmd.TranscriptID)
+	return s.refreshIndexLocked(cmd.SessionID)
+}
+
+func (s *FileStore) AppendTools(ctx context.Context, cmd AppendToolsCommand) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if cmd.Type != ToolsAdded && cmd.Type != ToolsRemoved {
+		return fmt.Errorf("append tools: unexpected type %q", cmd.Type)
+	}
+
+	rec := cmd.Record
+	full := Record{
+		ID:        fmt.Sprintf("%s:tools:%d", cmd.SessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      cmd.Type,
+		AgentID:   cmd.AgentID,
+		Tools:     &rec,
+	}
+	return s.appendRecord(s.transcriptPath(cmd.SessionID), full, false)
+}
+
+func (s *FileStore) AppendSystemSection(ctx context.Context, cmd AppendSystemSectionCommand) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if cmd.Type != SystemSectionAdded && cmd.Type != SystemSectionRemoved {
+		return fmt.Errorf("append system section: unexpected type %q", cmd.Type)
+	}
+
+	rec := cmd.Record
+	full := Record{
+		ID:        fmt.Sprintf("%s:system:%d", cmd.SessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      cmd.Type,
+		AgentID:   cmd.AgentID,
+		System:    &rec,
+	}
+	return s.appendRecord(s.transcriptPath(cmd.SessionID), full, false)
+}
+
+func (s *FileStore) AppendInference(ctx context.Context, cmd AppendInferenceCommand) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if cmd.Type != InferenceRequested && cmd.Type != InferenceResponded {
+		return fmt.Errorf("append inference: unexpected type %q", cmd.Type)
+	}
+
+	rec := cmd.Record
+	full := Record{
+		ID:        fmt.Sprintf("%s:inference:%d", cmd.SessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      cmd.Type,
+		AgentID:   cmd.AgentID,
+		Inference: &rec,
+	}
+	// inference.responded sync-flushes the file so any preceding telemetry
+	// (system.section.*, tools.*, inference.requested) from this turn lands
+	// on disk together; inference.requested itself stays in the page cache.
+	return s.appendRecord(s.transcriptPath(cmd.SessionID), full, cmd.Type == InferenceResponded)
 }
 
 func (s *FileStore) Compact(ctx context.Context, cmd CompactCommand) error {
@@ -152,16 +230,16 @@ func (s *FileStore) Compact(ctx context.Context, cmd CompactCommand) error {
 	}
 
 	rec := Record{
-		ID:           fmt.Sprintf("%s:compact:%d", cmd.TranscriptID, cmd.Time.UnixNano()),
-		TranscriptID: cmd.TranscriptID,
-		Time:         cmd.Time,
-		Type:         RecordCompacted,
-		System:       &SystemRecord{BoundaryID: cmd.BoundaryID},
+		ID:        fmt.Sprintf("%s:compact:%d", cmd.SessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.SessionID,
+		Time:      cmd.Time,
+		Type:      SessionCompacted,
+		Session:   &SessionRecord{BoundaryID: cmd.BoundaryID},
 	}
-	if err := s.appendRecord(s.transcriptPath(cmd.TranscriptID), rec); err != nil {
+	if err := s.appendRecord(s.transcriptPath(cmd.SessionID), rec, true); err != nil {
 		return err
 	}
-	return s.refreshIndexLocked(cmd.TranscriptID)
+	return s.refreshIndexLocked(cmd.SessionID)
 }
 
 func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
@@ -172,16 +250,16 @@ func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
 		return err
 	}
 
-	sourcePath := s.transcriptPath(cmd.SourceTranscriptID)
+	sourcePath := s.transcriptPath(cmd.SourceSessionID)
 	records, err := s.loadRecordsLocked(sourcePath)
 	if err != nil {
 		return err
 	}
 	if len(records) == 0 {
-		return fmt.Errorf("source transcript not found: %s", cmd.SourceTranscriptID)
+		return fmt.Errorf("source transcript not found: %s", cmd.SourceSessionID)
 	}
 
-	destPath := s.transcriptPath(cmd.NewTranscriptID)
+	destPath := s.transcriptPath(cmd.NewSessionID)
 	tmpPath := destPath + ".tmp"
 	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
@@ -190,7 +268,7 @@ func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
 	enc := json.NewEncoder(f)
 	enc.SetEscapeHTML(false)
 	for _, rec := range records {
-		rec.TranscriptID = cmd.NewTranscriptID
+		rec.SessionID = cmd.NewSessionID
 		rec.Time = cmd.Time
 		if err := enc.Encode(rec); err != nil {
 			_ = f.Close()
@@ -199,12 +277,12 @@ func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
 		}
 	}
 	forkRec := Record{
-		ID:           fmt.Sprintf("%s:fork:%d", cmd.NewTranscriptID, cmd.Time.UnixNano()),
-		TranscriptID: cmd.NewTranscriptID,
-		Time:         cmd.Time,
-		Type:         RecordForked,
-		System: &SystemRecord{
-			ParentID: cmd.SourceTranscriptID,
+		ID:        fmt.Sprintf("%s:fork:%d", cmd.NewSessionID, cmd.Time.UnixNano()),
+		SessionID: cmd.NewSessionID,
+		Time:      cmd.Time,
+		Type:      SessionForked,
+		Session: &SessionRecord{
+			ParentID: cmd.SourceSessionID,
 		},
 	}
 	if err := enc.Encode(forkRec); err != nil {
@@ -220,54 +298,7 @@ func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename fork transcript: %w", err)
 	}
-	return s.refreshIndexLocked(cmd.NewTranscriptID)
-}
-
-func (s *FileStore) Replace(ctx context.Context, cmd ReplaceCommand) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	tx := cmd.Transcript
-	if tx.ID == "" {
-		return fmt.Errorf("replace transcript: missing transcript ID")
-	}
-
-	records, err := recordsForTranscript(tx)
-	if err != nil {
-		return err
-	}
-
-	path := s.transcriptPath(tx.ID)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create transcript dir: %w", err)
-	}
-
-	tmpPath := path + ".tmp"
-	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil {
-		return fmt.Errorf("open transcript file: %w", err)
-	}
-	enc := json.NewEncoder(f)
-	enc.SetEscapeHTML(false)
-	for _, rec := range records {
-		if err := enc.Encode(rec); err != nil {
-			_ = f.Close()
-			_ = os.Remove(tmpPath)
-			return fmt.Errorf("write transcript record: %w", err)
-		}
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("close transcript file: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("rename transcript file: %w", err)
-	}
-	return s.refreshIndexLocked(tx.ID)
+	return s.refreshIndexLocked(cmd.NewSessionID)
 }
 
 func (s *FileStore) Load(ctx context.Context, transcriptID string) (*Transcript, error) {
@@ -305,7 +336,7 @@ func (s *FileStore) List(ctx context.Context, projectID string, opts ListOptions
 			continue
 		}
 		items = append(items, ListItem{
-			TranscriptID: entry.TranscriptID,
+			SessionID:    entry.SessionID,
 			FullPath:     entry.FullPath,
 			CreatedAt:    entry.CreatedAt,
 			UpdatedAt:    entry.UpdatedAt,
@@ -367,12 +398,13 @@ func (s *FileStore) Delete(ctx context.Context, transcriptID string) error {
 	if err := os.Remove(s.transcriptPath(transcriptID)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete transcript file: %w", err)
 	}
+	delete(s.persistedIDs, transcriptID)
 
 	index, err := s.loadIndexLocked()
 	if err == nil {
 		filtered := make([]fileIndexEntry, 0, len(index.Entries))
 		for _, entry := range index.Entries {
-			if entry.TranscriptID != transcriptID {
+			if entry.SessionID != transcriptID {
 				filtered = append(filtered, entry)
 			}
 		}
@@ -394,7 +426,21 @@ func (s *FileStore) indexPath() string {
 	return filepath.Join(s.baseDir, transcriptIndexFile)
 }
 
-func (s *FileStore) appendRecord(path string, rec Record) error {
+// appendRecord writes one record to the JSONL. fsync is gated by sync so
+// hot-path telemetry (system.section.*, tools.*, inference.requested) can be
+// buffered in the OS page cache and rolled up to disk at turn boundaries.
+//
+// Durability classes:
+//   - sync=true: user input (message.appended), turn-completion
+//     (inference.responded), lifecycle events (session.started, session.compacted).
+//     A crash after these must not lose them.
+//   - sync=false: pure telemetry. Worst case on crash: the in-flight turn's
+//     telemetry is lost, but the message/state of preceding turns is intact
+//     because their write fsynced.
+//
+// Single-process per file: the append+close pair preserves order regardless
+// of fsync; durability is the only thing the flag toggles.
+func (s *FileStore) appendRecord(path string, rec Record, sync bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create transcript dir: %w", err)
 	}
@@ -409,9 +455,11 @@ func (s *FileStore) appendRecord(path string, rec Record) error {
 		f.Close()
 		return fmt.Errorf("append transcript record: %w", err)
 	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return fmt.Errorf("sync transcript file: %w", err)
+	if sync {
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return fmt.Errorf("sync transcript file: %w", err)
+		}
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("close transcript file: %w", err)
@@ -419,87 +467,32 @@ func (s *FileStore) appendRecord(path string, rec Record) error {
 	return nil
 }
 
-func recordsForTranscript(tx Transcript) ([]Record, error) {
-	now := time.Now()
-	createdAt := tx.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = now
+// persistedIDsLocked returns the cached set of message IDs already written to
+// the given transcript, scanning the file on first access. The returned map is
+// owned by the store; callers update it after a successful append.
+func (s *FileStore) persistedIDsLocked(transcriptID string) (map[string]struct{}, error) {
+	if seen, ok := s.persistedIDs[transcriptID]; ok {
+		return seen, nil
 	}
-	updatedAt := tx.UpdatedAt
-	if updatedAt.IsZero() {
-		updatedAt = createdAt
+	seen, err := scanMessageIDs(s.transcriptPath(transcriptID))
+	if err != nil {
+		return nil, err
 	}
-
-	records := []Record{{
-		ID:           tx.ID + ":start",
-		TranscriptID: tx.ID,
-		Time:         createdAt,
-		Type:         RecordStarted,
-		Cwd:          tx.Cwd,
-		System: &SystemRecord{
-			Provider: tx.Provider,
-			Model:    tx.Model,
-			ParentID: tx.ParentID,
-		},
-	}}
-
-	for i, node := range tx.Messages {
-		messageTime := node.Time
-		if messageTime.IsZero() {
-			messageTime = createdAt.Add(time.Duration(i+1) * time.Millisecond)
-		}
-		if node.ID == "" {
-			return nil, fmt.Errorf("replace transcript: message %d missing ID", i)
-		}
-		records = append(records, Record{
-			ID:           tx.ID + ":" + node.ID,
-			TranscriptID: tx.ID,
-			Time:         messageTime,
-			Type:         RecordMessageAppended,
-			ParentID:     node.ParentID,
-			Cwd:          node.Cwd,
-			GitBranch:    node.GitBranch,
-			AgentID:      node.AgentID,
-			IsSidechain:  node.IsSidechain,
-			Message: &MessageRecord{
-				MessageID: node.ID,
-				Role:      node.Role,
-				Content:   append([]ContentBlock(nil), node.Content...),
-			},
-		})
+	if s.persistedIDs == nil {
+		s.persistedIDs = make(map[string]map[string]struct{})
 	}
-
-	ops := []PatchOp{
-		PatchTitle(tx.State.Title),
-		PatchLastPrompt(tx.State.LastPrompt),
-		patchTag(tx.State.Tag),
-		patchMode(tx.State.Mode),
-	}
-	if len(tx.State.Tasks) > 0 {
-		ops = append(ops, PatchTasks(TrackerTasksFromView(tx.State.Tasks)))
-	}
-	if tx.State.Worktree != nil {
-		ops = append(ops, patchWorktree(tx.State.Worktree))
-	}
-	records = append(records, Record{
-		ID:           fmt.Sprintf("%s:state:%d", tx.ID, updatedAt.UnixNano()),
-		TranscriptID: tx.ID,
-		Time:         updatedAt,
-		Type:         RecordStatePatched,
-		State: &StateRecord{
-			Ops: ops,
-		},
-	})
-	return records, nil
+	s.persistedIDs[transcriptID] = seen
+	return seen, nil
 }
 
-func (s *FileStore) messageExistsLocked(path, messageID string) (bool, error) {
+func scanMessageIDs(path string) (map[string]struct{}, error) {
+	seen := make(map[string]struct{})
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return seen, nil
 		}
-		return false, fmt.Errorf("open transcript file: %w", err)
+		return nil, fmt.Errorf("open transcript file: %w", err)
 	}
 	defer f.Close()
 
@@ -510,14 +503,14 @@ func (s *FileStore) messageExistsLocked(path, messageID string) (bool, error) {
 		if json.Unmarshal(scanner.Bytes(), &rec) != nil {
 			continue
 		}
-		if rec.Type == RecordMessageAppended && rec.Message != nil && rec.Message.MessageID == messageID {
-			return true, nil
+		if rec.Type == MessageAppended && rec.Message != nil {
+			seen[rec.Message.MessageID] = struct{}{}
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return false, fmt.Errorf("scan transcript file: %w", err)
+		return nil, fmt.Errorf("scan transcript file: %w", err)
 	}
-	return false, nil
+	return seen, nil
 }
 
 func (s *FileStore) loadRecordsLocked(path string) ([]Record, error) {
@@ -600,7 +593,7 @@ func (s *FileStore) rebuildIndexLocked() error {
 			continue
 		}
 		index.Entries = append(index.Entries, fileIndexEntry{
-			TranscriptID: item.TranscriptID,
+			SessionID:    item.SessionID,
 			FullPath:     item.FullPath,
 			CreatedAt:    item.CreatedAt,
 			UpdatedAt:    item.UpdatedAt,
@@ -629,7 +622,7 @@ func (s *FileStore) refreshIndexLocked(transcriptID string) error {
 	}
 
 	entry := fileIndexEntry{
-		TranscriptID: item.TranscriptID,
+		SessionID:    item.SessionID,
 		FullPath:     item.FullPath,
 		CreatedAt:    item.CreatedAt,
 		UpdatedAt:    item.UpdatedAt,
@@ -641,7 +634,7 @@ func (s *FileStore) refreshIndexLocked(transcriptID string) error {
 	}
 
 	for i := range index.Entries {
-		if index.Entries[i].TranscriptID == transcriptID {
+		if index.Entries[i].SessionID == transcriptID {
 			index.Entries[i] = entry
 			return s.saveIndexLocked(index)
 		}
@@ -666,7 +659,7 @@ func (s *FileStore) buildListItemLocked(transcriptID string) (ListItem, error) {
 	}
 
 	return ListItem{
-		TranscriptID: transcriptID,
+		SessionID:    transcriptID,
 		FullPath:     s.transcriptPath(transcriptID),
 		CreatedAt:    transcript.CreatedAt,
 		UpdatedAt:    transcript.UpdatedAt,

--- a/internal/session/transcript/fs_store_impl_test.go
+++ b/internal/session/transcript/fs_store_impl_test.go
@@ -15,39 +15,39 @@ func TestFileStoreStartAppendListLoad(t *testing.T) {
 
 	now := time.Date(2026, 4, 6, 16, 0, 0, 0, time.UTC)
 	if err := store.Start(context.Background(), StartCommand{
-		TranscriptID: "tx-1",
-		ProjectID:    "proj-1",
-		Cwd:          "/tmp/project",
-		Provider:     "openai",
-		Model:        "gpt-test",
-		Time:         now,
+		SessionID: "tx-1",
+		ProjectID: "proj-1",
+		Cwd:       "/tmp/project",
+		Provider:  "openai",
+		Model:     "gpt-test",
+		Time:      now,
 	}); err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
 	if err := store.AppendMessage(context.Background(), AppendMessageCommand{
-		TranscriptID: "tx-1",
-		MessageID:    "m1",
-		Time:         now.Add(time.Second),
-		Role:         "user",
-		Content:      []ContentBlock{{Type: "text", Text: "hello"}},
+		SessionID: "tx-1",
+		MessageID: "m1",
+		Time:      now.Add(time.Second),
+		Role:      "user",
+		Content:   []ContentBlock{{Type: "text", Text: "hello"}},
 	}); err != nil {
 		t.Fatalf("AppendMessage(user): %v", err)
 	}
 	if err := store.AppendMessage(context.Background(), AppendMessageCommand{
-		TranscriptID: "tx-1",
-		MessageID:    "m2",
-		ParentID:     "m1",
-		Time:         now.Add(2 * time.Second),
-		Role:         "assistant",
-		Content:      []ContentBlock{{Type: "text", Text: "world"}},
-		GitBranch:    "main",
+		SessionID: "tx-1",
+		MessageID: "m2",
+		ParentID:  "m1",
+		Time:      now.Add(2 * time.Second),
+		Role:      "assistant",
+		Content:   []ContentBlock{{Type: "text", Text: "world"}},
+		GitBranch: "main",
 	}); err != nil {
 		t.Fatalf("AppendMessage(assistant): %v", err)
 	}
 	if err := store.PatchState(context.Background(), PatchStateCommand{
-		TranscriptID: "tx-1",
-		Time:         now.Add(3 * time.Second),
-		Ops:          []PatchOp{PatchTitle("Fix bug"), PatchLastPrompt("hello")},
+		SessionID: "tx-1",
+		Time:      now.Add(3 * time.Second),
+		Ops:       []PatchOp{PatchTitle("Fix bug"), PatchLastPrompt("hello")},
 	}); err != nil {
 		t.Fatalf("PatchState(): %v", err)
 	}
@@ -87,36 +87,36 @@ func TestFileStoreCompactAndFork(t *testing.T) {
 
 	now := time.Date(2026, 4, 6, 16, 10, 0, 0, time.UTC)
 	if err := store.Start(context.Background(), StartCommand{
-		TranscriptID: "tx-1",
-		ProjectID:    "proj-1",
-		Cwd:          "/tmp/project",
-		Time:         now,
+		SessionID: "tx-1",
+		ProjectID: "proj-1",
+		Cwd:       "/tmp/project",
+		Time:      now,
 	}); err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
 	if err := store.AppendMessage(context.Background(), AppendMessageCommand{
-		TranscriptID: "tx-1",
-		MessageID:    "m1",
-		Time:         now.Add(time.Second),
-		Role:         "user",
-		Content:      []ContentBlock{{Type: "text", Text: "hello"}},
+		SessionID: "tx-1",
+		MessageID: "m1",
+		Time:      now.Add(time.Second),
+		Role:      "user",
+		Content:   []ContentBlock{{Type: "text", Text: "hello"}},
 	}); err != nil {
 		t.Fatalf("AppendMessage(): %v", err)
 	}
 	if err := store.AppendMessage(context.Background(), AppendMessageCommand{
-		TranscriptID: "tx-1",
-		MessageID:    "m2",
-		ParentID:     "m1",
-		Time:         now.Add(2 * time.Second),
-		Role:         "assistant",
-		Content:      []ContentBlock{{Type: "text", Text: "world"}},
+		SessionID: "tx-1",
+		MessageID: "m2",
+		ParentID:  "m1",
+		Time:      now.Add(2 * time.Second),
+		Role:      "assistant",
+		Content:   []ContentBlock{{Type: "text", Text: "world"}},
 	}); err != nil {
 		t.Fatalf("AppendMessage(m2): %v", err)
 	}
 	if err := store.Compact(context.Background(), CompactCommand{
-		TranscriptID: "tx-1",
-		Time:         now.Add(3 * time.Second),
-		BoundaryID:   "m1",
+		SessionID:  "tx-1",
+		Time:       now.Add(3 * time.Second),
+		BoundaryID: "m1",
 	}); err != nil {
 		t.Fatalf("Compact(): %v", err)
 	}
@@ -130,9 +130,9 @@ func TestFileStoreCompactAndFork(t *testing.T) {
 	}
 
 	if err := store.Fork(context.Background(), ForkCommand{
-		SourceTranscriptID: "tx-1",
-		NewTranscriptID:    "tx-2",
-		Time:               now.Add(4 * time.Second),
+		SourceSessionID: "tx-1",
+		NewSessionID:    "tx-2",
+		Time:            now.Add(4 * time.Second),
 	}); err != nil {
 		t.Fatalf("Fork(): %v", err)
 	}
@@ -145,7 +145,9 @@ func TestFileStoreCompactAndFork(t *testing.T) {
 	}
 }
 
-func TestFileStoreReplace(t *testing.T) {
+// AppendMessage must be idempotent on the message ID and survive across
+// FileStore instances (the second store reads the existing file fresh).
+func TestFileStoreAppendMessageIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewFileStore(dir, "proj-1")
 	if err != nil {
@@ -153,36 +155,39 @@ func TestFileStoreReplace(t *testing.T) {
 	}
 
 	now := time.Date(2026, 4, 6, 16, 20, 0, 0, time.UTC)
-	err = store.Replace(context.Background(), ReplaceCommand{
-		Transcript: Transcript{
-			ID:        "tx-1",
-			Cwd:       "/tmp/project",
-			CreatedAt: now,
-			UpdatedAt: now.Add(2 * time.Second),
-			Provider:  "openai",
-			Model:     "gpt-test",
-			Messages: []Node{
-				{ID: "m1", Role: "user", Time: now.Add(time.Second), Content: []ContentBlock{{Type: "text", Text: "hello"}}},
-				{ID: "m2", ParentID: "m1", Role: "assistant", Time: now.Add(2 * time.Second), Content: []ContentBlock{{Type: "text", Text: "world"}}},
-			},
-			State: State{
-				Title:      "Saved via replace",
-				LastPrompt: "hello",
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("Replace(): %v", err)
+	if err := store.Start(context.Background(), StartCommand{
+		SessionID: "tx-1", Cwd: "/tmp/project", Provider: "openai", Model: "gpt-test", Time: now,
+	}); err != nil {
+		t.Fatalf("Start(): %v", err)
 	}
 
-	transcript, err := store.Load(context.Background(), "tx-1")
+	msg := AppendMessageCommand{
+		SessionID: "tx-1",
+		MessageID: "m1",
+		Time:      now.Add(time.Second),
+		Role:      "user",
+		Content:   []ContentBlock{{Type: "text", Text: "hello"}},
+	}
+	for i := range 3 {
+		if err := store.AppendMessage(context.Background(), msg); err != nil {
+			t.Fatalf("AppendMessage() #%d: %v", i, err)
+		}
+	}
+
+	// A fresh store (empty cache) must still dedupe via the on-disk scan.
+	fresh, err := NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore() fresh: %v", err)
+	}
+	if err := fresh.AppendMessage(context.Background(), msg); err != nil {
+		t.Fatalf("AppendMessage() fresh: %v", err)
+	}
+
+	tx, err := store.Load(context.Background(), "tx-1")
 	if err != nil {
 		t.Fatalf("Load(): %v", err)
 	}
-	if transcript.State.Title != "Saved via replace" {
-		t.Fatalf("Title = %q", transcript.State.Title)
-	}
-	if len(transcript.Messages) != 2 {
-		t.Fatalf("len(Messages) = %d, want 2", len(transcript.Messages))
+	if len(tx.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1 (dedup failed)", len(tx.Messages))
 	}
 }

--- a/internal/session/transcript/projector.go
+++ b/internal/session/transcript/projector.go
@@ -15,11 +15,11 @@ func Project(records []Record) (*Transcript, error) {
 
 	for _, r := range records {
 		switch r.Type {
-		case RecordStarted:
+		case SessionStarted:
 			applyStarted(t, r)
-		case RecordForked:
+		case SessionForked:
 			applyForked(t, r)
-		case RecordMessageAppended:
+		case MessageAppended:
 			n, err := buildNode(r)
 			if err != nil {
 				return nil, err
@@ -27,7 +27,7 @@ func Project(records []Record) (*Transcript, error) {
 			messageMap[n.ID] = n
 			order = append(order, n.ID)
 			if t.ID == "" {
-				t.ID = r.TranscriptID
+				t.ID = r.SessionID
 			}
 			if t.Cwd == "" {
 				t.Cwd = r.Cwd
@@ -38,27 +38,29 @@ func Project(records []Record) (*Transcript, error) {
 			if t.UpdatedAt.Before(r.Time) {
 				t.UpdatedAt = r.Time
 			}
-		case RecordStatePatched:
+		case StatePatched:
 			if err := applyStatePatch(&t.State, r.State); err != nil {
 				return nil, err
 			}
 			if t.ID == "" {
-				t.ID = r.TranscriptID
+				t.ID = r.SessionID
 			}
 			if t.UpdatedAt.Before(r.Time) {
 				t.UpdatedAt = r.Time
 			}
-		case RecordCompacted:
-			if r.System != nil {
-				compactBoundary = r.System.BoundaryID
+		case SessionCompacted:
+			if r.Session != nil {
+				compactBoundary = r.Session.BoundaryID
 			}
 			if t.ID == "" {
-				t.ID = r.TranscriptID
+				t.ID = r.SessionID
 			}
 			if t.UpdatedAt.Before(r.Time) {
 				t.UpdatedAt = r.Time
 			}
 		}
+		// Unknown types are intentionally ignored: the trace is forward-
+		// compatible with record kinds the projector doesn't model yet.
 	}
 
 	t.Messages = materializeActiveChain(messageMap, order, compactBoundary)
@@ -67,7 +69,7 @@ func Project(records []Record) (*Transcript, error) {
 
 func applyStarted(t *Transcript, r Record) {
 	if t.ID == "" {
-		t.ID = r.TranscriptID
+		t.ID = r.SessionID
 	}
 	if t.Cwd == "" {
 		t.Cwd = r.Cwd
@@ -78,22 +80,22 @@ func applyStarted(t *Transcript, r Record) {
 	if t.UpdatedAt.Before(r.Time) {
 		t.UpdatedAt = r.Time
 	}
-	if r.System != nil {
-		t.Provider = r.System.Provider
-		t.Model = r.System.Model
-		t.ParentID = r.System.ParentID
+	if r.Session != nil {
+		t.Provider = r.Session.Provider
+		t.Model = r.Session.Model
+		t.ParentID = r.Session.ParentID
 	}
 }
 
 func applyForked(t *Transcript, r Record) {
 	if t.ID == "" {
-		t.ID = r.TranscriptID
+		t.ID = r.SessionID
 	}
 	if t.UpdatedAt.Before(r.Time) {
 		t.UpdatedAt = r.Time
 	}
-	if r.System != nil && r.System.ParentID != "" {
-		t.ParentID = r.System.ParentID
+	if r.Session != nil && r.Session.ParentID != "" {
+		t.ParentID = r.Session.ParentID
 	}
 }
 
@@ -161,7 +163,10 @@ func applyStatePatch(state *State, patch *StateRecord) error {
 			}
 			state.Worktree = &wt
 		default:
-			return fmt.Errorf("unknown state patch path: %s", op.Path)
+			// Unknown patch paths are ignored so older readers tolerate
+			// records produced by newer schemas. New paths must remain
+			// additive; never repurpose an existing path's meaning.
+			continue
 		}
 	}
 	return nil

--- a/internal/session/transcript/projector_test.go
+++ b/internal/session/transcript/projector_test.go
@@ -12,27 +12,27 @@ func TestProjectStartAndAppendMessages(t *testing.T) {
 	now := time.Date(2026, 4, 6, 14, 0, 0, 0, time.UTC)
 	transcript, err := Project([]Record{
 		{
-			ID:           "tx-1:start",
-			TranscriptID: "tx-1",
-			Time:         now,
-			Type:         RecordStarted,
-			Cwd:          "/tmp/project",
-			System:       &SystemRecord{Provider: "openai", Model: "gpt-test"},
+			ID:        "tx-1:start",
+			SessionID: "tx-1",
+			Time:      now,
+			Type:      SessionStarted,
+			Cwd:       "/tmp/project",
+			Session:   &SessionRecord{Provider: "openai", Model: "gpt-test"},
 		},
 		{
-			ID:           "rec-1",
-			TranscriptID: "tx-1",
-			Time:         now.Add(time.Second),
-			Type:         RecordMessageAppended,
-			Message:      &MessageRecord{MessageID: "msg-1", Role: "user", Content: []ContentBlock{{Type: "text", Text: "hello"}}},
+			ID:        "rec-1",
+			SessionID: "tx-1",
+			Time:      now.Add(time.Second),
+			Type:      MessageAppended,
+			Message:   &MessageRecord{MessageID: "msg-1", Role: "user", Content: []ContentBlock{{Type: "text", Text: "hello"}}},
 		},
 		{
-			ID:           "rec-2",
-			TranscriptID: "tx-1",
-			Time:         now.Add(2 * time.Second),
-			Type:         RecordMessageAppended,
-			ParentID:     "msg-1",
-			Message:      &MessageRecord{MessageID: "msg-2", Role: "assistant", Content: []ContentBlock{{Type: "text", Text: "world"}}},
+			ID:        "rec-2",
+			SessionID: "tx-1",
+			Time:      now.Add(2 * time.Second),
+			Type:      MessageAppended,
+			ParentID:  "msg-1",
+			Message:   &MessageRecord{MessageID: "msg-2", Role: "assistant", Content: []ContentBlock{{Type: "text", Text: "world"}}},
 		},
 	})
 	if err != nil {
@@ -51,9 +51,9 @@ func TestProjectStartAndAppendMessages(t *testing.T) {
 
 func TestProjectStatePatchLastWins(t *testing.T) {
 	transcript, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTitle("A"), patchMode("normal")}}},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTitle("B"), patchMode("plan")}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{PatchTitle("A"), PatchMode("normal")}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{PatchTitle("B"), PatchMode("plan")}}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)
@@ -75,8 +75,8 @@ func TestProjectTasksAndWorktreePatches(t *testing.T) {
 	}
 	wt := &WorktreeState{OriginalCwd: "/repo", WorktreePath: "/repo/.wt/1", WorktreeName: "fix-1"}
 	transcript, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]tracker.Task{task}), patchWorktree(wt)}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]tracker.Task{task}), PatchWorktree(wt)}}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)
@@ -91,9 +91,9 @@ func TestProjectTasksAndWorktreePatches(t *testing.T) {
 
 func TestProjectWorktreeNullClears(t *testing.T) {
 	transcript, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{patchWorktree(&WorktreeState{WorktreeName: "a"})}}},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{patchWorktree(nil)}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{PatchWorktree(&WorktreeState{WorktreeName: "a"})}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{PatchWorktree(nil)}}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)
@@ -106,11 +106,11 @@ func TestProjectWorktreeNullClears(t *testing.T) {
 func TestProjectCompactBoundaryTruncatesActiveChain(t *testing.T) {
 	now := time.Date(2026, 4, 6, 14, 20, 0, 0, time.UTC)
 	transcript, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: now, Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: now.Add(time.Second), Type: RecordMessageAppended, Message: &MessageRecord{MessageID: "m1", Role: "user"}},
-		{TranscriptID: "tx-1", Time: now.Add(2 * time.Second), Type: RecordMessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m2", Role: "assistant"}},
-		{TranscriptID: "tx-1", Time: now.Add(3 * time.Second), Type: RecordMessageAppended, ParentID: "m2", Message: &MessageRecord{MessageID: "m3", Role: "user"}},
-		{TranscriptID: "tx-1", Time: now.Add(4 * time.Second), Type: RecordCompacted, System: &SystemRecord{BoundaryID: "m2"}},
+		{SessionID: "tx-1", Time: now, Type: SessionStarted},
+		{SessionID: "tx-1", Time: now.Add(time.Second), Type: MessageAppended, Message: &MessageRecord{MessageID: "m1", Role: "user"}},
+		{SessionID: "tx-1", Time: now.Add(2 * time.Second), Type: MessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m2", Role: "assistant"}},
+		{SessionID: "tx-1", Time: now.Add(3 * time.Second), Type: MessageAppended, ParentID: "m2", Message: &MessageRecord{MessageID: "m3", Role: "user"}},
+		{SessionID: "tx-1", Time: now.Add(4 * time.Second), Type: SessionCompacted, Session: &SessionRecord{BoundaryID: "m2"}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)
@@ -120,23 +120,31 @@ func TestProjectCompactBoundaryTruncatesActiveChain(t *testing.T) {
 	}
 }
 
-func TestProjectUnknownPatchPathReturnsError(t *testing.T) {
-	_, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: time.Now(), Type: RecordStatePatched, State: &StateRecord{Ops: []PatchOp{{Path: "bad.path", Value: json.RawMessage(`"x"`)}}}},
+// Unknown patch paths are silently ignored so older readers tolerate records
+// produced by newer schemas. The rest of the patch list must still apply.
+func TestProjectUnknownPatchPathIsIgnored(t *testing.T) {
+	tx, err := Project([]Record{
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
+		{SessionID: "tx-1", Time: time.Now(), Type: StatePatched, State: &StateRecord{Ops: []PatchOp{
+			{Path: "bad.path", Value: json.RawMessage(`"x"`)},
+			PatchTitle("Still applied"),
+		}}},
 	})
-	if err == nil {
-		t.Fatal("expected error for unknown patch path")
+	if err != nil {
+		t.Fatalf("Project(): %v", err)
+	}
+	if tx.State.Title != "Still applied" {
+		t.Fatalf("Title = %q, want %q (unknown path should not block subsequent ops)", tx.State.Title, "Still applied")
 	}
 }
 
 func TestProjectLatestLeafWins(t *testing.T) {
 	now := time.Date(2026, 4, 6, 14, 30, 0, 0, time.UTC)
 	transcript, err := Project([]Record{
-		{TranscriptID: "tx-1", Time: now, Type: RecordStarted},
-		{TranscriptID: "tx-1", Time: now.Add(time.Second), Type: RecordMessageAppended, Message: &MessageRecord{MessageID: "m1", Role: "user"}},
-		{TranscriptID: "tx-1", Time: now.Add(2 * time.Second), Type: RecordMessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m2", Role: "assistant"}},
-		{TranscriptID: "tx-1", Time: now.Add(3 * time.Second), Type: RecordMessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m3", Role: "assistant"}},
+		{SessionID: "tx-1", Time: now, Type: SessionStarted},
+		{SessionID: "tx-1", Time: now.Add(time.Second), Type: MessageAppended, Message: &MessageRecord{MessageID: "m1", Role: "user"}},
+		{SessionID: "tx-1", Time: now.Add(2 * time.Second), Type: MessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m2", Role: "assistant"}},
+		{SessionID: "tx-1", Time: now.Add(3 * time.Second), Type: MessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m3", Role: "assistant"}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)

--- a/internal/session/transcript/records.go
+++ b/internal/session/transcript/records.go
@@ -5,12 +5,20 @@ import (
 	"time"
 )
 
+// Record type values follow <entity>.<verb> (past tense), lowercase,
+// dot-separated. See docs/tracing.md for the full taxonomy.
 const (
-	RecordStarted         = "transcript.started"
-	RecordMessageAppended = "message.appended"
-	RecordStatePatched    = "state.patched"
-	RecordCompacted       = "transcript.compacted"
-	RecordForked          = "transcript.forked"
+	SessionStarted       = "session.started"
+	SessionForked        = "session.forked"
+	SessionCompacted     = "session.compacted"
+	MessageAppended      = "message.appended"
+	StatePatched         = "state.patched"
+	InferenceRequested   = "inference.requested"
+	InferenceResponded   = "inference.responded"
+	SystemSectionAdded   = "system.section.added"
+	SystemSectionRemoved = "system.section.removed"
+	ToolsAdded           = "tools.added"
+	ToolsRemoved         = "tools.removed"
 )
 
 const (
@@ -23,10 +31,10 @@ const (
 )
 
 type Record struct {
-	ID           string    `json:"id"`
-	TranscriptID string    `json:"transcriptId"`
-	Time         time.Time `json:"time"`
-	Type         string    `json:"type"`
+	ID        string    `json:"id"`
+	SessionID string    `json:"sessionId"`
+	Time      time.Time `json:"time"`
+	Type      string    `json:"type"`
 
 	ParentID    string `json:"parentId,omitempty"`
 	IsSidechain bool   `json:"isSidechain,omitempty"`
@@ -35,9 +43,12 @@ type Record struct {
 	GitBranch   string `json:"gitBranch,omitempty"`
 	AgentID     string `json:"agentId,omitempty"`
 
-	Message *MessageRecord `json:"message,omitempty"`
-	State   *StateRecord   `json:"state,omitempty"`
-	System  *SystemRecord  `json:"system,omitempty"`
+	Message   *MessageRecord       `json:"message,omitempty"`
+	State     *StateRecord         `json:"state,omitempty"`
+	Session   *SessionRecord       `json:"session,omitempty"`
+	Inference *InferenceRecord     `json:"inference,omitempty"`
+	System    *SystemSectionRecord `json:"system,omitempty"`
+	Tools     *ToolsRecord         `json:"tools,omitempty"`
 }
 
 type MessageRecord struct {
@@ -55,11 +66,72 @@ type PatchOp struct {
 	Value json.RawMessage `json:"value"`
 }
 
-type SystemRecord struct {
+// SessionRecord carries the lifecycle payload for session.started /
+// session.forked / session.compacted records. The three event types
+// multiplex on a single struct because the fields are sparse and the
+// projector dispatches on Record.Type rather than payload shape.
+type SessionRecord struct {
 	Provider   string `json:"provider,omitempty"`
 	Model      string `json:"model,omitempty"`
 	ParentID   string `json:"parentId,omitempty"`
 	BoundaryID string `json:"boundaryId,omitempty"`
+}
+
+// InferenceRecord carries the payload for inference.requested /
+// inference.responded. The "requested" side captures the digests of what was
+// sent to the LLM (system prompt, tools, active message chain); the "responded"
+// side captures stop reason, latency, and token usage. Big fields live in the
+// digests — full payloads are reconstructible by replaying preceding records.
+type InferenceRecord struct {
+	Turn         int    `json:"turn"`
+	Provider     string `json:"provider,omitempty"`
+	Model        string `json:"model,omitempty"`
+	MaxTokens    int    `json:"maxTokens,omitempty"`
+	SystemDigest string `json:"systemDigest,omitempty"`
+	ToolsDigest  string `json:"toolsDigest,omitempty"`
+
+	// MessageIDs is the active chain at request time, in send order.
+	// Recorded on inference.requested only.
+	MessageIDs []string `json:"messageIds,omitempty"`
+
+	// Response fields — populated on inference.responded only.
+	StopReason string         `json:"stopReason,omitempty"`
+	LatencyMs  int64          `json:"latencyMs,omitempty"`
+	Usage      *InferenceUsage `json:"usage,omitempty"`
+}
+
+type InferenceUsage struct {
+	InputTokens       int `json:"inputTokens"`
+	OutputTokens      int `json:"outputTokens"`
+	CacheCreateTokens int `json:"cacheCreateTokens,omitempty"`
+	CacheReadTokens   int `json:"cacheReadTokens,omitempty"`
+}
+
+// SystemSectionRecord carries the payload for system.section.added /
+// system.section.removed. On removal, Content is empty.
+type SystemSectionRecord struct {
+	Name    string `json:"name"`
+	Slot    int    `json:"slot,omitempty"`
+	Content string `json:"content,omitempty"`
+	Caller  string `json:"caller,omitempty"`
+}
+
+// ToolSchemaView mirrors a tool schema in transcript-local types so the
+// transcript package stays free of cross-package imports. Recorder converts
+// from the runtime ToolSchema before writing.
+type ToolSchemaView struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// ToolsRecord carries the payload for tools.added / tools.removed.
+// One tool per record (Add/Remove fire individually); Schema is set on
+// "added", Name on "removed".
+type ToolsRecord struct {
+	Schema *ToolSchemaView `json:"schema,omitempty"`
+	Name   string          `json:"name,omitempty"`
+	Caller string          `json:"caller,omitempty"`
 }
 
 type ContentBlock struct {
@@ -78,7 +150,13 @@ type ContentBlock struct {
 	Content   []ContentBlock `json:"content,omitempty"`
 	IsError   bool           `json:"is_error,omitempty"`
 
-	Source *ImageSource `json:"source,omitempty"`
+	// Source marks the provenance of injected content (e.g. "hook:UserPromptSubmit",
+	// "command:/identity", "reminder:system-reminder"). Empty for user-authored
+	// blocks and for ContentBlocks that the model itself produced.
+	Source string `json:"source,omitempty"`
+
+	// ImageSource is the inlined image data on type=image blocks.
+	ImageSource *ImageSource `json:"imageSource,omitempty"`
 }
 
 type ImageSource struct {

--- a/internal/session/transcript/records_test.go
+++ b/internal/session/transcript/records_test.go
@@ -9,13 +9,13 @@ import (
 func TestRecordJSONRoundTrip(t *testing.T) {
 	now := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
 	rec := Record{
-		ID:           "rec-1",
-		TranscriptID: "tx-1",
-		Time:         now,
-		Type:         RecordMessageAppended,
-		ParentID:     "msg-0",
-		Cwd:          "/tmp/project",
-		GitBranch:    "main",
+		ID:        "rec-1",
+		SessionID: "tx-1",
+		Time:      now,
+		Type:      MessageAppended,
+		ParentID:  "msg-0",
+		Cwd:       "/tmp/project",
+		GitBranch: "main",
 		Message: &MessageRecord{
 			MessageID: "msg-1",
 			Role:      "assistant",
@@ -36,7 +36,7 @@ func TestRecordJSONRoundTrip(t *testing.T) {
 		t.Fatalf("Unmarshal(): %v", err)
 	}
 
-	if got.ID != rec.ID || got.TranscriptID != rec.TranscriptID || got.Type != rec.Type {
+	if got.ID != rec.ID || got.SessionID != rec.SessionID || got.Type != rec.Type {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", got, rec)
 	}
 	if got.Message == nil || len(got.Message.Content) != 2 {

--- a/internal/session/transcript/store.go
+++ b/internal/session/transcript/store.go
@@ -11,48 +11,73 @@ import (
 )
 
 type StartCommand struct {
-	TranscriptID string
-	ProjectID    string
-	Cwd          string
-	Provider     string
-	Model        string
-	ParentID     string
-	Time         time.Time
+	SessionID string
+	ProjectID string
+	Cwd       string
+	Provider  string
+	Model     string
+	ParentID  string
+	Time      time.Time
 }
 
 type AppendMessageCommand struct {
-	TranscriptID string
-	MessageID    string
-	ParentID     string
-	Time         time.Time
-	Cwd          string
-	GitBranch    string
-	AgentID      string
-	IsSidechain  bool
-	Role         string
-	Content      []ContentBlock
+	SessionID   string
+	MessageID   string
+	ParentID    string
+	Time        time.Time
+	Cwd         string
+	GitBranch   string
+	AgentID     string
+	IsSidechain bool
+	Role        string
+	Content     []ContentBlock
 }
 
 type PatchStateCommand struct {
-	TranscriptID string
-	Time         time.Time
-	Ops          []PatchOp
+	SessionID string
+	Time      time.Time
+	Ops       []PatchOp
 }
 
 type CompactCommand struct {
-	TranscriptID string
-	Time         time.Time
-	BoundaryID   string
+	SessionID  string
+	Time       time.Time
+	BoundaryID string
 }
 
 type ForkCommand struct {
-	SourceTranscriptID string
-	NewTranscriptID    string
-	Time               time.Time
+	SourceSessionID string
+	NewSessionID    string
+	Time            time.Time
 }
 
-type ReplaceCommand struct {
-	Transcript Transcript
+// AppendInferenceCommand writes either an inference.requested or
+// inference.responded record. Type selects which; Record carries the payload.
+type AppendInferenceCommand struct {
+	SessionID string
+	AgentID   string
+	Time      time.Time
+	Type      string // InferenceRequested or InferenceResponded
+	Record    InferenceRecord
+}
+
+// AppendSystemSectionCommand writes system.section.added or
+// system.section.removed. Removed sections drop Content from Record.
+type AppendSystemSectionCommand struct {
+	SessionID string
+	AgentID   string
+	Time      time.Time
+	Type      string // SystemSectionAdded or SystemSectionRemoved
+	Record    SystemSectionRecord
+}
+
+// AppendToolsCommand writes tools.added or tools.removed.
+type AppendToolsCommand struct {
+	SessionID string
+	AgentID   string
+	Time      time.Time
+	Type      string // ToolsAdded or ToolsRemoved
+	Record    ToolsRecord
 }
 
 type ListOptions struct {
@@ -60,28 +85,33 @@ type ListOptions struct {
 	IncludeSidechain bool
 }
 
-func PatchTitle(title string) PatchOp {
-	return mustPatch(PatchPathTitle, title)
-}
-
-func PatchLastPrompt(prompt string) PatchOp {
-	return mustPatch(PatchPathLastPrompt, prompt)
-}
-
-func patchTag(tag string) PatchOp {
-	return mustPatch(PatchPathTag, tag)
-}
-
-func patchMode(mode string) PatchOp {
-	return mustPatch(PatchPathMode, mode)
-}
-
+func PatchTitle(title string) PatchOp       { return mustPatch(PatchPathTitle, title) }
+func PatchLastPrompt(prompt string) PatchOp { return mustPatch(PatchPathLastPrompt, prompt) }
+func PatchTag(tag string) PatchOp           { return mustPatch(PatchPathTag, tag) }
+func PatchMode(mode string) PatchOp         { return mustPatch(PatchPathMode, mode) }
 func PatchTasks(tasks []tracker.Task) PatchOp {
 	return mustPatch(PatchPathTasks, tasks)
 }
+func PatchWorktree(worktree *WorktreeState) PatchOp { return mustPatch(PatchPathWorktree, worktree) }
 
-func patchWorktree(worktree *WorktreeState) PatchOp {
-	return mustPatch(PatchPathWorktree, worktree)
+// StateOpsFor builds the full set of patch ops for a projected state.
+// Used by the session save path to express the current snapshot as a single
+// patch record. Zero-valued fields still produce ops (the projector applies
+// last-wins, so re-patching empty values is safe).
+func StateOpsFor(state State) []PatchOp {
+	ops := []PatchOp{
+		PatchTitle(state.Title),
+		PatchLastPrompt(state.LastPrompt),
+		PatchTag(state.Tag),
+		PatchMode(state.Mode),
+	}
+	if len(state.Tasks) > 0 {
+		ops = append(ops, PatchTasks(TrackerTasksFromView(state.Tasks)))
+	}
+	if state.Worktree != nil {
+		ops = append(ops, PatchWorktree(state.Worktree))
+	}
+	return ops
 }
 
 func mustPatch(path string, v any) PatchOp {

--- a/internal/session/transcript/store_test.go
+++ b/internal/session/transcript/store_test.go
@@ -26,8 +26,8 @@ func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 	}{
 		{name: "title", got: PatchTitle("New Title"), want: `"New Title"`},
 		{name: "lastPrompt", got: PatchLastPrompt("continue"), want: `"continue"`},
-		{name: "mode", got: patchMode("plan"), want: `"plan"`},
-		{name: "tag", got: patchTag("urgent"), want: `"urgent"`},
+		{name: "mode", got: PatchMode("plan"), want: `"plan"`},
+		{name: "tag", got: PatchTag("urgent"), want: `"urgent"`},
 	}
 
 	for _, tc := range cases {
@@ -45,7 +45,7 @@ func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 		t.Fatalf("unexpected task patch payload: %+v", decodedTasks)
 	}
 
-	wtPatch := patchWorktree(&WorktreeState{
+	wtPatch := PatchWorktree(&WorktreeState{
 		OriginalCwd:  "/repo",
 		WorktreePath: "/repo/.wt/1",
 		WorktreeName: "fix-1",
@@ -59,8 +59,8 @@ func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 	}
 }
 
-func Test_patchWorktreeAllowsNil(t *testing.T) {
-	patch := patchWorktree(nil)
+func Test_PatchWorktreeAllowsNil(t *testing.T) {
+	patch := PatchWorktree(nil)
 	if string(patch.Value) != "null" {
 		t.Fatalf("expected null payload, got %s", string(patch.Value))
 	}

--- a/internal/session/transcript/types.go
+++ b/internal/session/transcript/types.go
@@ -53,7 +53,7 @@ type TrackerTaskView struct {
 }
 
 type ListItem struct {
-	TranscriptID string
+	SessionID string
 	FullPath     string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time

--- a/internal/session/transcript/types_test.go
+++ b/internal/session/transcript/types_test.go
@@ -83,7 +83,7 @@ func TestMetadataAndTaskViewHelpers(t *testing.T) {
 	}
 
 	itemMeta := MetadataFromListItem(ListItem{
-		TranscriptID: "tx-2",
+		SessionID:    "tx-2",
 		Title:        "Resume work",
 		LastPrompt:   "continue",
 		CreatedAt:    now,

--- a/internal/session/transcript/view.go
+++ b/internal/session/transcript/view.go
@@ -43,7 +43,7 @@ func MetadataFromTranscript(t *Transcript) MetadataView {
 
 func MetadataFromListItem(item ListItem, cwd string) MetadataView {
 	return MetadataView{
-		ID:           item.TranscriptID,
+		ID:           item.SessionID,
 		Title:        item.Title,
 		LastPrompt:   item.LastPrompt,
 		CreatedAt:    item.CreatedAt,

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -285,7 +285,7 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	if e.mcpRegistry != nil {
 		mcpCaller := mcp.NewCaller(e.mcpRegistry)
 		for _, t := range mcp.AsCoreTools(schemas, mcpCaller) {
-			tools.Add(t)
+			tools.Add(t, "mcp:"+t.Name())
 		}
 	}
 

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -554,7 +554,9 @@ func (s *stubLLM) InputLimit() int { return 0 }
 // stubSystem is a minimal core.System for tests.
 type stubSystem struct{}
 
-func (s *stubSystem) Prompt() string     { return "" }
-func (s *stubSystem) Use(_ core.Section) {}
-func (s *stubSystem) Drop(_ string)      {}
-func (s *stubSystem) Refresh(_ string)   {}
+func (s *stubSystem) Prompt() string                       { return "" }
+func (s *stubSystem) Use(_ core.Section, _ string)         {}
+func (s *stubSystem) Drop(_, _ string)                     {}
+func (s *stubSystem) Refresh(_, _ string)                  {}
+func (s *stubSystem) Sections() []core.Section             { return nil }
+func (s *stubSystem) SetObserver(_ func(core.SystemChange)) {}

--- a/internal/subagent/progress_tools.go
+++ b/internal/subagent/progress_tools.go
@@ -19,10 +19,11 @@ func (p *progressTools) Get(name string) core.Tool {
 	}
 	return &progressTool{inner: t, onExec: p.onExec}
 }
-func (p *progressTools) All() []core.Tool           { return p.inner.All() }
-func (p *progressTools) Add(t core.Tool)            { p.inner.Add(t) }
-func (p *progressTools) Remove(name string)         { p.inner.Remove(name) }
-func (p *progressTools) Schemas() []core.ToolSchema { return p.inner.Schemas() }
+func (p *progressTools) All() []core.Tool                       { return p.inner.All() }
+func (p *progressTools) Add(t core.Tool, caller string)         { p.inner.Add(t, caller) }
+func (p *progressTools) Remove(name, caller string)             { p.inner.Remove(name, caller) }
+func (p *progressTools) Schemas() []core.ToolSchema             { return p.inner.Schemas() }
+func (p *progressTools) SetObserver(fn func(core.ToolsChange))  { p.inner.SetObserver(fn) }
 
 type progressTool struct {
 	inner  core.Tool

--- a/internal/tool/permission.go
+++ b/internal/tool/permission.go
@@ -32,10 +32,11 @@ func (pt *permissionTools) Get(name string) core.Tool {
 	return &permissionTool{inner: t, check: pt.check}
 }
 
-func (pt *permissionTools) All() []core.Tool           { return pt.inner.All() }
-func (pt *permissionTools) Add(tool core.Tool)         { pt.inner.Add(tool) }
-func (pt *permissionTools) Remove(name string)         { pt.inner.Remove(name) }
-func (pt *permissionTools) Schemas() []core.ToolSchema { return pt.inner.Schemas() }
+func (pt *permissionTools) All() []core.Tool                          { return pt.inner.All() }
+func (pt *permissionTools) Add(tool core.Tool, caller string)         { pt.inner.Add(tool, caller) }
+func (pt *permissionTools) Remove(name, caller string)                { pt.inner.Remove(name, caller) }
+func (pt *permissionTools) Schemas() []core.ToolSchema                { return pt.inner.Schemas() }
+func (pt *permissionTools) SetObserver(fn func(core.ToolsChange))     { pt.inner.SetObserver(fn) }
 
 // permissionTool wraps a single core.Tool with permission checking.
 type permissionTool struct {

--- a/internal/trace/server.go
+++ b/internal/trace/server.go
@@ -1,0 +1,257 @@
+// Package trace serves the gen-code session transcripts to a local web UI.
+//
+// The viewer is read-only, single-process, localhost-only. It exposes a small
+// HTTP API that mirrors the JSONL on disk — the wire format IS the file
+// format — plus an SSE endpoint for live tail. UI assets are embedded so the
+// binary is self-contained.
+package trace
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/genai-io/gen-code/internal/trace/ui"
+)
+
+// Server hosts the trace viewer for a single project directory.
+type Server struct {
+	projectDir string // .../.gen/projects/<encoded-cwd>
+	mux        *http.ServeMux
+
+	mu       sync.Mutex
+	watchers map[string]*tailer // sessionID -> active tailer
+}
+
+func New(projectDir string) *Server {
+	s := &Server{
+		projectDir: projectDir,
+		mux:        http.NewServeMux(),
+		watchers:   make(map[string]*tailer),
+	}
+	s.routes()
+	return s
+}
+
+func (s *Server) Handler() http.Handler { return s.mux }
+
+func (s *Server) routes() {
+	// UI assets — strip the "assets/" prefix to expose them at the root.
+	assets, err := fs.Sub(ui.Assets, "assets")
+	if err == nil {
+		s.mux.Handle("/", http.FileServer(http.FS(assets)))
+	}
+
+	s.mux.HandleFunc("/api/sessions", s.handleListSessions)
+	// Per-session routes: /api/sessions/{id}/records, /api/sessions/{id}/stream
+	s.mux.HandleFunc("/api/sessions/", s.handleSessionRoute)
+}
+
+// transcriptsDir is the JSONL location: <projectDir>/transcripts.
+func (s *Server) transcriptsDir() string {
+	return filepath.Join(s.projectDir, "transcripts")
+}
+
+type sessionListItem struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	Size      int64     `json:"size"`
+}
+
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	entries, err := os.ReadDir(s.transcriptsDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSON(w, []sessionListItem{})
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	items := make([]sessionListItem, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		item := sessionListItem{ID: id, UpdatedAt: info.ModTime(), Size: info.Size()}
+		// First user-typed text in the file makes a decent title preview without
+		// loading the whole transcript.
+		item.Title = previewTitle(filepath.Join(s.transcriptsDir(), e.Name()))
+		items = append(items, item)
+	}
+	// Newest first.
+	sortByUpdatedDesc(items)
+	writeJSON(w, items)
+}
+
+// handleSessionRoute routes /api/sessions/{id}/{action} to the matching handler.
+func (s *Server) handleSessionRoute(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/sessions/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+	sessionID, action := parts[0], parts[1]
+	if sessionID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch action {
+	case "records":
+		s.handleRecords(w, r, sessionID)
+	case "stream":
+		s.handleStream(w, r, sessionID)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) sessionPath(id string) (string, bool) {
+	// Defense against path traversal — sessionID must look like a single
+	// filename segment.
+	if strings.ContainsAny(id, "/\\") || id == "" {
+		return "", false
+	}
+	p := filepath.Join(s.transcriptsDir(), id+".jsonl")
+	return p, true
+}
+
+func (s *Server) handleRecords(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path, ok := s.sessionPath(sessionID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
+	data, nextOffset, err := readFromOffset(path, after)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("X-Next-Offset", strconv.FormatInt(nextOffset, 10))
+	_, _ = w.Write(data)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// readFromOffset reads bytes from the file starting at offset. Returns the
+// bytes plus the new end-of-file offset. Always returns at line boundaries —
+// trailing partial line is left for the next read.
+func readFromOffset(path string, offset int64) ([]byte, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	end := info.Size()
+	if offset >= end {
+		return nil, end, nil
+	}
+	if _, err := f.Seek(offset, 0); err != nil {
+		return nil, 0, err
+	}
+	buf := make([]byte, end-offset)
+	n, err := f.Read(buf)
+	if err != nil {
+		return nil, 0, err
+	}
+	buf = buf[:n]
+	// Trim trailing partial line.
+	if i := lastNewline(buf); i >= 0 {
+		return buf[:i+1], offset + int64(i+1), nil
+	}
+	// No newline yet — leave the bytes for next poll.
+	return nil, offset, nil
+}
+
+func lastNewline(b []byte) int {
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// previewTitle returns a short prefix of the first user-role message's text
+// content, suitable for a list view. Best-effort; returns "" on any error.
+func previewTitle(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var rec struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"message"`
+		}
+		if err := dec.Decode(&rec); err != nil {
+			return ""
+		}
+		if rec.Type != "message.appended" || rec.Message == nil || rec.Message.Role != "user" {
+			continue
+		}
+		for _, c := range rec.Message.Content {
+			if c.Type == "text" {
+				t := strings.TrimSpace(c.Text)
+				if t == "" {
+					continue
+				}
+				if len(t) > 80 {
+					t = t[:80] + "…"
+				}
+				return t
+			}
+		}
+	}
+	return ""
+}
+
+func sortByUpdatedDesc(items []sessionListItem) {
+	// Insertion sort — list size is small (tens of sessions per project).
+	for i := 1; i < len(items); i++ {
+		j := i
+		for j > 0 && items[j].UpdatedAt.After(items[j-1].UpdatedAt) {
+			items[j-1], items[j] = items[j], items[j-1]
+			j--
+		}
+	}
+}
+

--- a/internal/trace/server_test.go
+++ b/internal/trace/server_test.go
@@ -1,0 +1,97 @@
+package trace
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// End-to-end smoke: write a transcript file under projectDir/transcripts, hit
+// the public API, and verify the listing + records endpoints reflect what's
+// on disk. Also catches the path-traversal guard.
+func TestServerListAndRecords(t *testing.T) {
+	projectDir := t.TempDir()
+	txDir := filepath.Join(projectDir, "transcripts")
+	if err := os.MkdirAll(txDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := strings.Join([]string{
+		`{"id":"sess-1:start","sessionId":"sess-1","time":"2026-05-15T00:00:00Z","type":"session.started","session":{"provider":"p","model":"m"}}`,
+		`{"id":"sess-1:m1","sessionId":"sess-1","time":"2026-05-15T00:00:01Z","type":"message.appended","message":{"messageId":"m1","role":"user","content":[{"type":"text","text":"hello"}]}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(txDir, "sess-1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	srv := httptest.NewServer(New(projectDir).Handler())
+	defer srv.Close()
+
+	// /api/sessions returns the one transcript with title pulled from the
+	// first user message text.
+	resp, err := srv.Client().Get(srv.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions: %v", err)
+	}
+	defer resp.Body.Close()
+	var list []sessionListItem
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "sess-1" {
+		t.Fatalf("unexpected session list: %+v", list)
+	}
+	if list[0].Title != "hello" {
+		t.Fatalf("Title = %q, want %q", list[0].Title, "hello")
+	}
+
+	// /api/sessions/sess-1/records?after=0 returns the full body and a
+	// next-offset header equal to the file size.
+	resp2, err := srv.Client().Get(srv.URL + "/api/sessions/sess-1/records?after=0")
+	if err != nil {
+		t.Fatalf("GET records: %v", err)
+	}
+	defer resp2.Body.Close()
+	if got := resp2.Header.Get("X-Next-Offset"); got != "" {
+		// Must equal len(body) since the file is fully line-terminated.
+		if parsed, _ := json.Number(got).Int64(); parsed != int64(len(body)) {
+			t.Fatalf("X-Next-Offset = %s, want %d", got, len(body))
+		}
+	}
+
+	// Path traversal must be rejected even with URL-encoded slashes.
+	resp3, err := srv.Client().Get(srv.URL + "/api/sessions/..%2Fetc/records")
+	if err != nil {
+		t.Fatalf("GET traversal: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Fatalf("traversal status = %d, want 404", resp3.StatusCode)
+	}
+}
+
+// An empty project directory must yield an empty list, not an error.
+func TestServerListNoTranscripts(t *testing.T) {
+	projectDir := t.TempDir()
+
+	srv := httptest.NewServer(New(projectDir).Handler())
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var list []sessionListItem
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %+v", list)
+	}
+}

--- a/internal/trace/stream.go
+++ b/internal/trace/stream.go
@@ -1,0 +1,98 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// handleStream serves SSE: client connects, we replay the file from the start,
+// then poll for new content. Each emitted event carries one JSONL record line.
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path, ok := s.sessionPath(sessionID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if _, err := os.Stat(path); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ctx := r.Context()
+	var offset int64
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Send everything on the first pass, then poll for growth. Buffered I/O
+	// means new bytes appear without fsync (cf. C4 — telemetry sits in the
+	// page cache until a turn boundary), so polling is the safe choice.
+	if err := sendNewLines(ctx, w, flusher, path, &offset); err != nil {
+		return
+	}
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := sendNewLines(ctx, w, flusher, path, &offset); err != nil {
+				return
+			}
+		case <-keepAlive.C:
+			// Comment line keeps proxies / browsers from idle-timing out.
+			fmt.Fprint(w, ": keep-alive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+// sendNewLines reads any new bytes past *offset and writes them as SSE
+// messages. Advances *offset by the consumed byte count. Returns the first
+// error from the writer (typically client disconnect).
+func sendNewLines(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, path string, offset *int64) error {
+	data, next, err := readFromOffset(path, *offset)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return ctx.Err()
+	}
+	// Split on newlines and emit each non-empty line as a single SSE message.
+	start := 0
+	for i, b := range data {
+		if b != '\n' {
+			continue
+		}
+		line := data[start:i]
+		start = i + 1
+		if len(line) == 0 {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", line); err != nil {
+			return err
+		}
+	}
+	flusher.Flush()
+	*offset = next
+	return nil
+}
+
+// tailer is reserved for future fan-out (one watcher per file, many
+// subscribers). The MVP currently does per-client polling, which is simpler
+// and adequate for localhost use.
+type tailer struct{}

--- a/internal/trace/ui/assets/app.js
+++ b/internal/trace/ui/assets/app.js
@@ -1,0 +1,192 @@
+// Minimal trace viewer — no build step, vanilla JS.
+//
+// State machine:
+//   1. Fetch /api/sessions, populate sidebar.
+//   2. On session click, open SSE /api/sessions/{id}/stream.
+//   3. Each SSE event carries one JSONL record line; append to timeline.
+//   4. On row click, render the full JSON in the detail pane.
+
+const $ = (sel) => document.querySelector(sel);
+const sessions = $("#session-list");
+const timeline = $("#timeline");
+const detail = $("#detail-body");
+const sessionMeta = $("#session-meta");
+const statusEl = $("#status");
+
+const state = {
+  currentSession: null,
+  records: [],
+  eventSource: null,
+  filters: {
+    message:   true,
+    inference: true,
+    tool:      true,
+    system:    true,
+    state:     true,
+  },
+};
+
+function classify(type) {
+  if (!type) return "unknown";
+  if (type.startsWith("session."))         return "session";
+  if (type.startsWith("message."))         return "message";
+  if (type.startsWith("inference."))       return "inference";
+  if (type.startsWith("tools."))           return "tool";
+  if (type === "tool.invoked" || type === "tool.completed") return "tool";
+  if (type.startsWith("system."))          return "system";
+  if (type === "state.patched")            return "state";
+  return "unknown";
+}
+
+function fmtTime(s) {
+  if (!s) return "";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString();
+}
+
+function labelFor(rec) {
+  let label = rec.type;
+  if (rec.message)   label += "  " + (rec.message.role || "");
+  if (rec.system)    label += "  " + (rec.system.name || "");
+  if (rec.tools && rec.tools.schema) label += "  " + rec.tools.schema.name;
+  if (rec.tools && rec.tools.name)   label += "  " + rec.tools.name;
+  if (rec.inference) label += "  turn " + (rec.inference.turn || "?");
+  return label;
+}
+
+function setStatus(text, live) {
+  statusEl.textContent = text;
+  statusEl.classList.toggle("live", !!live);
+}
+
+async function loadSessions() {
+  setStatus("loading…");
+  try {
+    const r = await fetch("/api/sessions");
+    if (!r.ok) throw new Error(r.statusText);
+    const list = await r.json();
+    renderSessionList(list);
+    setStatus("");
+  } catch (e) {
+    setStatus("error: " + e.message);
+  }
+}
+
+function renderSessionList(list) {
+  sessions.innerHTML = "";
+  if (!list.length) {
+    const li = document.createElement("li");
+    li.textContent = "(no sessions in this project)";
+    li.style.color = "var(--fg-dim)";
+    sessions.appendChild(li);
+    return;
+  }
+  for (const s of list) {
+    const li = document.createElement("li");
+    li.dataset.id = s.id;
+    li.innerHTML =
+      '<div>' + escapeHTML(s.title || "(untitled)") + '</div>' +
+      '<span class="id">' + s.id.slice(0, 12) + '… · ' + Math.round(s.size / 1024) + 'KB</span>';
+    li.addEventListener("click", () => openSession(s.id, li));
+    sessions.appendChild(li);
+  }
+}
+
+function openSession(id, li) {
+  for (const x of sessions.querySelectorAll("li.active")) x.classList.remove("active");
+  if (li) li.classList.add("active");
+
+  if (state.eventSource) {
+    state.eventSource.close();
+    state.eventSource = null;
+  }
+  state.currentSession = id;
+  state.records = [];
+  timeline.innerHTML = "";
+  detail.textContent = "Click a record to inspect its payload.";
+  sessionMeta.textContent = id;
+
+  const es = new EventSource("/api/sessions/" + encodeURIComponent(id) + "/stream");
+  state.eventSource = es;
+  setStatus("connecting…");
+
+  es.onopen = () => setStatus("connected", true);
+  es.onerror = () => setStatus("disconnected");
+  es.onmessage = (ev) => {
+    let rec;
+    try {
+      rec = JSON.parse(ev.data);
+    } catch (e) {
+      return;
+    }
+    state.records.push(rec);
+    appendRow(rec, state.records.length - 1);
+  };
+}
+
+function appendRow(rec, idx) {
+  const klass = classify(rec.type);
+  if (!passesFilter(klass)) return;
+
+  const row = document.createElement("div");
+  row.className = "row " + klass;
+  row.dataset.idx = idx;
+  row.innerHTML =
+    '<span class="time">' + fmtTime(rec.time) + '</span>' +
+    '<span class="swatch"></span>' +
+    '<span class="label">' + escapeHTML(labelFor(rec)) + '</span>';
+  row.addEventListener("click", () => showDetail(idx, row));
+  timeline.appendChild(row);
+
+  // Auto-scroll if user is near the bottom.
+  if (timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight < 100) {
+    timeline.scrollTop = timeline.scrollHeight;
+  }
+}
+
+function showDetail(idx, row) {
+  for (const x of timeline.querySelectorAll(".row.active")) x.classList.remove("active");
+  row.classList.add("active");
+  const rec = state.records[idx];
+  detail.textContent = JSON.stringify(rec, null, 2);
+}
+
+function passesFilter(klass) {
+  if (klass === "state")     return state.filters.state;
+  if (klass === "tool")      return state.filters.tool;
+  if (klass === "system")    return state.filters.system;
+  if (klass === "inference") return state.filters.inference;
+  if (klass === "message")   return state.filters.message;
+  return true;
+}
+
+function wireFilters() {
+  const map = {
+    "filter-state":     "state",
+    "filter-tools":     "tool",
+    "filter-system":    "system",
+    "filter-inference": "inference",
+    "filter-message":   "message",
+  };
+  for (const [id, key] of Object.entries(map)) {
+    const el = document.getElementById(id);
+    el.addEventListener("change", () => {
+      state.filters[key] = el.checked;
+      // Re-render timeline against current filters.
+      timeline.innerHTML = "";
+      state.records.forEach((r, i) => appendRow(r, i));
+    });
+  }
+}
+
+function escapeHTML(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+wireFilters();
+loadSessions();

--- a/internal/trace/ui/assets/index.html
+++ b/internal/trace/ui/assets/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>gen trace</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>gen trace</h1>
+    <span id="status" class="status idle"></span>
+  </header>
+
+  <main>
+    <aside id="sidebar">
+      <h2>Sessions</h2>
+      <ul id="session-list" class="session-list"></ul>
+    </aside>
+
+    <section id="viewer">
+      <div id="timeline-header">
+        <span id="session-meta">Select a session to begin.</span>
+        <label class="filters">
+          <input type="checkbox" id="filter-state" checked> state.patched
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-tools" checked> tools.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-system" checked> system.section.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-inference" checked> inference.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-message" checked> message
+        </label>
+      </div>
+      <div id="timeline" class="timeline"></div>
+    </section>
+
+    <section id="detail" class="detail">
+      <pre id="detail-body">Click a record to inspect its payload.</pre>
+    </section>
+  </main>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/internal/trace/ui/assets/style.css
+++ b/internal/trace/ui/assets/style.css
@@ -1,0 +1,174 @@
+:root {
+  --bg: #0f1115;
+  --bg-2: #1a1d24;
+  --fg: #d6d9de;
+  --fg-dim: #8a93a6;
+  --accent: #6aa9ff;
+  --border: #262b35;
+
+  --c-session: #f5a623;
+  --c-message: #6aa9ff;
+  --c-inference: #b388ff;
+  --c-tool: #58d68d;
+  --c-system: #ffd93d;
+  --c-state: #5a6273;
+  --c-unknown: #555;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+header h1 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.status {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--bg-2);
+  color: var(--fg-dim);
+}
+.status.live { background: #1d4d2b; color: #c8f7c8; }
+.status.live::before { content: "● live "; }
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 240px 1fr 1fr;
+  min-height: 0;
+}
+
+aside {
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+aside h2 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: var(--fg-dim);
+  letter-spacing: 0.05em;
+  margin: 0.25rem 0 0.5rem;
+}
+.session-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.session-list li {
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+.session-list li:hover { background: var(--bg-2); }
+.session-list li.active {
+  background: var(--bg-2);
+  border-color: var(--accent);
+}
+.session-list .id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  color: var(--fg-dim);
+  display: block;
+}
+
+#viewer {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  min-width: 0;
+}
+#timeline-header {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+#timeline-header .filters {
+  color: var(--fg-dim);
+  cursor: pointer;
+}
+#session-meta {
+  flex: 1;
+  color: var(--fg-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.timeline {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+.row {
+  display: grid;
+  grid-template-columns: 70px 4px 1fr;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+}
+.row:hover { background: var(--bg-2); }
+.row.active {
+  background: var(--bg-2);
+  border-left-color: var(--accent);
+}
+.row .time {
+  color: var(--fg-dim);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+.row .swatch {
+  align-self: stretch;
+  border-radius: 1px;
+}
+.row .label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row.session  .swatch { background: var(--c-session); }
+.row.message  .swatch { background: var(--c-message); }
+.row.inference .swatch { background: var(--c-inference); }
+.row.tool     .swatch { background: var(--c-tool); }
+.row.system   .swatch { background: var(--c-system); }
+.row.state    .swatch { background: var(--c-state); }
+.row.unknown  .swatch { background: var(--c-unknown); }
+
+.detail {
+  overflow: auto;
+  padding: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+.detail pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg);
+}

--- a/internal/trace/ui/embed.go
+++ b/internal/trace/ui/embed.go
@@ -1,0 +1,10 @@
+// Package ui embeds the trace viewer's static assets.
+package ui
+
+import "embed"
+
+// Assets carries the SPA shell. The trace server strips the "assets/" prefix
+// to serve files at "/".
+//
+//go:embed assets
+var Assets embed.FS


### PR DESCRIPTION
## Summary

Adds end-to-end session tracing: every byte that reaches the model is captured as a structured event in the session's JSONL, and a local `gen trace` viewer renders the timeline. See `docs/tracing.md` for the first-principles design.

## What's in this PR

**5 commits, layered:**

1. **`refactor: append-only transcript persistence + fsync batching`** — replaces `FileStore.Replace` (full-file rewrite per turn) with `Start` + per-event `AppendMessage` + single `PatchState`. Adds an in-memory `persistedIDs` cache so dedup is O(1) after the first scan. fsync is now turn-boundary batched: critical writes (`message.appended`, `inference.responded`) sync; telemetry writes (`system.section.*`, `tools.*`, `inference.requested`, `state.patched`) buffer in the page cache and ride along on the next turn-boundary flush. Typical turn drops from ~5 fsync calls to 1.

2. **`refactor: unify record/payload naming + ContentBlock.Source field`** — every record type now follows `<entity>[.<sub-entity>].<past-tense-verb>`. Renames: `transcript.*` → `session.*`, `TranscriptID` → `SessionID` everywhere (Go field + JSON tag), `SystemRecord` → `SessionRecord` (the struct never held system-prompt data; name now matches intent), `Record.System` → `Record.Session`. Adds `ContentBlock.Source` for provenance; renames the existing image-data field to `ImageSource` to free the namespace. Projector tolerates unknown patch paths for forward compatibility.

3. **`feat: trace recorder for inference / system / tools + content provenance`** — new `session.Recorder` wired through `core.Config.OnEvent` translates lifecycle events into transcript records:
   - `inference.requested` (digests of system prompt / tool list / message chain) and `inference.responded` (stop reason, latency, token usage)
   - `system.section.added` / `system.section.removed` driven by a new observer on `core.System`; `Use(sec, caller)` / `Drop(name, caller)` carry caller info (`system:init`, `command:identity`, `subagent:init`, etc.). `SetObserver` replays existing sections on attach so the event chain is complete from t0.
   - `tools.added` / `tools.removed` via the same pattern on `core.Tools`. MCP registrations use caller `mcp:<toolname>`. Both wrappers (`permissionTools`, `progressTools`) pass-through.
   - Content provenance: `splitTextByProvenance` splits user-message content on `<system-reminder>` boundaries and tags those blocks with `Source="reminder"`. Round-trip safe — `extractUserContent` concatenates all text blocks back into the original `core.Message.Content` string.
   - Non-blocking `emitTelemetry` for observer-fired events so the agent goroutine never blocks on a slow TUI consumer.

4. **`feat: gen trace web viewer`** — new `internal/trace` package + `gen trace` subcommand. Localhost-only HTTP server, polling-based tailer (no fsnotify dependency), SSE live tail, JSONL is the wire format (server doesn't reshape records). Vanilla JS frontend, no build step, assets embedded via `go:embed`. CLI refuses any non-loopback `--addr`.

5. **`docs: tracing event model`** — first-principles doc covering event taxonomy, payload shapes, replay algorithm, troubleshooting recipes, and the viewer's HTTP API.

## Architecture decisions

- **Cause not effect**: observers fire on `Use`/`Drop`/`Add`/`Remove`, with explicit `caller` strings. Avoids digest-comparison-after-the-fact which would lose the "who changed this?" attribution.
- **Replay on attach**: `SetObserver` snapshots current state and replays it as synthetic `added` events. Lets the recorder be wired at agent-construction time without losing the initial state established by `system.Build()`.
- **Event bus reuse**: extended existing `core.Event` types (`OnSystemChange`, `OnToolsChange`) instead of introducing a separate `Recorder` interface. The TUI already subscribes to the outbox; the recorder is a second consumer on the same stream.
- **JSONL is the wire format**: the trace viewer's `/api/sessions/{id}/records` returns the JSONL lines untouched. One schema across disk, network, and browser.
- **Round-trip safety on splitting**: `splitTextByProvenance` never trims; concatenating all returned blocks' `Text` fields reproduces the input byte-for-byte. `extractUserContent` does that concat. Net effect on `core.Message.Content` is zero.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 51 packages pass, 0 FAIL
- [x] Targeted unit tests added:
  - `TestRecorderWritesRequestedAndRespondedPerTurn`
  - `TestRecorderWritesSystemSectionEvents`
  - `TestRecorderWritesToolsChangeEvents`
  - `TestRecorderNilSafe`
  - `Test_userContentToBlocks_splitsByProvenance`
  - `Test_userContentToBlocks_plainTextOneBlock`
  - `TestServerListAndRecords` (+ path-traversal guard)
  - `TestServerListNoTranscripts`
  - `TestFileStoreAppendMessageIsIdempotent`
- [x] Round-trip preservation: `Test_messagesToEntries_roundtrip` still passes despite the ContentBlock split
- [x] Manual smoke test: built binary, ran `gen trace --addr 127.0.0.1:38081 --no-open`, verified `/api/sessions` returned real local sessions and SPA assets served correctly

## Compatibility

- No backward compatibility is preserved for the on-disk schema. Existing transcripts written before this PR will not load — the JSON tag rename (`transcriptId` → `sessionId`) and record-type rename (`transcript.*` → `session.*`) are breaking.
- No external callers outside `internal/session/` and the in-process agent build paths use the renamed types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)