### PR TITLE
refactor(session): delete Service interface; *Setup is the contract

### DIFF
--- a/docs/packages/session.md
+++ b/docs/packages/session.md
@@ -18,47 +18,69 @@ duplicates one mid-stream.
 
 ## Contract
 
+No producer-side `Service` interface. Consumers of session don't share
+a narrow common surface — the agent loop wants `NewRecorder` + `ID`;
+the app composition root wants `Save` / `Load` / `LoadLatest` /
+`EnsureStore` / `SetID`; the TUI selector wants `*Store` directly. A
+union interface would just be `*Setup` with a rename, which TEMPLATE
+Rule 3 forbids. If a future caller benefits from narrowing, declare a
+small consumer-defined interface in that caller's package.
+
 ```go
 package session
 
-// Service is the public contract for the session module.
-type Service interface {
-    // identity
-    ID() string
-    SetID(id string)
-    TranscriptPath() string
-
-    // store access
-    GetStore() *Store
-    SetStore(s *Store)
-    EnsureStore(cwd string) error
-
-    // persistence (delegates to store)
-    Save(snap *Snapshot) error
-    Load(id string) (*Snapshot, error)
-    LoadLatest() (*Snapshot, error)
-    List() ([]*SessionMetadata, error)
-    Fork(id string) (*Snapshot, error)
-
-    // tracing
-    NewRecorder(agentID, provider, model string, maxTokens int) *Recorder
-    Recorder() *Recorder
+// Setup is the per-process session state: ID, store, recorder. Owned
+// by the app composition root; accessed by feature packages through
+// the methods below.
+type Setup struct {
+    Store     *Store
+    SessionID string
+    /* unexported */
 }
+
+// Identity + store
+func (s *Setup) ID() string
+func (s *Setup) SetID(id string)
+func (s *Setup) TranscriptPath() string
+func (s *Setup) GetStore() *Store
+func (s *Setup) EnsureStore(cwd string) error
+
+// Persistence (delegates to *Store)
+func (s *Setup) Save(snap *Snapshot) error
+func (s *Setup) Load(id string) (*Snapshot, error)
+func (s *Setup) LoadLatest() (*Snapshot, error)
+func (s *Setup) Fork(id string) (*Snapshot, error)
+
+// Recorder
+func (s *Setup) NewRecorder(agentID, provider, model string, maxTokens int) *Recorder
+func (s *Setup) Recorder() *Recorder
+
+// Package-level access.
+func Initialize(opts Options)
+func Default() *Setup
+func SetDefaultSetup(s *Setup)   // test-only
+func ResetDefaultSetup()         // test-only
 ```
 
-### Known Violations
+### Why no interface
 
