### PR TITLE
refactor(skill): delete dead AddPluginSkills plumbing

### DIFF
--- a/docs/packages/skill.md
+++ b/docs/packages/skill.md
@@ -53,13 +53,6 @@ type Service interface {
     PromptSection() string                       // rendered section for system prompt
     GetSkillInvocationPrompt(name string) string // full skill content for injection
 
-    // plugin
-    AddPluginSkills(paths []struct {
-        Path      string
-        Namespace string
-        IsProject bool
-    })
-
     // concrete access
     Registry() *Registry
 }
@@ -71,29 +64,27 @@ type Service interface {
 
 Tracked for PR-3. The contract above is verbatim from today's code.
 
-- **Rule 1 (small).** **12 methods** across four concerns. Suggested split:
+- **Rule 1 (small).** **11 methods** across four concerns. Suggested split:
   - `SkillQuery` → `List`, `Get`, `Count` (or pick three of the seven
     query methods; consolidate `IsEnabled` / `GetEnabled` / `GetActive`
     behind a `Filter(state SkillState)` if downstream usage permits)
   - `SkillStateStore` → `SetEnabled`, `GetDisabledAt`
   - `SkillPrompt` → `PromptSection`, `GetSkillInvocationPrompt`
-  - `SkillSourceRegistrar` → `AddPluginSkills`
   - Remove `Registry()` (see Rule 7)
 - **Rule 7 (no escape hatch).** `Registry() *Registry` lets every caller
   reach the concrete type. Drop it; if a caller needs methods that aren't
   on `Service`, add them to the appropriate split interface or have the
   caller depend on `*Registry` directly.
-- **Rule 4 (named types over anonymous structs).** `AddPluginSkills` takes
-  `[]struct { Path string; Namespace string; IsProject bool }`. Define
-  `type PluginSkillSource struct { ... }` and take `[]PluginSkillSource`.
-  Anonymous structs in exported signatures cannot be referenced by name
-  and break go-doc readability.
 - **Rule 5 (constructors return concrete types).** `Default()` returns
   `Service` (interface). Should return `*Registry` if callers are
   collaborators in the same module.
 - **Singleton via `Default()` and `DefaultIfInit()`.** Same issue as
   `hook` and `agent`: two-flavor accessors paper over racy init. Move
   construction into the app composition root.
+
+*Resolved in this PR:* removed the unused exported `AddPluginSkills`
+method (and its `addPluginPath` / `additionalPaths` plumbing), which
+was the only Rule 4 (anonymous struct) violation in the package.
 
 ## Internals
 

--- a/internal/skill/loader.go
+++ b/internal/skill/loader.go
@@ -26,8 +26,7 @@ type pluginInstall struct {
 
 // Loader handles loading skills from multiple directories.
 type loader struct {
-	cwd             string       // Current working directory for project-level skills
-	additionalPaths []searchPath // Additional paths from plugins
+	cwd string // Current working directory for project-level skills
 }
 
 // searchPath represents a skill search location with optional namespace.
@@ -42,20 +41,6 @@ func newLoader(cwd string) *loader {
 	return &loader{
 		cwd: cwd,
 	}
-}
-
-// addPluginPath adds a plugin skill path to the loader.
-// Plugin paths are searched after user-level but before project-level skills.
-func (l *loader) addPluginPath(path, namespace string, isProjectScope bool) {
-	scope := ScopeUserPlugin
-	if isProjectScope {
-		scope = ScopeProjectPlugin
-	}
-	l.additionalPaths = append(l.additionalPaths, searchPath{
-		path:      path,
-		scope:     scope,
-		namespace: namespace,
-	})
 }
 
 // getSearchPaths returns skill directories in priority order (lowest to highest).
@@ -99,34 +84,6 @@ func (l *loader) getSearchPaths() []searchPath {
 		path:  filepath.Join(l.cwd, ".gen", "skills"),
 		scope: ScopeProject,
 	})
-
-	// Insert additional plugin paths at appropriate positions
-	if len(l.additionalPaths) > 0 {
-		// Separate user and project plugin paths
-		var userPluginPaths, projectPluginPaths []searchPath
-		for _, ap := range l.additionalPaths {
-			if ap.scope == ScopeProjectPlugin {
-				projectPluginPaths = append(projectPluginPaths, ap)
-			} else {
-				userPluginPaths = append(userPluginPaths, ap)
-			}
-		}
-
-		// Insert at correct positions
-		// User plugin paths go after ScopeUser (position after ~/.gen/skills)
-		// Project plugin paths go after ScopeClaudeProject (before ScopeProject)
-		var result []searchPath
-		for _, p := range paths {
-			result = append(result, p)
-			switch p.scope {
-			case ScopeUser:
-				result = append(result, userPluginPaths...)
-			case ScopeClaudeProject:
-				result = append(result, projectPluginPaths...)
-			}
-		}
-		return result
-	}
 
 	return paths
 }

