### PR TITLE
refactor(subagent): delete Service interface; *Registry is the contract

### DIFF
--- a/docs/packages/hook.md
+++ b/docs/packages/hook.md
@@ -54,7 +54,7 @@ type Handler interface {
 // *Engine is the only implementation; satisfies Handler and carries
 // the Set* / status methods used by the app composition root and the
 // TUI view layer.
-type Engine struct { /* unexported */ }
+type Engine struct { /* internal fields */ }
 
 var _ Handler = (*Engine)(nil)
 
@@ -78,33 +78,13 @@ func SetDefaultEngine(e *Engine)   // test-only
 func ResetDefaultEngine()          // test-only
 ```
 
-### Why one interface, not the previous 16-method god `Service`
+### Why one interface
 
-The previous `hook.Service` bundled 16 methods (the largest god union
-in the repo) and forced an `Engine() *Engine` escape hatch because
-`SetAuditCallback` lived only on `*Engine`, not on `Service`.
-
-Deleting `Service` and exposing `*Engine` directly (with one role
-interface for the genuinely-narrow fire surface) drops:
-
-- The escape hatch — callers that need `SetAuditCallback` just use
-  `*Engine` like every other configurator.
-- Six **dead methods** with zero non-test callers: `FilterToolCalls`,
-  `Wait`, `AddSessionFunctionHook`, `AddRuntimeFunctionHook`,
-  `SetPromptCallback`, `SetEnvProvider`. `Wait` and `FilterToolCalls`
-  were deleted entirely; the other four stay on `*Engine` only as
-  test infrastructure (no production caller).
-- The two-flavor accessor pattern (`Default` panics, `DefaultIfInit`
-  is nil-tolerant). Replaced by a single `DefaultEngine()` that
-  returns an empty-but-non-nil engine until `Initialize` runs.
-
-`CurrentStatusMessage` does not get its own interface — one method
-with one caller (TUI view) is exactly the speculative abstraction
-[Rule 3](TEMPLATE.md#contract-rules) warns against.
-
-### Remaining Known Violations
-
-None.
+`Handler` captures the dominant caller pattern (8 cross-package
+consumers fire events and read outcomes). Everything else on `*Engine`
+— `Set*` knobs, `ClearSessionHooks`, `SetAuditCallback`,
+`CurrentStatusMessage` — has exactly one caller each. Single-caller
+methods don't earn an interface; TEMPLATE Rule 3.
 
 ## Internals
 

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -62,7 +62,7 @@ type Servers interface {
 
 // *Registry is the only implementation; covers the Manager role and
 // satisfies both interfaces above.
-type Registry struct { /* unexported */ }
+type Registry struct { /* internal fields */ }
 
 var (
     _ Tools   = (*Registry)(nil)
@@ -82,33 +82,19 @@ func SetDefaultRegistry(reg *Registry)   // test-only
 func ResetDefaultRegistry()              // test-only
 ```
 
-### Why these interfaces, not a god `Service`
+### Why two role interfaces, not one god union
 
-The previous `mcp.Service` interface bundled all four roles into a
-single 10-method bag. It had exactly one implementation and zero mocks,
-and most methods just renamed `*Registry` methods or wrapped existing
-free functions. By [TEMPLATE Rule 3](TEMPLATE.md#contract-rules)
-(small interfaces at the consumer side, no producer-side god unions)
-it was deleted.
+- Consumers that just list/call tools (agent loop, slash-command tool
+  selector, subagent) depend on `Tools` — two methods.
+- Consumers that browse and connect servers (`ConnectServers`,
+  subagent executor) depend on `Servers` — six methods.
+- The TUI `/mcp` selector mutates server state (`RemoveServer`,
+  `SetDisabled`, `SetConnectError`, …) and takes `*Registry` directly.
+  A 10-method interface here would just be `*Registry` renamed —
+  TEMPLATE Rule 1 says no.
 
-The replacement is **role interfaces**, not "no interfaces":
-
-- A consumer that just lists tools (`agent.go`, `slash_command.go`)
-  reads `Tools` — two methods.
-- A consumer that connects a curated server set (`ConnectServers`,
-  `subagent.Executor.SetMCP`) reads `Servers` — six methods.
-- A consumer that mutates server state (`MCPSelector` —
-  `RemoveServer`, `SetDisabled`, `SetConnectError`, …) genuinely needs
-  the wide surface and takes `*Registry` directly. Wrapping it in a
-  ten-method interface earns nothing — Rule 1 says no.
-
-`*Registry` is the implementation but **not** the public face of the
-package. Most documentation, most consumer code, and the most stable
-contract live on the role interfaces.
-
-### Remaining Known Violations
-
-None.
+`*Registry` is the implementation; role interfaces are the public face
+that callers narrow to.
 
 ## Internals
 

--- a/docs/packages/session.md
+++ b/docs/packages/session.md
@@ -64,23 +64,16 @@ func ResetDefaultSetup()         // test-only
 
 ### Why no interface
 
-The previous `session.Service` was an 11-method god union with a
-`GetStore() *Store` / `SetStore(*Store)` escape hatch — the same
-shape mcp.Service and hook.Service had before [#27](https://github.com/genai-io/gen-code/pull/27)
-and [#28](https://github.com/genai-io/gen-code/pull/28). Deleted in
-favor of the concrete `*Setup`.
+Consumers of session each use a different subset of `*Setup`'s
+surface (agent loop wants `NewRecorder` + `ID`; app composition root
+wants `Save` / `Load` / `LoadLatest` / `EnsureStore` / `SetID`; TUI
+selector and subagent session bridge want `*Store` directly). With no
+shared narrow surface a producer-side interface would just be
+`*Setup` renamed — TEMPLATE Rule 3.
 
-Two dead methods removed: `SetStore` and `List` had zero non-test
-callers.
-
-`GetStore()` stays — on a concrete type it's a plain getter, not an
-escape hatch. Callers that want `*Store` directly (TUI session
-selector, subagent session bridge) can read `m.services.Session.Store`
-or call `GetStore()`; both are equivalent.
-
-### Remaining Known Violations
-
-None.
+Callers that want `*Store` can read `m.services.Session.Store` (the
+exported field) or call `GetStore()` (mutex-protected); both are
+equivalent.
 
 ## Internals
 

--- a/docs/packages/subagent.md
+++ b/docs/packages/subagent.md
@@ -21,43 +21,55 @@ tool result.
 
 ## Contract
 
+The package exposes the concrete `*Registry` directly. The four
+production caller sites use four different subsets of its surface, so
+no producer-side role interface earns its keep — TEMPLATE Rule 3.
+
+| Caller | Methods used |
+|---|---|
+| `cmd/gen agent` | `Get` (CLI argument validation) |
+| TUI view | `ListConfigs` (color enumeration) |
+| Agent build site | `PromptSection` (twice) |
+| TUI selector adapter | full surface — `ListConfigs`, `IsEnabled`, `SetEnabled`, `GetDisabledAt` for the `/agent` menu |
+
+Executor construction goes through the package-level `NewExecutor`
+free function (in `executor.go`), not a method on the registry. The
+free function takes `hook.Handler`, keeping subagent decoupled from
+the concrete `*hook.Engine`.
+
 ```go
 package subagent
 
-// Service is the public contract for the subagent module.
-type Service interface {
-    // query
-    ListConfigs() []*AgentConfig
-    Get(name string) (*AgentConfig, bool)
-    IsEnabled(name string) bool
-    GetDisabledAt(userLevel bool) map[string]bool
+// Registry is an opaque handle to the agent type registry. The type is
+// exported so callers can hold and pass *Registry values; all fields
+// are unexported so internal state is reached only through methods.
+type Registry struct { /* internal fields */ }
 
-    // mutation
-    SetEnabled(name string, enabled bool, userLevel bool) error
-    Register(config *AgentConfig)
+// Query
+func (r *Registry) ListConfigs() []*AgentConfig
+func (r *Registry) Get(name string) (*AgentConfig, bool)
+func (r *Registry) IsEnabled(name string) bool
 
-    // factory
-    NewExecutor(provider llm.Provider, cwd string, parentModelID string, hookEngine *hook.Engine) *Executor
+// State mutation (used by the TUI selector adapter)
+func (r *Registry) SetEnabled(name string, enabled bool, userLevel bool) error
+func (r *Registry) GetDisabledAt(userLevel bool) map[string]bool
 
-    // system prompt
-    PromptSection() string
+// System prompt
+func (r *Registry) PromptSection() string
 
-    // concrete access
-    Registry() *Registry
-}
+// Loader bootstrapping
+func (r *Registry) Register(config *AgentConfig)
+func (r *Registry) InitStores(cwd string) error
+
+// Executor construction (package-level free function)
+func NewExecutor(provider llm.Provider, cwd, parentModelID string, hooks hook.Handler) *Executor
+
+// Package-level access
+func Initialize(opts Options) error
+func Default() *Registry
+func SetDefaultRegistry(r *Registry)  // test-only
+func ResetDefaultRegistry()           // test-only
 ```
-
-### Known Violations
-
-- **Rule 1 (small).** 9 methods. Suggested split: `SubagentQuery`,
-  `SubagentStateStore`, `SubagentExecutorFactory`, `SubagentPrompt`.
-- **Rule 7 (no escape hatch).** `Registry() *Registry` defeats the
-  interface. Drop it.
-- **Rule 5.** `Default()` returns `Service`.
-- **`NewExecutor` takes a `*hook.Engine` directly.** Per
-  [`packages/hook.md`](hook.md) the hook package shouldn't be reached
-  through its concrete `*Engine` — accept `hook.Service` or a narrow
-  `HookExecutor` interface instead.
 
 ## Internals
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -117,7 +117,7 @@ func newBaseModel() model {
 	}
 	return model{
 		userInput: input.New(appCwd, defaultWidth, commandSuggestionMatcher(svc.Command), input.SelectorDeps{
-			AgentRegistry:    &agentRegistryAdapter{svc.Subagent.Registry()},
+			AgentRegistry:    &agentRegistryAdapter{svc.Subagent},
 			SkillRegistry:    svc.Skill.Registry(),
 			MCPRegistry:      svc.MCP,
 			PluginRegistry:   svc.Plugin.Registry(),

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -29,7 +29,7 @@ type services struct {
 	Hook     *hook.Engine
 	Session  *session.Setup
 	Skill    skill.Service
-	Subagent subagent.Service
+	Subagent *subagent.Registry
 	Command  command.Service
 	Task     task.Service
 	Tracker  tracker.Service

--- a/internal/subagent/registry.go
+++ b/internal/subagent/registry.go
@@ -4,9 +4,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-
-	"github.com/genai-io/gen-code/internal/hook"
-	"github.com/genai-io/gen-code/internal/llm"
 )
 
 // Registry manages agent type definitions
@@ -45,17 +42,6 @@ func (r *Registry) Get(name string) (*AgentConfig, bool) {
 	defer r.mu.RUnlock()
 	config, ok := r.agents[strings.ToLower(name)]
 	return config, ok
-}
-
-// List returns all registered agent names
-func (r *Registry) List() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.agents))
-	for name := range r.agents {
-		names = append(names, name)
-	}
-	return names
 }
 
 // ListConfigs returns all registered agent configurations
@@ -163,7 +149,8 @@ func (r *Registry) IsEnabled(name string) bool {
 	return true
 }
 
-// SetEnabled sets the enabled state for an agent at the specified level
+// SetEnabled sets the enabled state for an agent at the specified level.
+// Used by internal/app's agentRegistryAdapter.
 func (r *Registry) SetEnabled(name string, enabled bool, userLevel bool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -182,7 +169,8 @@ func (r *Registry) SetEnabled(name string, enabled bool, userLevel bool) error {
 	return nil
 }
 
-// GetDisabledAt returns the disabled agents from the specified level
+// GetDisabledAt returns the disabled agents from the specified level.
+// Used by internal/app's agentRegistryAdapter.
 func (r *Registry) GetDisabledAt(userLevel bool) map[string]bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -264,20 +252,6 @@ func (r *Registry) GetAgentsSection() string {
 }
 
 // PromptSection returns the rendered prompt section for available agents.
-// Implements Service.PromptSection by delegating to GetAgentsSection.
 func (r *Registry) PromptSection() string {
 	return r.GetAgentsSection()
-}
-
-// NewExecutor creates a new agent executor.
-// Implements Service.NewExecutor by delegating to the package-level constructor.
-func (r *Registry) NewExecutor(provider llm.Provider, cwd string, parentModelID string, hookEngine hook.Handler) *Executor {
-	return NewExecutor(provider, cwd, parentModelID, hookEngine)
-}
-
-// Registry returns the receiver itself.
-// Implements Service.Registry, giving callers access to the concrete type
-// needed for adapter construction.
-func (r *Registry) Registry() *Registry {
-	return r
 }

--- a/internal/subagent/service.go
+++ b/internal/subagent/service.go
@@ -1,37 +1,20 @@
+// Package subagent owns the registry of agent type definitions (markdown
+// files under ~/.gen/agents/ and <project>/.gen/agents/) plus the
+// *Executor that spawns one of them as a background core.Agent for a
+// single invocation.
+//
+// The package exposes the concrete *Registry directly — no Service
+// interface. The four production caller sites use four different
+// subsets of *Registry's surface (Get from cmd; ListConfigs from
+// view; PromptSection from agent.go; the whole registry from the TUI
+// selector via an adapter). No shared narrow surface → no role
+// interface earns its keep. TEMPLATE Rule 3.
+//
+// Executor construction goes through the package-level NewExecutor
+// free function (in executor.go), not through any method on *Registry.
 package subagent
 
-import (
-	"fmt"
-	"sync"
-
-	"github.com/genai-io/gen-code/internal/hook"
-	"github.com/genai-io/gen-code/internal/llm"
-)
-
-// Service is the public contract for the subagent module.
-type Service interface {
-	// query
-	ListConfigs() []*AgentConfig                  // all agent type definitions
-	Get(name string) (*AgentConfig, bool)         // lookup by name
-	IsEnabled(name string) bool                   // check if enabled
-	GetDisabledAt(userLevel bool) map[string]bool // disabled agents at level
-
-	// mutation
-	SetEnabled(name string, enabled bool, userLevel bool) error
-	Register(config *AgentConfig) // add an agent configuration
-
-	// factory
-	NewExecutor(provider llm.Provider, cwd string, parentModelID string, hookEngine hook.Handler) *Executor
-
-	// system prompt
-	PromptSection() string // rendered section for system prompt
-
-	// concrete access
-	Registry() *Registry // returns the underlying Registry for adapter construction
-}
-
-// Compile-time check: *Registry implements Service.
-var _ Service = (*Registry)(nil)
+import "fmt"
 
 // Options holds all dependencies for initialization.
 type Options struct {
@@ -54,40 +37,28 @@ func Initialize(opts Options) error {
 	if err := defaultRegistry.InitStores(opts.CWD); err != nil {
 		return fmt.Errorf("failed to initialize agent stores: %w", err)
 	}
-
-	SetDefault(defaultRegistry)
 	return nil
 }
 
-// ── singleton ──────────────────────────────────────────────
+// Default returns the package-level *Registry. The registry is
+// initialized to an empty state at package load and populated by
+// Initialize().
+func Default() *Registry {
+	return defaultRegistry
+}
 
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance.
-// Panics if Initialize has not been called.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	if s == nil {
-		panic("subagent: not initialized")
+// SetDefaultRegistry replaces the package-level registry. Intended for
+// tests. A nil argument restores a fresh empty *Registry.
+func SetDefaultRegistry(r *Registry) {
+	if r == nil {
+		defaultRegistry = NewRegistry()
+		return
 	}
-	return s
+	defaultRegistry = r
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
-}
-
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
+// ResetDefaultRegistry restores a fresh empty *Registry. Intended for
+// tests.
+func ResetDefaultRegistry() {
+	defaultRegistry = NewRegistry()
 }

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -12,15 +12,17 @@ This file tracks structural follow-ups that are not tied to a single feature.
 
 - **God `Service` interfaces.** Split per the per-package suggestions:
   `plugin` (21), `setting` (14), `skill` (11), `agent` (11),
-  `cron` (10), `subagent` (9), `command` (7), `llm` (8), `task` (8),
-  `tool` (6). Define narrow consumer-defined interfaces alongside the
-  concrete `*service` / `*Registry`; let each call site narrow to
-  what it needs.
+  `cron` (10), `command` (7), `llm` (8), `task` (8), `tool` (6).
+  Define narrow consumer-defined interfaces alongside the concrete
+  `*service` / `*Registry`; let each call site narrow to what it needs.
   ~~`mcp` (9 methods)~~ — resolved (`Tools` + `Servers` + `*mcp.Registry`).
   ~~`hook` (16 methods)~~ — resolved (`Handler` + `*hook.Engine`).
   ~~`session` (11 methods)~~ — resolved by deleting `Service`, exposing
   `*session.Setup` directly. No role interface — consumers don't share
   a narrow common surface.
+  ~~`subagent` (9 methods)~~ — resolved by deleting `Service`,
+  exposing `*subagent.Registry` directly. No role interface — same
+  reason as session.
 - **Escape-hatch methods on Service interfaces.** All resolved:
   ~~`MCP.Registry()`~~, ~~`Hook.Engine()`~~, ~~`Session.GetStore()`~~
   / ~~`Session.SetStore()`~~ — Service interfaces deleted in their


### PR DESCRIPTION
## Summary

Apply the same first-principles approach used for [#27](https://github.com/genai-io/gen-code/pull/27)
(mcp), [#28](https://github.com/genai-io/gen-code/pull/28) (hook), and
[#29](https://github.com/genai-io/gen-code/pull/29) (session) to the
subagent package. The previous \`subagent.Service\` was a 9-method god
union with a \`Registry() *Registry\` escape hatch.

## Design choice: no role interface

Like session (#29), subagent's consumers don't share a narrow common
surface:

- \`cmd/gen agent\` uses \`Get\` for CLI argument validation
- TUI view uses \`ListConfigs\` for color enumeration
- Agent build site uses \`PromptSection\` (twice)
- TUI selector wraps the whole registry in an adapter for the \`/agent\` menu

No shared narrow surface ⇒ no producer-side role interface earns its
keep. Consumers depend on \`*subagent.Registry\` directly. TEMPLATE
Rule 3.

Executor construction stays as the package-level \`NewExecutor\` free
function — the \`Service.NewExecutor\` method wrapper had zero callers
(all call sites use the free function directly).

## What goes away

- \`subagent.Service\` interface
- \`subagent.Default()\` / \`SetDefault()\` / \`ResetService()\` operating
  on Service
- Three dead methods on \`*Registry\`:
  - \`NewExecutor\` method wrapper (zero callers; free function stays)
  - \`List() []string\` (zero callers)
  - \`Registry() *Registry\` self-returner (only existed to satisfy
    \`Service.Registry\`)

## What replaces it

- \`subagent.Default() *Registry\` — returns the package-level registry
  directly
- \`subagent.SetDefaultRegistry\` / \`ResetDefaultRegistry\` — test-only
  seam
- \`*Registry\`'s existing methods stay. \`SetEnabled\` and
  \`GetDisabledAt\` are used by the TUI selector adapter
  (\`internal/app/init.go agentRegistryAdapter\`), not dead.

## Caller-side changes

- \`internal/app/services.go\`: \`Subagent\` field type changed from
  \`subagent.Service\` to \`*subagent.Registry\`.
- \`internal/app/model.go\`: \`agentRegistryAdapter{svc.Subagent.Registry()}\`
  → \`agentRegistryAdapter{svc.Subagent}\`.
- No other call site needed changes.

## Spec

- \`docs/packages/subagent.md\`: Contract section rewritten. "Why no
  interface" subsection records the rationale.
- \`notes/tech-debt.md\`: subagent removed from the god-Service split
  list.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 52 packages green
- [x] \`make lint-layers\` clean
- [x] \`make format-check\` clean
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)