### PR TITLE
refactor(plugin): delete Service interface; *Registry is the contract

### DIFF
--- a/cmd/gen/plugin.go
+++ b/cmd/gen/plugin.go
@@ -159,7 +159,7 @@ Examples:
 			return err
 		}
 
-		installer := plugin.Default().NewInstaller(cwd)
+		installer := plugin.NewInstaller(plugin.Default(), cwd)
 		_ = installer.LoadMarketplaces() // Non-fatal, continue with empty marketplaces
 
 		scope := parsePluginScope(pluginScope)
@@ -185,7 +185,7 @@ var pluginUninstallCmd = &cobra.Command{
 			return err
 		}
 
-		installer := plugin.Default().NewInstaller(cwd)
+		installer := plugin.NewInstaller(plugin.Default(), cwd)
 		scope := parsePluginScope(pluginScope)
 
 		if err := installer.Uninstall(name, scope); err != nil {

--- a/docs/packages/plugin.md
+++ b/docs/packages/plugin.md
@@ -22,73 +22,62 @@ contributes without importing `plugin` directly.
 
 ## Contract
 
+The package exposes `*Registry` directly plus package-level free
+functions for the cross-domain integration surface. No producer-side
+interface — each downstream consumer (skill / subagent / command / mcp
+/ setting) pulls a different small set of free functions, so a unified
+interface would just collect unrelated methods.
+
 ```go
 package plugin
 
-// Service is the public contract for the plugin module.
-type Service interface {
-    // loading
-    Load(ctx context.Context, cwd string) error
-    LoadClaudePlugins(ctx context.Context) error
-    LoadFromPath(ctx context.Context, path string) error
+// Registry is the opaque handle to the loaded plugin set plus per-scope
+// enabled state. Type exported, fields unexported.
+type Registry struct { /* internal fields */ }
 
-    // query
-    List() []*Plugin
-    Get(name string) (*Plugin, bool)
-    GetEnabled() []*Plugin
-    Count() int
-    EnabledCount() int
+// Loading
+func (r *Registry) Load(ctx context.Context, cwd string) error
+func (r *Registry) LoadFromPath(ctx context.Context, path string) error
+func (r *Registry) LoadClaudePlugins(ctx context.Context) error
 
-    // mutation
-    Enable(name string, scope Scope) error
-    Disable(name string, scope Scope) error
+// Query
+func (r *Registry) Get(name string) (*Plugin, bool)
+func (r *Registry) List() []*Plugin
+func (r *Registry) GetEnabled() []*Plugin
+func (r *Registry) Count() int
+func (r *Registry) EnabledCount() int
+func (r *Registry) GetByScope(scope Scope) []*Plugin
 
-    // installer
-    NewInstaller(cwd string) *Installer
+// Mutation
+func (r *Registry) Enable(name string, scope Scope) error
+func (r *Registry) Disable(name string, scope Scope) error
+func (r *Registry) Register(p *Plugin)
+func (r *Registry) Unregister(name string)
 
-    // access
-    Registry() *Registry
+// Installer construction (package-level free function)
+func NewInstaller(reg *Registry, cwd string) *Installer
 
-    // plugin root management
-    SetActivePluginRoot(path string)
-    ClearActivePluginRoot()
-    FindPluginRootForPath(path string) string
+// Cross-domain integration (package-level free functions; read from
+// the package-level default registry). Each consumer that needs
+// plugin-contributed data imports plugin and calls one of these:
+func GetPluginAgentPaths() []PluginPath
+func GetPluginSkillPaths() []PluginPath
+func GetPluginCommandPaths() []PluginPath
+func GetPluginMCPServers() []PluginMCPServer
+func GetPluginHooks() map[string][]setting.Hook
+func PluginEnv() []string
 
-    // cross-domain (consumed by other services at init)
-    AgentPaths() []PluginPath
-    SkillPaths() []PluginPath
-    CommandPaths() []PluginPath
-    MCPServers() []PluginMCPServer
-    PluginHooks() map[string][]setting.Hook
-    PluginEnv() []string
-}
+// Plugin root tracking (process-global state; package-level functions)
+func SetActivePluginRoot(path string)
+func ClearActivePluginRoot()
+func FindPluginRootForPath(path string) string
+
+// Package-level access
+func Initialize(ctx context.Context, opts Options) error
+func Default() *Registry
+func SetDefaultRegistry(r *Registry)  // test-only
+func ResetDefaultRegistry()           // test-only
 ```
-
-### Known Violations
-
-- **Rule 1 (small).** 21 methods — second worst after `hook`. Concerns
-  span loading, querying, mutating, installing, registry-access, plugin
-  root management, and six cross-domain accessor methods. Suggested
-  split:
-  - `PluginLoader` → `Load`, `LoadClaudePlugins`, `LoadFromPath`
-  - `PluginRegistry` → `List`, `Get`, `GetEnabled`, `Count`,
-    `EnabledCount`
-  - `PluginStateStore` → `Enable`, `Disable`
-  - `PluginInstallerFactory` → `NewInstaller`
-  - `PluginContributions` → the six `AgentPaths`/`SkillPaths`/… methods
-- **Rule 7 (escape hatches).** `Registry() *Registry` and
-  `SetActivePluginRoot` / `ClearActivePluginRoot` /
-  `FindPluginRootForPath` (package-level state) both leak. The latter
-  three are package-level globals dressed up as methods; move into the
-  registry value.
-- **Rule 5.** `Default()` returns `Service`.
-- **Cross-domain coupling.** Each `*Paths()` method exists so that
-  `command`/`skill`/`subagent`/`mcp` can consume plugin contributions
-  without importing `plugin`. The right pattern is reverse-injection:
-  on `Initialize`, `plugin` *pushes* its contributions into each
-  consumer rather than each consumer *pulling* from `plugin`. Today's
-  init order (callbacks passed in `Options{PluginAgentPaths: ...}`) is
-  already half of this; finish it.
 
 ## Internals
 

--- a/internal/app/input/on_plugin_test.go
+++ b/internal/app/input/on_plugin_test.go
@@ -207,8 +207,8 @@ func TestRenderInstalledDetailShowsStructuredSections(t *testing.T) {
 
 func TestHandlePluginCommandMarketplaceAddListRemove(t *testing.T) {
 	reg := coreplugin.NewRegistry()
-	coreplugin.SetDefault(coreplugin.WrapRegistry(reg))
-	t.Cleanup(coreplugin.ResetService)
+	coreplugin.SetDefaultRegistry(reg)
+	t.Cleanup(coreplugin.ResetDefaultRegistry)
 
 	tmpHome := t.TempDir()
 	tmpDir := t.TempDir()
@@ -247,8 +247,8 @@ func TestHandlePluginCommandMarketplaceAddListRemove(t *testing.T) {
 
 func TestHandlePluginCommandInstallFromMarketplace(t *testing.T) {
 	reg := coreplugin.NewRegistry()
-	coreplugin.SetDefault(coreplugin.WrapRegistry(reg))
-	t.Cleanup(coreplugin.ResetService)
+	coreplugin.SetDefaultRegistry(reg)
+	t.Cleanup(coreplugin.ResetDefaultRegistry)
 
 	tmpHome := t.TempDir()
 	tmpDir := t.TempDir()

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -44,7 +44,7 @@ type CommandDeps struct {
 
 	// Domain services
 	Skill   *skill.Registry
-	Plugin  plugin.Service
+	Plugin  *plugin.Registry
 	MCP     *mcp.Registry
 	Tracker tracker.Service
 	Cron    cron.Service
@@ -191,7 +191,7 @@ func (c CommandController) executeSkillSlashCommand(sk *skill.Skill, args string
 		c.deps.Input.Skill.SetPending(sk.FullName(), c.deps.Skill.GetSkillInvocationPrompt(sk.FullName()))
 	}
 	if c.deps.Plugin != nil {
-		c.deps.Plugin.SetActivePluginRoot(c.deps.Plugin.FindPluginRootForPath(sk.SkillDir))
+		plugin.SetActivePluginRoot(plugin.FindPluginRootForPath(sk.SkillDir))
 	}
 	if args != "" {
 		c.deps.Input.Skill.PendingArgs = fmt.Sprintf("/%s %s", sk.FullName(), args)
@@ -201,12 +201,12 @@ func (c CommandController) executeSkillSlashCommand(sk *skill.Skill, args string
 	return ""
 }
 
-func ApplySkillInvocation(state *Model, sk *skill.Skill, args string, skillSvc *skill.Registry, pluginSvc plugin.Service) {
+func ApplySkillInvocation(state *Model, sk *skill.Skill, args string, skillSvc *skill.Registry, pluginSvc *plugin.Registry) {
 	if skillSvc != nil {
 		state.Skill.SetPending(sk.FullName(), skillSvc.GetSkillInvocationPrompt(sk.FullName()))
 	}
 	if pluginSvc != nil {
-		pluginSvc.SetActivePluginRoot(pluginSvc.FindPluginRootForPath(sk.SkillDir))
+		plugin.SetActivePluginRoot(plugin.FindPluginRootForPath(sk.SkillDir))
 	}
 	if args != "" {
 		state.Skill.PendingArgs = fmt.Sprintf("/%s %s", sk.FullName(), args)
@@ -220,7 +220,7 @@ func (c CommandController) executeCustomCommand(pc *command.CustomCommand, args 
 		c.deps.Input.Skill.SetPending(pc.FullName(), command.WrapInvocation(pc.FullName(), instructions))
 	}
 	if c.deps.Plugin != nil {
-		c.deps.Plugin.SetActivePluginRoot(c.deps.Plugin.FindPluginRootForPath(pc.FilePath))
+		plugin.SetActivePluginRoot(plugin.FindPluginRootForPath(pc.FilePath))
 	}
 	c.deps.Input.Skill.PendingArgs = formatSlashInvocation(pc.FullName(), args)
 	return ""

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -120,7 +120,7 @@ func newBaseModel() model {
 			AgentRegistry:    &agentRegistryAdapter{svc.Subagent},
 			SkillRegistry:    svc.Skill,
 			MCPRegistry:      svc.MCP,
-			PluginRegistry:   svc.Plugin.Registry(),
+			PluginRegistry:   svc.Plugin,
 			IdentityRegistry: svc.Identity,
 			Setting:          svc.Setting,
 			LoadDisabled:     svc.Setting.GetDisabledToolsAt,

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -35,7 +35,7 @@ type services struct {
 	Tracker  tracker.Service
 	Cron     cron.Service
 	MCP      *mcp.Registry
-	Plugin   plugin.Service
+	Plugin   *plugin.Registry
 	Agent    agent.Service
 	Identity *identity.Registry
 	Reminder *reminder.Service

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/genai-io/gen-code/internal/image"
 	"github.com/genai-io/gen-code/internal/llm"
 	"github.com/genai-io/gen-code/internal/mcp"
+	"github.com/genai-io/gen-code/internal/plugin"
 	"go.uber.org/zap"
 
 	"github.com/genai-io/gen-code/internal/log"
@@ -459,7 +460,7 @@ func (m *model) submitDeps() input.SubmitDeps {
 			ctrl := input.NewCommandController(m.commandDeps())
 			return ctrl.HandleSubmit(text)
 		},
-		ClearPluginRoot: m.services.Plugin.ClearActivePluginRoot,
+		ClearPluginRoot: plugin.ClearActivePluginRoot,
 	}
 }
 

--- a/internal/plugin/service.go
+++ b/internal/plugin/service.go
@@ -1,137 +1,45 @@
+// Package plugin loads, installs, and enables plugin bundles that
+// contribute skills, subagent definitions, slash commands, MCP servers,
+// hooks, and env vars to the host application.
+//
+// The package exposes *Registry directly. Plugin's many cross-domain
+// outputs (agent paths, skill paths, command paths, MCP servers, hooks,
+// env vars) are consumed via the package-level free functions in
+// integration.go — each downstream consumer (skill / subagent / command
+// / mcp / setting) pulls what it needs. There is no shared narrow
+// surface for a producer-side role interface.
 package plugin
 
-import (
-	"context"
-	"sync"
-
-	"github.com/genai-io/gen-code/internal/setting"
-)
-
-// Service is the public contract for the plugin module.
-type Service interface {
-	// loading
-	Load(ctx context.Context, cwd string) error          // load plugins from standard dirs
-	LoadClaudePlugins(ctx context.Context) error         // load Claude Code plugins
-	LoadFromPath(ctx context.Context, path string) error // load plugin from path
-
-	// query
-	List() []*Plugin                 // all loaded plugins
-	Get(name string) (*Plugin, bool) // lookup by name
-	GetEnabled() []*Plugin           // all enabled plugins
-	Count() int                      // total number of loaded plugins
-	EnabledCount() int               // number of enabled plugins
-
-	// mutation
-	Enable(name string, scope Scope) error
-	Disable(name string, scope Scope) error
-
-	// installer
-	NewInstaller(cwd string) *Installer // create plugin installer
-
-	// access
-	Registry() *Registry // return the underlying *Registry
-
-	// plugin root management
-	SetActivePluginRoot(path string)
-	ClearActivePluginRoot()
-	FindPluginRootForPath(path string) string
-
-	// cross-domain (consumed by other services at init)
-	AgentPaths() []PluginPath               // agent file paths from enabled plugins
-	SkillPaths() []PluginPath               // skill directory paths from enabled plugins
-	CommandPaths() []PluginPath             // command file paths from enabled plugins
-	MCPServers() []PluginMCPServer          // MCP servers from enabled plugins
-	PluginHooks() map[string][]setting.Hook // hook definitions from enabled plugins
-	PluginEnv() []string                    // environment variables for enabled plugins
-}
-
-// Compile-time check: *service implements Service.
-var _ Service = (*service)(nil)
+import "context"
 
 // Options holds all dependencies for initialization.
 type Options struct {
 	CWD string
 }
 
-// Initialize loads plugins into the default registry and sets the singleton Service.
+// Initialize loads plugins into the package-level *Registry.
 func Initialize(ctx context.Context, opts Options) error {
-	if err := defaultRegistry.Load(ctx, opts.CWD); err != nil {
-		return err
+	return defaultRegistry.Load(ctx, opts.CWD)
+}
+
+// Default returns the package-level *Registry. The registry is
+// initialized at package load (empty) and populated by Initialize().
+func Default() *Registry {
+	return defaultRegistry
+}
+
+// SetDefaultRegistry replaces the package-level registry. Intended for
+// tests. A nil argument restores a fresh empty *Registry.
+func SetDefaultRegistry(r *Registry) {
+	if r == nil {
+		defaultRegistry = NewRegistry()
+		return
 	}
-	SetDefault(&service{registry: defaultRegistry})
-	return nil
+	defaultRegistry = r
 }
 
-// ── singleton ──────────────────────────────────────────────
-
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance.
-// Falls back to wrapping defaultRegistry if Initialize has not been called.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	if s != nil {
-		return s
-	}
-	return &service{registry: defaultRegistry}
+// ResetDefaultRegistry restores a fresh empty *Registry. Intended for
+// tests.
+func ResetDefaultRegistry() {
+	defaultRegistry = NewRegistry()
 }
-
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
-}
-
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
-
-// WrapRegistry creates a Service from a *Registry. Used by tests.
-func WrapRegistry(reg *Registry) Service {
-	return &service{registry: reg}
-}
-
-// ── implementation ─────────────────────────────────────────
-
-// service wraps the Registry to satisfy the Service interface.
-type service struct {
-	registry *Registry
-}
-
-func (s *service) Load(ctx context.Context, cwd string) error { return s.registry.Load(ctx, cwd) }
-func (s *service) LoadClaudePlugins(ctx context.Context) error {
-	return s.registry.LoadClaudePlugins(ctx)
-}
-func (s *service) LoadFromPath(ctx context.Context, path string) error {
-	return s.registry.LoadFromPath(ctx, path)
-}
-func (s *service) NewInstaller(cwd string) *Installer { return NewInstaller(s.registry, cwd) }
-func (s *service) List() []*Plugin                    { return s.registry.List() }
-func (s *service) Get(name string) (*Plugin, bool)    { return s.registry.Get(name) }
-func (s *service) GetEnabled() []*Plugin              { return s.registry.GetEnabled() }
-func (s *service) Count() int                         { return s.registry.Count() }
-func (s *service) EnabledCount() int                  { return s.registry.EnabledCount() }
-
-func (s *service) Enable(name string, scope Scope) error  { return s.registry.Enable(name, scope) }
-func (s *service) Disable(name string, scope Scope) error { return s.registry.Disable(name, scope) }
-
-func (s *service) SetActivePluginRoot(path string)          { SetActivePluginRoot(path) }
-func (s *service) ClearActivePluginRoot()                   { ClearActivePluginRoot() }
-func (s *service) FindPluginRootForPath(path string) string { return FindPluginRootForPath(path) }
-
-func (s *service) AgentPaths() []PluginPath               { return GetPluginAgentPaths() }
-func (s *service) SkillPaths() []PluginPath               { return GetPluginSkillPaths() }
-func (s *service) CommandPaths() []PluginPath             { return GetPluginCommandPaths() }
-func (s *service) MCPServers() []PluginMCPServer          { return GetPluginMCPServers() }
-func (s *service) PluginHooks() map[string][]setting.Hook { return GetPluginHooks() }
-func (s *service) PluginEnv() []string                    { return PluginEnv() }
-func (s *service) Registry() *Registry                    { return s.registry }

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -11,10 +11,10 @@ This file tracks structural follow-ups that are not tied to a single feature.
 ### Code refactors flagged by `docs/packages/*/Known Violations`
 
 - **God `Service` interfaces.** Split per the per-package suggestions:
-  `plugin` (21), `setting` (14), `agent` (11), `cron` (10),
-  `command` (7), `llm` (8), `task` (8), `tool` (6).
-  Define narrow consumer-defined interfaces alongside the concrete
-  `*service` / `*Registry`; let each call site narrow to what it needs.
+  `setting` (14), `agent` (11), `cron` (10), `command` (7),
+  `llm` (8), `task` (8), `tool` (6). Define narrow consumer-defined
+  interfaces alongside the concrete `*service` / `*Registry`; let each
+  call site narrow to what it needs.
   ~~`mcp` (9 methods)~~ — resolved (`Tools` + `Servers` + `*mcp.Registry`).
   ~~`hook` (16 methods)~~ — resolved (`Handler` + `*hook.Engine`).
   ~~`session` (11 methods)~~ — resolved by deleting `Service`, exposing
@@ -25,6 +25,10 @@ This file tracks structural follow-ups that are not tied to a single feature.
   reason as session.
   ~~`skill` (11 methods)~~ — resolved by deleting `Service`, exposing
   `*skill.Registry` directly. No role interface — same reason.
+  ~~`plugin` (21 methods)~~ — resolved by deleting `Service`, exposing
+  `*plugin.Registry` directly + the existing package-level free
+  functions (`GetPlugin*Paths`, `SetActivePluginRoot`, etc.) that the
+  Service methods just wrapped.
 - **Escape-hatch methods on Service interfaces.** All resolved:
   ~~`MCP.Registry()`~~, ~~`Hook.Engine()`~~, ~~`Session.GetStore()`~~
   / ~~`Session.SetStore()`~~ — Service interfaces deleted in their


### PR DESCRIPTION
## Summary

Apply the same first-principles approach used for #27/#28/#29/#30/#31
to the plugin package. \`plugin.Service\` was a **21-method god union**
— the largest in the repo — with a \`Registry() *Registry\` escape
hatch plus six wrapper methods around package-level free functions
(\`SetActivePluginRoot\`, \`FindPluginRootForPath\`, \`AgentPaths\`,
\`SkillPaths\`, \`CommandPaths\`, \`MCPServers\`, \`PluginHooks\`,
\`PluginEnv\`).

The wrappers were pure delegation. Callers can use the free functions
directly. The genuine state is \`*Registry\`.

## What goes away

- \`plugin.Service\` interface (21 methods)
- \`*service\` struct (pure wrapper over \`*Registry\` + free functions)
- \`plugin.Default()\` / \`SetDefault()\` / \`ResetService()\` /
  \`WrapRegistry()\` — Service singleton plumbing
- \`Registry() *Registry\` escape hatch

## What replaces it

- \`plugin.Default() *Registry\` — package-level \`*Registry\` directly
- \`plugin.SetDefaultRegistry\` / \`ResetDefaultRegistry\` — test-only seam
- \`*Registry\` has Load / LoadFromPath / LoadClaudePlugins / Get /
  List / GetEnabled / Count / EnabledCount / Enable / Disable /
  GetByScope / Register / Unregister
- Free functions (already existed) for cross-domain integration:
  \`GetPluginAgentPaths\` / \`GetPluginSkillPaths\` /
  \`GetPluginCommandPaths\` / \`GetPluginMCPServers\` /
  \`GetPluginHooks\` / \`PluginEnv\` / \`SetActivePluginRoot\` /
  \`ClearActivePluginRoot\` / \`FindPluginRootForPath\` /
  \`NewInstaller\`

## Caller-side changes

- \`internal/app/services.go\`: \`Plugin\` field is \`*plugin.Registry\`
- \`internal/app/model.go\`: \`svc.Plugin.Registry()\` → \`svc.Plugin\`
- \`internal/app/update.go\`: \`m.services.Plugin.ClearActivePluginRoot\`
  → \`plugin.ClearActivePluginRoot\` (free function)
- \`internal/app/input/slash_command.go\`: \`SlashCommandDeps.Plugin\`
  type changed; three call sites switched to free functions
- \`internal/app/input/on_plugin_test.go\`:
  \`SetDefault(WrapRegistry(reg))\` → \`SetDefaultRegistry(reg)\`
- \`cmd/gen/plugin.go\`: \`plugin.Default().NewInstaller(cwd)\` →
  \`plugin.NewInstaller(plugin.Default(), cwd)\`

## Spec

- \`docs/packages/plugin.md\`: Contract rewritten with the opaque-handle
  pattern. Cross-domain methods documented as the free functions they
  always were under the wrapper.
- \`notes/tech-debt.md\`: plugin moved to the resolved column.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 52 packages green
- [x] \`make lint-layers\` clean
- [x] \`make format-check\` clean
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)