--- a/internal/skill/registry.go
+++ b/internal/skill/registry.go
@@ -367,57 +367,6 @@ func (r *Registry) GetSkillInvocationPrompt(name string) string {
 	return sb.String()
 }
 
-// AddPluginSkills loads skills from plugin paths and merges them into the registry.
-// This is used when plugins are loaded after initial skill initialization (e.g., --plugin-dir).
-func (r *Registry) AddPluginSkills(paths []struct {
-	Path      string
-	Namespace string
-	IsProject bool
-}) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	loader := newLoader(r.cwd)
-	for _, p := range paths {
-		loader.addPluginPath(p.Path, p.Namespace, p.IsProject)
-	}
-
-	// Only walk the additional plugin paths, not all paths
-	for _, sp := range loader.additionalPaths {
-		if _, err := os.Stat(sp.path); os.IsNotExist(err) {
-			continue
-		}
-		_ = filepath.Walk(sp.path, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() {
-				return nil
-			}
-			if strings.ToLower(info.Name()) != "skill.md" {
-				return nil
-			}
-			skill, err := loader.loadSkillFile(path, sp.scope, sp.namespace)
-			if err != nil {
-				return nil
-			}
-			fullName := skill.FullName()
-			if existing, ok := r.skills[fullName]; ok {
-				if skill.Scope > existing.Scope {
-					r.skills[fullName] = skill
-				}
-			} else {
-				r.skills[fullName] = skill
-			}
-			// Apply persisted states
-			if state, ok := r.userStore.GetState(fullName); ok {
-				r.skills[fullName].State = state
-			}
-			if state, ok := r.projectStore.GetState(fullName); ok {
-				r.skills[fullName].State = state
-			}
-			return nil
-		})
-	}
-}
-
 // Count returns the total number of loaded skills.
 func (r *Registry) Count() int {
 	r.mu.RLock()

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -21,13 +21,6 @@ type Service interface {
 	PromptSection() string                       // rendered section for system prompt
 	GetSkillInvocationPrompt(name string) string // full skill content for injection
 
-	// plugin
-	AddPluginSkills(paths []struct {
-		Path      string
-		Namespace string
-		IsProject bool
-	})
-
 	// concrete access
 	Registry() *Registry
 }

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -27,9 +27,9 @@ This file tracks structural follow-ups that are not tied to a single feature.
   `internal/app.newServices()` instead of pulling from each package's
   package-level singleton. Eliminates the two-flavor accessor pattern
   (`Default` panics; `DefaultIfInit` is nil-tolerant).
-- **`skill.AddPluginSkills` uses anonymous struct slice.** Replace with
-  a named `PluginSkillSource` type so the exported API is
-  go-doc-readable.
+- ~~**`skill.AddPluginSkills` uses anonymous struct slice.**~~ Resolved
+  by deleting the method entirely — it had zero callers and the
+  `addPluginPath` / `additionalPaths` plumbing behind it was dead too.
 
 ### Adapter cleanups
 


### PR DESCRIPTION
## Summary

Delete `skill.Service.AddPluginSkills`, the `*Registry.AddPluginSkills`
method, the `*loader.addPluginPath` helper, the `*loader.additionalPaths`
field, and the unreachable path-insertion branch in
`(*loader).getSearchPaths` — all dead code with zero callers in the
codebase.

This is the smallest item flagged by the per-package
[Known Violations](https://github.com/genai-io/gen-code/blob/docs/restructure/docs/packages/skill.md#known-violations)
audit in #25 (`docs/restructure`). It was the only Rule 4 violation
(anonymous struct in an exported API). The other PR-3 candidates (god
`Service` splits, `Default()` singleton removal, `Registry()` /
`Engine()` escape hatch drops) remain — see `notes/tech-debt.md`.

## Base branch

This PR targets `docs/restructure` (not `main`) so the doc updates in
`docs/packages/skill.md` and `notes/tech-debt.md` resolve against the
new structure. Will need to rebase / retarget if #25 merges first.

## What changed

- `internal/skill/service.go` — drop `AddPluginSkills` from `Service`.
- `internal/skill/registry.go` — drop the `AddPluginSkills` method (52 lines).
- `internal/skill/loader.go` — drop the `additionalPaths` field, the
  `addPluginPath` method, and the unreachable insertion branch in
  `getSearchPaths` (40 lines).
- `docs/packages/skill.md` — Contract + Known Violations updated.
- `notes/tech-debt.md` — entry marked resolved.

Net: **5 files, +9 / -119 lines.**

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages green (unit + integration)
- [x] `make lint-layers` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)