-- **Rule 1 (small).** 11 methods spanning identity, store access,
-  persistence, and tracing. Suggested split:
-  - `SessionIdentity` → `ID`, `SetID`, `TranscriptPath`
-  - `SessionStoreAccess` → `GetStore`, `SetStore`, `EnsureStore`
-  - `SessionPersistence` → `Save`, `Load`, `LoadLatest`, `List`, `Fork`
-  - `SessionRecording` → `NewRecorder`, `Recorder`
-- **Rule 7 (no escape hatch).** `GetStore() *Store` and `SetStore(*Store)`
-  let callers reach into the concrete store. If callers need store
-  methods, expose them on `Service` directly or have them depend on
-  `*Store`.
-- **Rule 5.** `Default()` returns `Service`. Reasoning same as elsewhere.
+The previous `session.Service` was an 11-method god union with a
+`GetStore() *Store` / `SetStore(*Store)` escape hatch — the same
+shape mcp.Service and hook.Service had before [#27](https://github.com/genai-io/gen-code/pull/27)
+and [#28](https://github.com/genai-io/gen-code/pull/28). Deleted in
+favor of the concrete `*Setup`.
+
+Two dead methods removed: `SetStore` and `List` had zero non-test
+callers.
+
+`GetStore()` stays — on a concrete type it's a plain getter, not an
+escape hatch. Callers that want `*Store` directly (TUI session
+selector, subagent session bridge) can read `m.services.Session.Store`
+or call `GetStore()`; both are equivalent.
+
+### Remaining Known Violations
+
+None.
 
 ## Internals
 

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -27,7 +27,7 @@ type services struct {
 	LLM      llm.Service
 	Tool     tool.Service
 	Hook     *hook.Engine
-	Session  session.Service
+	Session  *session.Setup
 	Skill    skill.Service
 	Subagent subagent.Service
 	Command  command.Service

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -1,39 +1,24 @@
+// Package session owns per-run conversation state: session identity,
+// transcript persistence, recorder, fork/load/save. The package exposes
+// the concrete *Setup directly — no Service interface.
+//
+// Why no interface: consumers of session don't share a narrow common
+// surface. The agent loop needs NewRecorder + ID; the app composition
+// root needs Save / Load / LoadLatest / EnsureStore / SetID; the TUI
+// session selector needs *Store. Each caller's slice is different. A
+// producer-side union interface would just be *Setup with a rename;
+// TEMPLATE Rule 3 says don't do that.
+//
+// If a future caller benefits from narrowing, declare a small
+// consumer-defined interface in that caller's package. Until then,
+// *Setup is the contract.
 package session
 
 import (
-	"sync"
-
 	"go.uber.org/zap"
 
 	"github.com/genai-io/gen-code/internal/log"
 )
-
-// Service is the public contract for the session module.
-type Service interface {
-	// identity
-	ID() string
-	SetID(id string)
-	TranscriptPath() string
-
-	// store access
-	GetStore() *Store
-	SetStore(s *Store)
-	EnsureStore(cwd string) error
-
-	// persistence (delegates to store)
-	Save(snap *Snapshot) error
-	Load(id string) (*Snapshot, error)
-	LoadLatest() (*Snapshot, error)
-	List() ([]*SessionMetadata, error)
-	Fork(id string) (*Snapshot, error)
-
-	// tracing
-	NewRecorder(agentID, provider, model string, maxTokens int) *Recorder
-	Recorder() *Recorder
-}
-
-// Compile-time check: *Setup implements Service.
-var _ Service = (*Setup)(nil)
 
 // Options holds configuration for Initialize.
 type Options struct {
@@ -41,6 +26,8 @@ type Options struct {
 }
 
 // Initialize creates a session store and generates a fresh session ID.
+// Installs the result on the package-level *Setup so Default() reflects
+// the new state.
 func Initialize(opts Options) {
 	store, err := NewStore(opts.CWD)
 	if err != nil {
@@ -51,39 +38,26 @@ func Initialize(opts Options) {
 	defaultSetup.SessionID = NewSessionID()
 	defaultSetup.Store = store
 	defaultSetup.mu.Unlock()
-
-	SetDefault(defaultSetup)
 }
 
-// ── singleton ──────────────────────────────────────────────
+// Default returns the package-level *Setup. Returns an empty (no-store,
+// no-session-ID) *Setup until Initialize runs, so callers that touch it
+// pre-init don't crash.
+func Default() *Setup {
+	return defaultSetup
+}
 
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance.
-// Panics if Initialize has not been called.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
+// SetDefaultSetup replaces the package-level *Setup. Intended for
+// tests. A nil argument restores a fresh empty *Setup.
+func SetDefaultSetup(s *Setup) {
 	if s == nil {
-		panic("session: not initialized")
+		defaultSetup = &Setup{}
+		return
 	}
-	return s
+	defaultSetup = s
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
-}
-
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
+// ResetDefaultSetup restores a fresh empty *Setup. Intended for tests.
+func ResetDefaultSetup() {
+	defaultSetup = &Setup{}
 }

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -81,13 +81,6 @@ func (s *Setup) GetStore() *Store {
 	return s.Store
 }
 
-// SetStore replaces the session store.
-func (s *Setup) SetStore(st *Store) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.Store = st
-}
-
 // Save persists a session snapshot via the store.
 func (s *Setup) Save(snap *Snapshot) error {
 	s.mu.RLock()
@@ -119,17 +112,6 @@ func (s *Setup) LoadLatest() (*Snapshot, error) {
 		return nil, fmt.Errorf("session store not initialized")
 	}
 	return st.GetLatest()
-}
-
-// List returns metadata for all sessions via the store.
-func (s *Setup) List() ([]*SessionMetadata, error) {
-	s.mu.RLock()
-	st := s.Store
-	s.mu.RUnlock()
-	if st == nil {
-		return nil, fmt.Errorf("session store not initialized")
-	}
-	return st.List()
 }
 
 // Fork forks a session by ID via the store.

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -11,21 +11,21 @@ This file tracks structural follow-ups that are not tied to a single feature.
 ### Code refactors flagged by `docs/packages/*/Known Violations`
 
 - **God `Service` interfaces.** Split per the per-package suggestions:
-  `plugin` (21), `setting` (14), `skill` (11), `session` (11),
-  `agent` (11), `cron` (10), `subagent` (9), `command` (7),
-  `llm` (8), `task` (8), `tool` (6). Define narrow consumer-defined
-  interfaces alongside the concrete `*service` / `*Registry`; let each
-  call site narrow to what it needs.
-  ~~`mcp` (9 methods)~~ — resolved by deleting `Service` entirely and
-  exposing role interfaces (`Tools`, `Servers`) + `*mcp.Registry`.
-  ~~`hook` (16 methods)~~ — resolved by deleting `Service`, exposing
-  one role interface (`Handler`) + `*hook.Engine` directly.
-- **Escape-hatch methods on Service interfaces.** Drop `.GetStore()` from
-  `session.Service`. Remaining call site: `internal/app/update.go`
-  (`Session.GetStore()`).
-  ~~`MCP.Registry()`~~ — resolved.
-  ~~`Hook.Engine()`~~ — resolved (Service deleted; consumers depend on
-  `hook.Handler` or `*hook.Engine` directly).
+  `plugin` (21), `setting` (14), `skill` (11), `agent` (11),
+  `cron` (10), `subagent` (9), `command` (7), `llm` (8), `task` (8),
+  `tool` (6). Define narrow consumer-defined interfaces alongside the
+  concrete `*service` / `*Registry`; let each call site narrow to
+  what it needs.
+  ~~`mcp` (9 methods)~~ — resolved (`Tools` + `Servers` + `*mcp.Registry`).
+  ~~`hook` (16 methods)~~ — resolved (`Handler` + `*hook.Engine`).
+  ~~`session` (11 methods)~~ — resolved by deleting `Service`, exposing
+  `*session.Setup` directly. No role interface — consumers don't share
+  a narrow common surface.
+- **Escape-hatch methods on Service interfaces.** All resolved:
+  ~~`MCP.Registry()`~~, ~~`Hook.Engine()`~~, ~~`Session.GetStore()`~~
+  / ~~`Session.SetStore()`~~ — Service interfaces deleted in their
+  respective packages; consumers depend on the concrete type or a
+  narrow role interface.
 - **Singleton via `Default()` / `DefaultIfInit()`.** Move construction
   into `cmd/gen` and pass the concrete service into
   `internal/app.newServices()` instead of pulling from each package's


### PR DESCRIPTION
## Summary

Apply the same first-principles approach used for [#27](https://github.com/genai-io/gen-code/pull/27)
(mcp) and [#28](https://github.com/genai-io/gen-code/pull/28) (hook)
to the session package. The previous \`session.Service\` was an
11-method god union with \`GetStore()\` / \`SetStore()\` escape hatches.

## Design choice: no role interface

Unlike mcp (\`Tools\` + \`Servers\`) and hook (\`Handler\`), session's
consumers don't share a narrow common surface:

- Agent loop needs \`NewRecorder\` + \`ID\`
- App composition root needs \`Save\` / \`Load\` / \`LoadLatest\` /
  \`EnsureStore\` / \`SetID\`
- TUI session selector needs \`*Store\`
- Subagent session bridge needs \`*Store\`

Each caller's slice is different. A producer-side union interface
would just be \`*Setup\` with a rename — exactly the speculative
abstraction TEMPLATE Rule 3 forbids. If a future caller benefits from
narrowing, declare a small consumer-defined interface in that caller's
package; the package itself doesn't manufacture one.

## What goes away

- \`session.Service\` interface
- \`session.Default()\` / \`SetDefault()\` / \`ResetService()\` operating
  on Service
- Two dead methods on \`*Setup\`:
  - \`SetStore\` — zero callers (production + tests)
  - \`List\` — zero callers (production + tests)

## What replaces it

- \`session.Default() *Setup\` — returns the package-level \`*Setup\`
  directly
- \`session.SetDefaultSetup\` / \`ResetDefaultSetup\` — test-only seam
- \`GetStore()\` stays on \`*Setup\` as a plain mutex-protected getter.
  On a concrete type it isn't an "escape hatch" — it's just a method.

## Caller-side changes

- \`internal/app/services.go\`: \`Session\` field changed from
  \`session.Service\` to \`*session.Setup\`. Every other call site
  (\`session.Default().ID()\` in init.go, \`m.services.Session.X\` across
  the app/ tree) works unchanged because \`*Setup\` has all the methods
  \`Service\` had minus the two dead ones.

## Spec

- \`docs/packages/session.md\`: Contract section rewritten. "Why no
  interface" subsection records the rationale.
- \`notes/tech-debt.md\`: session removed from the god-Service split
  list and the escape-hatch list. All three escape hatches
  (\`MCP.Registry\`, \`Hook.Engine\`, \`Session.GetStore\`/\`SetStore\`)
  are now resolved.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 52 packages green
- [x] \`make lint-layers\` clean
- [x] \`make format-check\` clean
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)