### PR TITLE
feat: gen trace web viewer

### DIFF
--- a/cmd/gen/trace.go
+++ b/cmd/gen/trace.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/genai-io/gen-code/internal/session"
+	"github.com/genai-io/gen-code/internal/trace"
+)
+
+var (
+	traceAddr   string
+	traceNoOpen bool
+)
+
+func init() {
+	traceCmd.Flags().StringVar(&traceAddr, "addr", "127.0.0.1:0", "Bind address (127.0.0.1 only; do not expose externally)")
+	traceCmd.Flags().BoolVar(&traceNoOpen, "no-open", false, "Print the URL but don't launch the browser")
+	rootCmd.AddCommand(traceCmd)
+}
+
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Open the local trace viewer for this project's sessions",
+	Long: `Launch a localhost web server that visualizes session transcripts
+recorded under ~/.gen/projects/<encoded-cwd>/transcripts/. The viewer is
+read-only and runs until Ctrl-C.
+
+By default the server binds 127.0.0.1 on a random port and opens the page
+in your default browser. Use --no-open to skip the browser launch and
+--addr to pin a port (e.g. --addr 127.0.0.1:38080).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		projectDir := projectDirFor(cwd)
+
+		// Sanity: warn if no transcripts have been recorded yet but still serve.
+		txDir := filepath.Join(projectDir, "transcripts")
+		if _, err := os.Stat(txDir); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Note: no transcripts found at %s — start a gen session to populate it.\n", txDir)
+		}
+
+		// Refuse to bind to anything that isn't loopback — guards against a
+		// fat-fingered --addr that would expose conversation history.
+		if err := requireLoopback(traceAddr); err != nil {
+			return err
+		}
+
+		ln, err := net.Listen("tcp", traceAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", traceAddr, err)
+		}
+		url := fmt.Sprintf("http://%s", ln.Addr().String())
+
+		srv := &http.Server{Handler: trace.New(projectDir).Handler()}
+
+		// Shutdown on SIGINT/SIGTERM.
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		go func() {
+			<-ctx.Done()
+			shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutCtx)
+		}()
+
+		fmt.Printf("gen trace: serving %s\n  project: %s\n", url, projectDir)
+		if !traceNoOpen {
+			openBrowser(url)
+		}
+
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	},
+}
+
+// projectDirFor returns ~/.gen/projects/<encoded-cwd>. Mirrors
+// session.encodePath without importing internals.
+func projectDirFor(cwd string) string {
+	home, _ := os.UserHomeDir()
+	encoded := session.EncodePath(cwd)
+	return filepath.Join(home, ".gen", "projects", encoded)
+}
+
+// requireLoopback rejects any bind address whose host isn't 127.0.0.1/::1.
+// Localhost-only is the security model — the trace contains everything the
+// model saw, including any secrets in tool inputs.
+func requireLoopback(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid --addr %q: %w", addr, err)
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	switch host {
+	case "127.0.0.1", "::1", "localhost":
+		return nil
+	}
+	return fmt.Errorf("--addr %q is not loopback; only 127.0.0.1, ::1, or localhost are allowed", addr)
+}
+
+func openBrowser(url string) {
+	var bin string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		bin, args = "open", []string{url}
+	case "linux":
+		bin, args = "xdg-open", []string{url}
+	case "windows":
+		bin, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return
+	}
+	_ = exec.Command(bin, args...).Start()
+}

--- a/internal/trace/server.go
+++ b/internal/trace/server.go
@@ -1,0 +1,257 @@
+// Package trace serves the gen-code session transcripts to a local web UI.
+//
+// The viewer is read-only, single-process, localhost-only. It exposes a small
+// HTTP API that mirrors the JSONL on disk — the wire format IS the file
+// format — plus an SSE endpoint for live tail. UI assets are embedded so the
+// binary is self-contained.
+package trace
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/genai-io/gen-code/internal/trace/ui"
+)
+
+// Server hosts the trace viewer for a single project directory.
+type Server struct {
+	projectDir string // .../.gen/projects/<encoded-cwd>
+	mux        *http.ServeMux
+
+	mu       sync.Mutex
+	watchers map[string]*tailer // sessionID -> active tailer
+}
+
+func New(projectDir string) *Server {
+	s := &Server{
+		projectDir: projectDir,
+		mux:        http.NewServeMux(),
+		watchers:   make(map[string]*tailer),
+	}
+	s.routes()
+	return s
+}
+
+func (s *Server) Handler() http.Handler { return s.mux }
+
+func (s *Server) routes() {
+	// UI assets — strip the "assets/" prefix to expose them at the root.
+	assets, err := fs.Sub(ui.Assets, "assets")
+	if err == nil {
+		s.mux.Handle("/", http.FileServer(http.FS(assets)))
+	}
+
+	s.mux.HandleFunc("/api/sessions", s.handleListSessions)
+	// Per-session routes: /api/sessions/{id}/records, /api/sessions/{id}/stream
+	s.mux.HandleFunc("/api/sessions/", s.handleSessionRoute)
+}
+
+// transcriptsDir is the JSONL location: <projectDir>/transcripts.
+func (s *Server) transcriptsDir() string {
+	return filepath.Join(s.projectDir, "transcripts")
+}
+
+type sessionListItem struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	Size      int64     `json:"size"`
+}
+
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	entries, err := os.ReadDir(s.transcriptsDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSON(w, []sessionListItem{})
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	items := make([]sessionListItem, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		item := sessionListItem{ID: id, UpdatedAt: info.ModTime(), Size: info.Size()}
+		// First user-typed text in the file makes a decent title preview without
+		// loading the whole transcript.
+		item.Title = previewTitle(filepath.Join(s.transcriptsDir(), e.Name()))
+		items = append(items, item)
+	}
+	// Newest first.
+	sortByUpdatedDesc(items)
+	writeJSON(w, items)
+}
+
+// handleSessionRoute routes /api/sessions/{id}/{action} to the matching handler.
+func (s *Server) handleSessionRoute(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/sessions/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+	sessionID, action := parts[0], parts[1]
+	if sessionID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch action {
+	case "records":
+		s.handleRecords(w, r, sessionID)
+	case "stream":
+		s.handleStream(w, r, sessionID)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) sessionPath(id string) (string, bool) {
+	// Defense against path traversal — sessionID must look like a single
+	// filename segment.
+	if strings.ContainsAny(id, "/\\") || id == "" {
+		return "", false
+	}
+	p := filepath.Join(s.transcriptsDir(), id+".jsonl")
+	return p, true
+}
+
+func (s *Server) handleRecords(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path, ok := s.sessionPath(sessionID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
+	data, nextOffset, err := readFromOffset(path, after)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("X-Next-Offset", strconv.FormatInt(nextOffset, 10))
+	_, _ = w.Write(data)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// readFromOffset reads bytes from the file starting at offset. Returns the
+// bytes plus the new end-of-file offset. Always returns at line boundaries —
+// trailing partial line is left for the next read.
+func readFromOffset(path string, offset int64) ([]byte, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	end := info.Size()
+	if offset >= end {
+		return nil, end, nil
+	}
+	if _, err := f.Seek(offset, 0); err != nil {
+		return nil, 0, err
+	}
+	buf := make([]byte, end-offset)
+	n, err := f.Read(buf)
+	if err != nil {
+		return nil, 0, err
+	}
+	buf = buf[:n]
+	// Trim trailing partial line.
+	if i := lastNewline(buf); i >= 0 {
+		return buf[:i+1], offset + int64(i+1), nil
+	}
+	// No newline yet — leave the bytes for next poll.
+	return nil, offset, nil
+}
+
+func lastNewline(b []byte) int {
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// previewTitle returns a short prefix of the first user-role message's text
+// content, suitable for a list view. Best-effort; returns "" on any error.
+func previewTitle(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var rec struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"message"`
+		}
+		if err := dec.Decode(&rec); err != nil {
+			return ""
+		}
+		if rec.Type != "message.appended" || rec.Message == nil || rec.Message.Role != "user" {
+			continue
+		}
+		for _, c := range rec.Message.Content {
+			if c.Type == "text" {
+				t := strings.TrimSpace(c.Text)
+				if t == "" {
+					continue
+				}
+				if len(t) > 80 {
+					t = t[:80] + "…"
+				}
+				return t
+			}
+		}
+	}
+	return ""
+}
+
+func sortByUpdatedDesc(items []sessionListItem) {
+	// Insertion sort — list size is small (tens of sessions per project).
+	for i := 1; i < len(items); i++ {
+		j := i
+		for j > 0 && items[j].UpdatedAt.After(items[j-1].UpdatedAt) {
+			items[j-1], items[j] = items[j], items[j-1]
+			j--
+		}
+	}
+}
+

--- a/internal/trace/server_test.go
+++ b/internal/trace/server_test.go
@@ -1,0 +1,97 @@
+package trace
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// End-to-end smoke: write a transcript file under projectDir/transcripts, hit
+// the public API, and verify the listing + records endpoints reflect what's
+// on disk. Also catches the path-traversal guard.
+func TestServerListAndRecords(t *testing.T) {
+	projectDir := t.TempDir()
+	txDir := filepath.Join(projectDir, "transcripts")
+	if err := os.MkdirAll(txDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := strings.Join([]string{
+		`{"id":"sess-1:start","sessionId":"sess-1","time":"2026-05-15T00:00:00Z","type":"session.started","session":{"provider":"p","model":"m"}}`,
+		`{"id":"sess-1:m1","sessionId":"sess-1","time":"2026-05-15T00:00:01Z","type":"message.appended","message":{"messageId":"m1","role":"user","content":[{"type":"text","text":"hello"}]}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(txDir, "sess-1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	srv := httptest.NewServer(New(projectDir).Handler())
+	defer srv.Close()
+
+	// /api/sessions returns the one transcript with title pulled from the
+	// first user message text.
+	resp, err := srv.Client().Get(srv.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions: %v", err)
+	}
+	defer resp.Body.Close()
+	var list []sessionListItem
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "sess-1" {
+		t.Fatalf("unexpected session list: %+v", list)
+	}
+	if list[0].Title != "hello" {
+		t.Fatalf("Title = %q, want %q", list[0].Title, "hello")
+	}
+
+	// /api/sessions/sess-1/records?after=0 returns the full body and a
+	// next-offset header equal to the file size.
+	resp2, err := srv.Client().Get(srv.URL + "/api/sessions/sess-1/records?after=0")
+	if err != nil {
+		t.Fatalf("GET records: %v", err)
+	}
+	defer resp2.Body.Close()
+	if got := resp2.Header.Get("X-Next-Offset"); got != "" {
+		// Must equal len(body) since the file is fully line-terminated.
+		if parsed, _ := json.Number(got).Int64(); parsed != int64(len(body)) {
+			t.Fatalf("X-Next-Offset = %s, want %d", got, len(body))
+		}
+	}
+
+	// Path traversal must be rejected even with URL-encoded slashes.
+	resp3, err := srv.Client().Get(srv.URL + "/api/sessions/..%2Fetc/records")
+	if err != nil {
+		t.Fatalf("GET traversal: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Fatalf("traversal status = %d, want 404", resp3.StatusCode)
+	}
+}
+
+// An empty project directory must yield an empty list, not an error.
+func TestServerListNoTranscripts(t *testing.T) {
+	projectDir := t.TempDir()
+
+	srv := httptest.NewServer(New(projectDir).Handler())
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var list []sessionListItem
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %+v", list)
+	}
+}

--- a/internal/trace/stream.go
+++ b/internal/trace/stream.go
@@ -1,0 +1,98 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// handleStream serves SSE: client connects, we replay the file from the start,
+// then poll for new content. Each emitted event carries one JSONL record line.
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path, ok := s.sessionPath(sessionID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if _, err := os.Stat(path); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ctx := r.Context()
+	var offset int64
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Send everything on the first pass, then poll for growth. Buffered I/O
+	// means new bytes appear without fsync (cf. C4 — telemetry sits in the
+	// page cache until a turn boundary), so polling is the safe choice.
+	if err := sendNewLines(ctx, w, flusher, path, &offset); err != nil {
+		return
+	}
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := sendNewLines(ctx, w, flusher, path, &offset); err != nil {
+				return
+			}
+		case <-keepAlive.C:
+			// Comment line keeps proxies / browsers from idle-timing out.
+			fmt.Fprint(w, ": keep-alive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+// sendNewLines reads any new bytes past *offset and writes them as SSE
+// messages. Advances *offset by the consumed byte count. Returns the first
+// error from the writer (typically client disconnect).
+func sendNewLines(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, path string, offset *int64) error {
+	data, next, err := readFromOffset(path, *offset)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return ctx.Err()
+	}
+	// Split on newlines and emit each non-empty line as a single SSE message.
+	start := 0
+	for i, b := range data {
+		if b != '\n' {
+			continue
+		}
+		line := data[start:i]
+		start = i + 1
+		if len(line) == 0 {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", line); err != nil {
+			return err
+		}
+	}
+	flusher.Flush()
+	*offset = next
+	return nil
+}
+
+// tailer is reserved for future fan-out (one watcher per file, many
+// subscribers). The MVP currently does per-client polling, which is simpler
+// and adequate for localhost use.
+type tailer struct{}

--- a/internal/trace/ui/assets/app.js
+++ b/internal/trace/ui/assets/app.js
@@ -1,0 +1,192 @@
+// Minimal trace viewer — no build step, vanilla JS.
+//
+// State machine:
+//   1. Fetch /api/sessions, populate sidebar.
+//   2. On session click, open SSE /api/sessions/{id}/stream.
+//   3. Each SSE event carries one JSONL record line; append to timeline.
+//   4. On row click, render the full JSON in the detail pane.
+
+const $ = (sel) => document.querySelector(sel);
+const sessions = $("#session-list");
+const timeline = $("#timeline");
+const detail = $("#detail-body");
+const sessionMeta = $("#session-meta");
+const statusEl = $("#status");
+
+const state = {
+  currentSession: null,
+  records: [],
+  eventSource: null,
+  filters: {
+    message:   true,
+    inference: true,
+    tool:      true,
+    system:    true,
+    state:     true,
+  },
+};
+
+function classify(type) {
+  if (!type) return "unknown";
+  if (type.startsWith("session."))         return "session";
+  if (type.startsWith("message."))         return "message";
+  if (type.startsWith("inference."))       return "inference";
+  if (type.startsWith("tools."))           return "tool";
+  if (type === "tool.invoked" || type === "tool.completed") return "tool";
+  if (type.startsWith("system."))          return "system";
+  if (type === "state.patched")            return "state";
+  return "unknown";
+}
+
+function fmtTime(s) {
+  if (!s) return "";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString();
+}
+
+function labelFor(rec) {
+  let label = rec.type;
+  if (rec.message)   label += "  " + (rec.message.role || "");
+  if (rec.system)    label += "  " + (rec.system.name || "");
+  if (rec.tools && rec.tools.schema) label += "  " + rec.tools.schema.name;
+  if (rec.tools && rec.tools.name)   label += "  " + rec.tools.name;
+  if (rec.inference) label += "  turn " + (rec.inference.turn || "?");
+  return label;
+}
+
+function setStatus(text, live) {
+  statusEl.textContent = text;
+  statusEl.classList.toggle("live", !!live);
+}
+
+async function loadSessions() {
+  setStatus("loading…");
+  try {
+    const r = await fetch("/api/sessions");
+    if (!r.ok) throw new Error(r.statusText);
+    const list = await r.json();
+    renderSessionList(list);
+    setStatus("");
+  } catch (e) {
+    setStatus("error: " + e.message);
+  }
+}
+
+function renderSessionList(list) {
+  sessions.innerHTML = "";
+  if (!list.length) {
+    const li = document.createElement("li");
+    li.textContent = "(no sessions in this project)";
+    li.style.color = "var(--fg-dim)";
+    sessions.appendChild(li);
+    return;
+  }
+  for (const s of list) {
+    const li = document.createElement("li");
+    li.dataset.id = s.id;
+    li.innerHTML =
+      '<div>' + escapeHTML(s.title || "(untitled)") + '</div>' +
+      '<span class="id">' + s.id.slice(0, 12) + '… · ' + Math.round(s.size / 1024) + 'KB</span>';
+    li.addEventListener("click", () => openSession(s.id, li));
+    sessions.appendChild(li);
+  }
+}
+
+function openSession(id, li) {
+  for (const x of sessions.querySelectorAll("li.active")) x.classList.remove("active");
+  if (li) li.classList.add("active");
+
+  if (state.eventSource) {
+    state.eventSource.close();
+    state.eventSource = null;
+  }
+  state.currentSession = id;
+  state.records = [];
+  timeline.innerHTML = "";
+  detail.textContent = "Click a record to inspect its payload.";
+  sessionMeta.textContent = id;
+
+  const es = new EventSource("/api/sessions/" + encodeURIComponent(id) + "/stream");
+  state.eventSource = es;
+  setStatus("connecting…");
+
+  es.onopen = () => setStatus("connected", true);
+  es.onerror = () => setStatus("disconnected");
+  es.onmessage = (ev) => {
+    let rec;
+    try {
+      rec = JSON.parse(ev.data);
+    } catch (e) {
+      return;
+    }
+    state.records.push(rec);
+    appendRow(rec, state.records.length - 1);
+  };
+}
+
+function appendRow(rec, idx) {
+  const klass = classify(rec.type);
+  if (!passesFilter(klass)) return;
+
+  const row = document.createElement("div");
+  row.className = "row " + klass;
+  row.dataset.idx = idx;
+  row.innerHTML =
+    '<span class="time">' + fmtTime(rec.time) + '</span>' +
+    '<span class="swatch"></span>' +
+    '<span class="label">' + escapeHTML(labelFor(rec)) + '</span>';
+  row.addEventListener("click", () => showDetail(idx, row));
+  timeline.appendChild(row);
+
+  // Auto-scroll if user is near the bottom.
+  if (timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight < 100) {
+    timeline.scrollTop = timeline.scrollHeight;
+  }
+}
+
+function showDetail(idx, row) {
+  for (const x of timeline.querySelectorAll(".row.active")) x.classList.remove("active");
+  row.classList.add("active");
+  const rec = state.records[idx];
+  detail.textContent = JSON.stringify(rec, null, 2);
+}
+
+function passesFilter(klass) {
+  if (klass === "state")     return state.filters.state;
+  if (klass === "tool")      return state.filters.tool;
+  if (klass === "system")    return state.filters.system;
+  if (klass === "inference") return state.filters.inference;
+  if (klass === "message")   return state.filters.message;
+  return true;
+}
+
+function wireFilters() {
+  const map = {
+    "filter-state":     "state",
+    "filter-tools":     "tool",
+    "filter-system":    "system",
+    "filter-inference": "inference",
+    "filter-message":   "message",
+  };
+  for (const [id, key] of Object.entries(map)) {
+    const el = document.getElementById(id);
+    el.addEventListener("change", () => {
+      state.filters[key] = el.checked;
+      // Re-render timeline against current filters.
+      timeline.innerHTML = "";
+      state.records.forEach((r, i) => appendRow(r, i));
+    });
+  }
+}
+
+function escapeHTML(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+wireFilters();
+loadSessions();

--- a/internal/trace/ui/assets/index.html
+++ b/internal/trace/ui/assets/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>gen trace</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>gen trace</h1>
+    <span id="status" class="status idle"></span>
+  </header>
+
+  <main>
+    <aside id="sidebar">
+      <h2>Sessions</h2>
+      <ul id="session-list" class="session-list"></ul>
+    </aside>
+
+    <section id="viewer">
+      <div id="timeline-header">
+        <span id="session-meta">Select a session to begin.</span>
+        <label class="filters">
+          <input type="checkbox" id="filter-state" checked> state.patched
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-tools" checked> tools.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-system" checked> system.section.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-inference" checked> inference.*
+        </label>
+        <label class="filters">
+          <input type="checkbox" id="filter-message" checked> message
+        </label>
+      </div>
+      <div id="timeline" class="timeline"></div>
+    </section>
+
+    <section id="detail" class="detail">
+      <pre id="detail-body">Click a record to inspect its payload.</pre>
+    </section>
+  </main>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/internal/trace/ui/assets/style.css
+++ b/internal/trace/ui/assets/style.css
@@ -1,0 +1,174 @@
+:root {
+  --bg: #0f1115;
+  --bg-2: #1a1d24;
+  --fg: #d6d9de;
+  --fg-dim: #8a93a6;
+  --accent: #6aa9ff;
+  --border: #262b35;
+
+  --c-session: #f5a623;
+  --c-message: #6aa9ff;
+  --c-inference: #b388ff;
+  --c-tool: #58d68d;
+  --c-system: #ffd93d;
+  --c-state: #5a6273;
+  --c-unknown: #555;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+header h1 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.status {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--bg-2);
+  color: var(--fg-dim);
+}
+.status.live { background: #1d4d2b; color: #c8f7c8; }
+.status.live::before { content: "● live "; }
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 240px 1fr 1fr;
+  min-height: 0;
+}
+
+aside {
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+aside h2 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: var(--fg-dim);
+  letter-spacing: 0.05em;
+  margin: 0.25rem 0 0.5rem;
+}
+.session-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.session-list li {
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+.session-list li:hover { background: var(--bg-2); }
+.session-list li.active {
+  background: var(--bg-2);
+  border-color: var(--accent);
+}
+.session-list .id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  color: var(--fg-dim);
+  display: block;
+}
+
+#viewer {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  min-width: 0;
+}
+#timeline-header {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+#timeline-header .filters {
+  color: var(--fg-dim);
+  cursor: pointer;
+}
+#session-meta {
+  flex: 1;
+  color: var(--fg-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.timeline {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+.row {
+  display: grid;
+  grid-template-columns: 70px 4px 1fr;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+}
+.row:hover { background: var(--bg-2); }
+.row.active {
+  background: var(--bg-2);
+  border-left-color: var(--accent);
+}
+.row .time {
+  color: var(--fg-dim);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+.row .swatch {
+  align-self: stretch;
+  border-radius: 1px;
+}
+.row .label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row.session  .swatch { background: var(--c-session); }
+.row.message  .swatch { background: var(--c-message); }
+.row.inference .swatch { background: var(--c-inference); }
+.row.tool     .swatch { background: var(--c-tool); }
+.row.system   .swatch { background: var(--c-system); }
+.row.state    .swatch { background: var(--c-state); }
+.row.unknown  .swatch { background: var(--c-unknown); }
+
+.detail {
+  overflow: auto;
+  padding: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+.detail pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg);
+}

--- a/internal/trace/ui/embed.go
+++ b/internal/trace/ui/embed.go
@@ -1,0 +1,10 @@
+// Package ui embeds the trace viewer's static assets.
+package ui
+
+import "embed"
+
+// Assets carries the SPA shell. The trace server strips the "assets/" prefix
+// to serve files at "/".
+//
+//go:embed assets
+var Assets embed.FS


### PR DESCRIPTION
**PR 4 of 5 — stacked on #15.** A local web UI for inspecting session transcripts.

```
gen trace                          # opens viewer in browser
gen trace --addr 127.0.0.1:38080   # pin port
gen trace --no-open                # print URL only
```

- **Backend** (`internal/trace`): localhost-only HTTP server, ~3 routes (`/api/sessions`, `/records`, `/stream`). Polling-based tailer (500ms tick), SSE for live updates. JSONL is the wire format — server returns disk bytes verbatim.
- **Frontend** (`internal/trace/ui/assets`): vanilla JS, no build step, ~200 lines. Sidebar (sessions) + colored timeline + JSON detail. Per-group filter checkboxes. Auto-scroll near bottom.
- **CLI** (`cmd/gen/trace.go`): refuses any non-loopback `--addr`. Path-traversal guard on session IDs.

Read-only, single binary (assets embedded via `go:embed`).

## Test

- [x] `TestServerListAndRecords` (records endpoint + path-traversal guard)
- [x] `TestServerListNoTranscripts` (empty project)
- [x] Smoke: built binary, ran against this repo's local sessions — `/api/sessions` returned real data, assets served

🤖 Generated with [Claude Code](https://claude.com/claude-code)