### PR TITLE
refactor: drop god Service interfaces across 7 packages

### DIFF
--- a/docs/packages/agent.md
+++ b/docs/packages/agent.md
@@ -21,29 +21,29 @@ same `Send` path used by user input.
 
 ## Contract
 
-Foreground agent session lifecycle. Holds the single core.Agent + permission bridge for the TUI session. The package exposes `*Session` directly — no Service interface.
+Foreground agent task lifecycle. Holds the single core.Agent + permission bridge for the running task. The package exposes `*Task` directly — no Service interface.
 
 ```go
 package agent
 
-// Session is the opaque handle. Type exported; fields unexported.
-type Session struct { /* internal fields */ }
+// Task is the opaque handle. Type exported; fields unexported.
+type Task struct { /* internal fields */ }
 
-func (s *Session) Start(params BuildParams, messages []core.Message) error
-func (s *Session) Stop()
-func (s *Session) Active() bool
-func (s *Session) Send(content string, images []core.Image)
-func (s *Session) Outbox() <-chan core.Event
-func (s *Session) PermissionBridge() *PermissionBridge
-func (s *Session) PendingPermission() *PermBridgeRequest
-func (s *Session) SetPendingPermission(req *PermBridgeRequest)
-func (s *Session) System() core.System
+func (s *Task) Start(params BuildParams, messages []core.Message) error
+func (s *Task) Stop()
+func (s *Task) Active() bool
+func (s *Task) Send(content string, images []core.Image)
+func (s *Task) Outbox() <-chan core.Event
+func (s *Task) PermissionBridge() *PermissionBridge
+func (s *Task) PendingPermission() *PermBridgeRequest
+func (s *Task) SetPendingPermission(req *PermBridgeRequest)
+func (s *Task) System() core.System
 
 // Package-level access
 func Initialize(opts Options)
-func Default() *Session
-func SetDefaultSession(s *Session)  // test-only
-func ResetDefaultSession()          // test-only
+func Default() *Task
+func SetDefaultTask(s *Task)  // test-only
+func ResetDefaultTask()          // test-only
 ```
 
 

--- a/docs/packages/agent.md
+++ b/docs/packages/agent.md
@@ -21,72 +21,31 @@ same `Send` path used by user input.
 
 ## Contract
 
-The seam consumed by `internal/app`:
+Foreground agent session lifecycle. Holds the single core.Agent + permission bridge for the TUI session. The package exposes `*Session` directly — no Service interface.
 
 ```go
 package agent
 
-// Service manages the main agent session lifecycle.
-type Service interface {
-    // Start builds a core.Agent from params, starts its goroutine.
-    // If messages is non-empty, they are loaded as conversation history.
-    Start(params BuildParams, messages []core.Message) error
+// Session is the opaque handle. Type exported; fields unexported.
+type Session struct { /* internal fields */ }
 
-    // Stop cancels the agent goroutine and cleans up.
-    Stop()
+func (s *Session) Start(params BuildParams, messages []core.Message) error
+func (s *Session) Stop()
+func (s *Session) Active() bool
+func (s *Session) Send(content string, images []core.Image)
+func (s *Session) Outbox() <-chan core.Event
+func (s *Session) PermissionBridge() *PermissionBridge
+func (s *Session) PendingPermission() *PermBridgeRequest
+func (s *Session) SetPendingPermission(req *PermBridgeRequest)
+func (s *Session) System() core.System
 
-    // Active reports whether an agent session is running.
-    Active() bool
-
-    // Send pushes a user message to the agent's inbox. No-op if not active.
-    Send(content string, images []core.Image)
-
-    // Outbox returns the agent's event channel. Nil if not active.
-    Outbox() <-chan core.Event
-
-    // PermissionBridge returns the current session's permission bridge.
-    PermissionBridge() *PermissionBridge
-
-    // PendingPermission gets the pending permission request.
-    PendingPermission() *PermBridgeRequest
-
-    // SetPendingPermission tracks a pending permission request for TUI approval.
-    SetPendingPermission(req *PermBridgeRequest)
-
-    // System returns the running agent's system prompt for hot-patching
-    // (e.g. swapping identity mid-session). Returns nil if no agent is
-    // active. Mutations are visible on the next inference call.
-    System() core.System
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Session
+func SetDefaultSession(s *Session)  // test-only
+func ResetDefaultSession()          // test-only
 ```
 
-The underlying primitive — `core.Agent` with its Inbox/Outbox channels —
-lives in [`packages/core.md`](core.md). This package wraps a single
-`core.Agent` per running session.
-
-### Known Violations
-
-These break the [Contract Rules](TEMPLATE.md#contract-rules) in the
-template. They are tracked here for a PR-3 cleanup; the present doc
-faithfully reflects today's code.
-
-- **Rule 1 (small).** `Service` has **11 methods** covering four concerns:
-  lifecycle (`Start`/`Stop`/`Active`), I/O (`Send`/`Outbox`), permission
-  bridge (`PermissionBridge`/`PendingPermission`/`SetPendingPermission`),
-  hot-patching (`System`). Suggested split:
-  - `AgentLifecycle` → `Start`, `Stop`, `Active`
-  - `AgentIO` → `Send`, `Outbox`
-  - `PermissionGate` → the three bridge methods
-  - `SystemPatcher` → `System`
-  Each call site narrows to the interface it actually uses; the concrete
-  `*service` keeps implementing all of them.
-- **Rule 5 (constructors return concrete types).** `Default()` returns
-  `Service` rather than the concrete `*service`. Callers can never reach
-  unexported fields and tests can't substitute behavior except through
-  `SetDefault`. Should return `*service` once exported, or split as above.
-- **Singleton via `Default()`.** Hidden global state; not strictly an
-  interface rule but it blocks the consumer-side interface pattern.
-  Construction should move into `internal/app/services.go`.
 
 ## Internals
 

--- a/docs/packages/command.md
+++ b/docs/packages/command.md
@@ -19,43 +19,29 @@ commands loaded from disk.
 
 ## Contract
 
+Slash command registry. Combines built-in handlers, dynamic providers (skill/agent surfaces), and custom markdown commands. The package exposes `*Registry` directly — no Service interface.
+
 ```go
 package command
 
-// Service is the public contract for the command module.
-type Service interface {
-    Get(name string) (Info, bool)
-    List() []Info
-    ListCustom() []CustomCommand
-    GetMatching(prefix string) []Info
-    IsCustomCommand(cmd string) (*CustomCommand, bool)
-    BuiltinNames() map[string]Info
-    GetCustomCommands() []Info
-}
+// Registry is the opaque handle. Type exported; fields unexported.
+type Registry struct { /* internal fields */ }
 
-type PluginCommandPath struct {
-    Path      string
-    Namespace string
-    IsProject bool
-}
+func (s *Registry) Get(name string) (Info, bool)
+func (s *Registry) List() []Info
+func (s *Registry) ListCustom() []CustomCommand
+func (s *Registry) GetMatching(prefix string) []Info
+func (s *Registry) IsCustomCommand(cmd string) (*CustomCommand, bool)
+func (s *Registry) BuiltinNames() map[string]Info
+func (s *Registry) GetCustomCommands() []Info
 
-type Options struct {
-    CWD                string
-    DynamicProviders   []func() []Info
-    PluginCommandPaths func() []PluginCommandPath
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Registry
+func SetDefaultRegistry(s *Registry)  // test-only
+func ResetDefaultRegistry()          // test-only
 ```
 
-### Known Violations
-
-- **Rule 1 (small).** 7 methods on `Service` is at the upper edge.
-  `List` / `BuiltinNames` / `GetCustomCommands` overlap conceptually;
-  could consolidate. Acceptable; the methods all serve the autocompleter.
-- **Rule 5.** `Default()` returns `Service`.
-- **Singleton via `Default()`.**
-
-Otherwise this is one of the cleaner package contracts — the surface is
-narrow and consumer-oriented.
 
 ## Internals
 

--- a/docs/packages/cron.md
+++ b/docs/packages/cron.md
@@ -17,47 +17,36 @@ non-durable jobs are in-memory only.
 
 ## Contract
 
+Cron expression scheduler. Jobs persist to disk when marked durable; the TUI loop calls Tick() to fire due jobs. The package exposes `*Scheduler` directly — no Service interface.
+
 ```go
 package cron
 
-// Service is the public contract for the cron module.
-type Service interface {
-    // CRUD
-    Add(job Job) error
-    Remove(id string) bool
-    Create(cronExpr, prompt string, recurring, durable bool) (*Job, error)
-    Delete(id string) error
-    List() []*Job
+// Scheduler is the opaque handle. Type exported; fields unexported.
+type Scheduler struct { /* internal fields */ }
 
-    // runtime
-    Tick() []FiredJob
+func (s *Scheduler) Add(job Job) error
+func (s *Scheduler) Remove(id string) bool
+func (s *Scheduler) Create(cronExpr, prompt string, recurring, durable bool) (*Job, error)
+func (s *Scheduler) Delete(id string) error
+func (s *Scheduler) List() []*Job
+func (s *Scheduler) Tick() []FiredJob
+func (s *Scheduler) Empty() bool
+func (s *Scheduler) Reset()
+func (s *Scheduler) SetStoragePath(path string)
+func (s *Scheduler) LoadDurable() error
 
-    // query
-    Empty() bool
-
-    // lifecycle
-    Reset()
-    SetStoragePath(path string)
-    LoadDurable() error
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Scheduler
+func SetDefaultScheduler(s *Scheduler)  // test-only
+func ResetDefaultScheduler()        // test-only
 ```
 
-### Known Violations
-
-- **Rule 1 (small).** 10 methods spanning CRUD, runtime tick, and
-  lifecycle. Could split into `CronJobs` (CRUD/Query) and `CronRuntime`
-  (Tick/Lifecycle).
-- **`Add` and `Create` overlap.** Both produce a `Job` from input. `Add`
-  takes a built `Job`; `Create` takes raw fields. The two-API surface
-  invites confusion — pick one.
-- **`Remove` returns bool, `Delete` returns error.** Different idioms
-  for the same operation. Consolidate.
-- **Rule 5.** `Default()` returns `Service`.
-- **Singleton via `Default()`.**
 
 ## Internals
 
-- `Store` (`store.go`) — concrete implementation. Holds the job map +
+- `Scheduler` (`store.go`) — concrete implementation. Holds the job map +
   optional `storagePath` for durable persistence.
 - `cron.go` — `Job` struct, cron expression parsing, next-fire-time
   calculation.

--- a/docs/packages/llm.md
+++ b/docs/packages/llm.md
@@ -20,42 +20,30 @@ streaming details for each call.
 
 ## Contract
 
+LLM provider connection handle + Client factory. Wraps the package-level *Setup (Store + Provider + CurrentModel) under a mutex. The package exposes `*Hub` directly — no Service interface.
+
 ```go
 package llm
 
-// Service is the public contract for the llm module.
-type Service interface {
-    // connection
-    Provider() Provider              // current active provider
-    SetProvider(p Provider)          // switch provider
-    ModelID() string                 // current model identifier
-    CurrentModel() *CurrentModelInfo // full model metadata
-    SetCurrentModel(info *CurrentModelInfo)
+// Hub is the opaque handle. Type exported; fields unexported.
+type Hub struct { /* internal fields */ }
 
-    // factory
-    NewClient(model string, maxTokens int) *Client
+func (s *Hub) Provider() Provider
+func (s *Hub) SetProvider(p Provider)
+func (s *Hub) ModelID() string
+func (s *Hub) CurrentModel() *CurrentModelInfo
+func (s *Hub) SetCurrentModel(info *CurrentModelInfo)
+func (s *Hub) NewClient(model string, maxTokens int) *Client
+func (s *Hub) Store() *Store
+func (s *Hub) ListProviders() map[Name][]Info
 
-    // store
-    Store() *Store // underlying provider persistence store
-
-    // registry
-    ListProviders() map[Name][]Info // all registered providers with status
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Hub
+func SetDefaultHub(s *Hub)  // test-only
+func ResetDefaultHub()          // test-only
 ```
 
-`Client` implements `core.LLM`. `Provider` is the per-backend handle
-(API key, auth method, list-models endpoint).
-
-### Known Violations
-
-- **Rule 1 (small).** 8 methods. Mixes connection state, factory, store
-  access, and registry listing. Suggested split: `LLMConnection`
-  (Provider/SetProvider/Model methods), `LLMClientFactory` (NewClient),
-  `LLMProviderRegistry` (ListProviders).
-- **Rule 7 (no escape hatch).** `Store()` exposes the concrete `*Store`.
-  Callers should depend on a narrower read-only view.
-- **Rule 5.** `Default()` returns `Service` not `*service`.
-- **Singleton via `Default()`.**
 
 ## Internals
 

--- a/docs/packages/llm.md
+++ b/docs/packages/llm.md
@@ -20,28 +20,28 @@ streaming details for each call.
 
 ## Contract
 
-LLM provider connection handle + Client factory. Wraps the package-level *Setup (Store + Provider + CurrentModel) under a mutex. The package exposes `*Hub` directly — no Service interface.
+Active LLM provider/model handle and `*Client` factory. Wraps the package-level *Setup (Store + Provider + CurrentModel) under a mutex. The package exposes `*ClientFactory` directly — no Service interface.
 
 ```go
 package llm
 
-// Hub is the opaque handle. Type exported; fields unexported.
-type Hub struct { /* internal fields */ }
+// ClientFactory is the opaque handle. Type exported; fields unexported.
+type ClientFactory struct { /* internal fields */ }
 
-func (s *Hub) Provider() Provider
-func (s *Hub) SetProvider(p Provider)
-func (s *Hub) ModelID() string
-func (s *Hub) CurrentModel() *CurrentModelInfo
-func (s *Hub) SetCurrentModel(info *CurrentModelInfo)
-func (s *Hub) NewClient(model string, maxTokens int) *Client
-func (s *Hub) Store() *Store
-func (s *Hub) ListProviders() map[Name][]Info
+func (s *ClientFactory) Provider() Provider
+func (s *ClientFactory) SetProvider(p Provider)
+func (s *ClientFactory) ModelID() string
+func (s *ClientFactory) CurrentModel() *CurrentModelInfo
+func (s *ClientFactory) SetCurrentModel(info *CurrentModelInfo)
+func (s *ClientFactory) NewClient(model string, maxTokens int) *Client
+func (s *ClientFactory) Store() *Store
+func (s *ClientFactory) ListProviders() map[Name][]Info
 
 // Package-level access
 func Initialize(opts Options)
-func Default() *Hub
-func SetDefaultHub(s *Hub)  // test-only
-func ResetDefaultHub()          // test-only
+func Default() *ClientFactory
+func SetDefaultClientFactory(s *ClientFactory)  // test-only
+func ResetDefaultClientFactory()          // test-only
 ```
 
 

--- a/docs/packages/setting.md
+++ b/docs/packages/setting.md
@@ -5,7 +5,7 @@ layer: feature
 
 # setting
 
-Settings loader, merger, and the central permission decision gate.
+Data loader, merger, and the central permission decision gate.
 Reads `~/.gen/settings.json` and `<project>/.gen/settings.json`, merges
 project-over-user with documented precedence, and decides allow / deny /
 ask for every tool call.
@@ -24,40 +24,40 @@ Two concerns live here:
 
 ## Contract
 
-Settings loader + central permission decision gate. *Manager wraps *Settings under a mutex; methods are mutex-protected views. The package exposes `*Manager` directly — no Service interface.
+Data loader + central permission decision gate. *Settings wraps *Data under a mutex; methods are mutex-protected views. The package exposes `*Settings` directly — no Service interface.
 
 ```go
 package setting
 
-// Manager is the opaque handle. Type exported; fields unexported.
-type Manager struct { /* internal fields */ }
+// Settings is the opaque handle. Type exported; fields unexported.
+type Settings struct { /* internal fields */ }
 
-func (s *Manager) Snapshot() *Settings
-func (s *Manager) AllowBypass() bool
-func (s *Manager) IsGitRepo(cwd string) bool
-func (s *Manager) Reload(cwd string) error
-func (s *Manager) DisabledTools() map[string]bool
-func (s *Manager) SearchProvider() string
-func (s *Manager) SetSearchProvider(provider string)
-func (s *Manager) Hooks() map[string][]Hook
-func (s *Manager) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior
-func (s *Manager) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision
-func (s *Manager) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool
-func (s *Manager) GetDisabledToolsAt(userLevel bool) map[string]bool
-func (s *Manager) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error
+func (s *Settings) Snapshot() *Data
+func (s *Settings) AllowBypass() bool
+func (s *Settings) IsGitRepo(cwd string) bool
+func (s *Settings) Reload(cwd string) error
+func (s *Settings) DisabledTools() map[string]bool
+func (s *Settings) SearchProvider() string
+func (s *Settings) SetSearchProvider(provider string)
+func (s *Settings) Hooks() map[string][]Hook
+func (s *Settings) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior
+func (s *Settings) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision
+func (s *Settings) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool
+func (s *Settings) GetDisabledToolsAt(userLevel bool) map[string]bool
+func (s *Settings) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error
 
 // Package-level access
 func Initialize(opts Options)
-func Default() *Manager
-func DefaultIfInit() *Manager           // nil pre-Initialize
-func SetDefaultManager(s *Manager)      // test-only
-func ResetDefaultManager()              // test-only
+func Default() *Settings
+func DefaultIfInit() *Settings           // nil pre-Initialize
+func SetDefaultSettings(s *Settings)      // test-only
+func ResetDefaultSettings()              // test-only
 ```
 
 
 ## Internals
 
-- `Settings` (`settings.go`) — value type holding all merged config.
+- `Data` (`settings.go`) — value type holding all merged config.
 - `loader.go` + `merger.go` — read the two tiers and combine them with
   documented precedence (project overrides user, except in a few flagged
   fields).

--- a/docs/packages/setting.md
+++ b/docs/packages/setting.md
@@ -24,50 +24,36 @@ Two concerns live here:
 
 ## Contract
 
+Settings loader + central permission decision gate. *Manager wraps *Settings under a mutex; methods are mutex-protected views. The package exposes `*Manager` directly — no Service interface.
+
 ```go
 package setting
 
-// Service is the public contract for the setting module.
-type Service interface {
-    // Snapshot returns the current merged settings.
-    Snapshot() *Settings
-    AllowBypass() bool
-    IsGitRepo(cwd string) bool
-    Reload(cwd string) error
-    DisabledTools() map[string]bool
-    SearchProvider() string
-    SetSearchProvider(provider string)
-    Hooks() map[string][]Hook
+// Manager is the opaque handle. Type exported; fields unexported.
+type Manager struct { /* internal fields */ }
 
-    // permission gate
-    CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior
-    HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision
-    ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool
+func (s *Manager) Snapshot() *Settings
+func (s *Manager) AllowBypass() bool
+func (s *Manager) IsGitRepo(cwd string) bool
+func (s *Manager) Reload(cwd string) error
+func (s *Manager) DisabledTools() map[string]bool
+func (s *Manager) SearchProvider() string
+func (s *Manager) SetSearchProvider(provider string)
+func (s *Manager) Hooks() map[string][]Hook
+func (s *Manager) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior
+func (s *Manager) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision
+func (s *Manager) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool
+func (s *Manager) GetDisabledToolsAt(userLevel bool) map[string]bool
+func (s *Manager) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error
 
-    // per-level disabled tools
-    GetDisabledToolsAt(userLevel bool) map[string]bool
-    UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Manager
+func DefaultIfInit() *Manager           // nil pre-Initialize
+func SetDefaultManager(s *Manager)      // test-only
+func ResetDefaultManager()              // test-only
 ```
 
-### Known Violations
-
-- **Rule 1 (small) — 14 methods.** Two concerns (config + permission)
-  fused. Suggested split into two packages or two interfaces:
-  - `Settings` → snapshot/reload/disabled-tools/search-provider/hooks
-  - `PermissionGate` → CheckPermission / HasPermissionToUseTool /
-    ResolveHookAllow / AllowBypass
-  This split matches the actual code surface and would let
-  `internal/tool` depend on `PermissionGate` alone.
-- **Rule 7 (no escape hatch).** `Snapshot() *Settings` returns a clone of
-  the concrete struct, which exposes every field. Most callers only need
-  a few — narrow with focused accessors.
-- **Rule 5.** `Default()` returns `Service`.
-- **Singleton via `Default()` + `DefaultIfInit()`.**
-- **Permission API surface is wide.** `CheckPermission`,
-  `HasPermissionToUseTool`, and `ResolveHookAllow` overlap in concern.
-  Consolidating into a single `Decide(req) PermissionDecision` would
-  simplify both callers and tests.
 
 ## Internals
 

--- a/docs/packages/task.md
+++ b/docs/packages/task.md
@@ -18,41 +18,34 @@ The TUI's task panel reads from this registry; the `TaskOutput` and
 
 ## Contract
 
+Background task manager. Tracks bash and subagent tasks for the TUI panel and the TaskOutput/TaskList tools. The package exposes `*Tracker` directly — no Service interface.
+
 ```go
 package task
 
-// Service is the public contract for the task module.
-type Service interface {
-    // lifecycle
-    RegisterTask(t BackgroundTask)
-    CreateBashTask(cmd *exec.Cmd, command, description string,
-                   ctx context.Context, cancel context.CancelFunc) *BashTask
-    Get(id string) (BackgroundTask, bool)
-    List() []BackgroundTask
-    ListRunning() []BackgroundTask
-    Kill(id string) error
-    Remove(id string)
+// Tracker is the opaque handle. Type exported; fields unexported.
+type Tracker struct { /* internal fields */ }
 
-    // output
-    SetOutputDir(dir string) error
-}
+func (m *Tracker) RegisterTask(t BackgroundTask)
+func (m *Tracker) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask
+func (m *Tracker) Get(id string) (BackgroundTask, bool)
+func (m *Tracker) List() []BackgroundTask
+func (m *Tracker) ListRunning() []BackgroundTask
+func (m *Tracker) Kill(id string) error
+func (m *Tracker) Remove(id string)
+func (m *Tracker) SetOutputDir(dir string) error
+
+// Package-level access
+func Initialize(opts Options)
+func Default() *Tracker
+func SetDefaultTracker(m *Tracker)  // test-only
+func ResetDefaultTracker()          // test-only
 ```
 
-### Known Violations
-
-- **Rule 1 (small).** 8 methods. Borderline. `Get` / `List` /
-  `ListRunning` could collapse to `Get(id)` + `List(filter)`.
-- **`CreateBashTask` knows too much about Bash.** A generic
-  `RegisterRunningProcess(p Process)` factory would be more reusable.
-  The Bash-specific signature is convenient for the one caller but
-  prevents future task types (HTTP, async hook) from using the same
-  factory.
-- **Rule 5.** `Default()` returns `Service`.
-- **Singleton via `Default()`.**
 
 ## Internals
 
-- `Manager` (`manager.go`) — concrete implementation. Tracks active and
+- `Tracker` (`manager.go`) — concrete implementation. Tracks active and
   completed tasks under a mutex.
 - `BackgroundTask` (`types.go`) — interface implemented by `BashTask` and
   `AgentTask`.

--- a/docs/packages/tool.md
+++ b/docs/packages/tool.md
@@ -19,44 +19,28 @@ and audit metadata.
 
 ## Contract
 
+Built-in tool registry: tools register at init time; consumers fetch by name and dispatch through the permission gate. The package exposes `*Registry` directly — no Service interface.
+
 ```go
 package tool
 
-// Service is the public contract for the tool module.
-type Service interface {
-    // registration
-    Register(t Tool)
-    RegisterAlias(alias string, t Tool)
-    Get(name string) (Tool, bool)
-    List() []string
+// Registry is the opaque handle. Type exported; fields unexported.
+type Registry struct { /* internal fields */ }
 
-    // execution
-    Execute(ctx context.Context, name string, params map[string]any, cwd string) toolresult.ToolResult
+func (r *Registry) Register(t Tool)
+func (r *Registry) RegisterAlias(alias string, t Tool)
+func (r *Registry) Get(name string) (Tool, bool)
+func (r *Registry) List() []string
+func (r *Registry) Execute(ctx context.Context, name string, params map[string]any, cwd string) toolresult.ToolResult
+func (r *Registry) PopSideEffect(toolCallID string) any
 
-    // side effects
-    PopSideEffect(toolCallID string) any
-}
+// Package-level access
+func Initialize(opts Options)
+func Default() *Registry
+func SetDefaultRegistry(r *Registry)  // test-only
+func ResetDefaultRegistry()           // test-only
 ```
 
-`Tool` itself is defined in [`packages/core.md`](core.md). The built-in
-tool implementations live under `internal/tool/{fs,web,agent,task,perm,
-mode,skill,tasktools,toolresult}/`.
-
-### Known Violations
-
-- **Rule 1 (small).** 6 methods on `Service` spanning registration,
-  execution, and a side-effect escape hatch. Acceptable; the seam is
-  cohesive. Possible future split: `ToolRegistry` (Register/Get/List) vs
-  `ToolDispatcher` (Execute/PopSideEffect).
-- **Rule 5 (constructors return concrete types).** `Default()` returns
-  `Service`; `defaultRegistry` is the only implementation. Returning
-  `*Registry` would let tests substitute behavior without `SetDefault`.
-- **`PopSideEffect` is a leaky abstraction.** Side effects (e.g. file
-  edits queued for confirmation) flow through a parallel channel rather
-  than the `ToolResult` value. Callers must remember to pop or leak data.
-  Consider folding side effects into `ToolResult`.
-- **Singleton via `Default()`.** Same as the rest of the codebase. Move
-  to composition root.
 
 ## Internals
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,34 +1,34 @@
-// Package agent owns the foreground agent session lifecycle. *Session
+// Package agent owns the foreground agent session lifecycle. *Task
 // is the concrete handle; the package exposes it directly.
 package agent
 
 // Options holds dependencies for initialization.
 type Options struct{}
 
-// Initialize installs a fresh *Session as the package-level default.
+// Initialize installs a fresh *Task as the package-level default.
 func Initialize(opts Options) {
-	defaultSession = &Session{}
+	defaultTask = &Task{}
 }
 
-// Default returns the package-level *Session.
-func Default() *Session {
-	return defaultSession
+// Default returns the package-level *Task.
+func Default() *Task {
+	return defaultTask
 }
 
-// SetDefaultSession replaces the package-level *Session. Intended for
-// tests. A nil argument restores a fresh empty *Session.
-func SetDefaultSession(s *Session) {
+// SetDefaultTask replaces the package-level *Task. Intended for
+// tests. A nil argument restores a fresh empty *Task.
+func SetDefaultTask(s *Task) {
 	if s == nil {
-		defaultSession = &Session{}
+		defaultTask = &Task{}
 		return
 	}
-	defaultSession = s
+	defaultTask = s
 }
 
-// ResetDefaultSession restores a fresh empty *Session. Intended for
+// ResetDefaultTask restores a fresh empty *Task. Intended for
 // tests.
-func ResetDefaultSession() {
-	defaultSession = &Session{}
+func ResetDefaultTask() {
+	defaultTask = &Task{}
 }
 
-var defaultSession = &Session{}
+var defaultTask = &Task{}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,80 +1,34 @@
+// Package agent owns the foreground agent session lifecycle. *Session
+// is the concrete handle; the package exposes it directly.
 package agent
-
-import (
-	"sync"
-
-	"github.com/genai-io/gen-code/internal/core"
-)
-
-// Service manages the main agent session lifecycle.
-type Service interface {
-	// Start builds a core.Agent from params, starts its goroutine.
-	// If messages is non-empty, they are loaded as conversation history.
-	Start(params BuildParams, messages []core.Message) error
-
-	// Stop cancels the agent goroutine and cleans up.
-	Stop()
-
-	// Active reports whether an agent session is running.
-	Active() bool
-
-	// Send pushes a user message to the agent's inbox. No-op if not active.
-	Send(content string, images []core.Image)
-
-	// Outbox returns the agent's event channel. Nil if not active.
-	Outbox() <-chan core.Event
-
-	// PermissionBridge returns the current session's permission bridge.
-	PermissionBridge() *PermissionBridge
-
-	// PendingPermission gets the pending permission request.
-	PendingPermission() *PermBridgeRequest
-
-	// SetPendingPermission tracks a pending permission request for TUI approval.
-	SetPendingPermission(req *PermBridgeRequest)
-
-	// System returns the running agent's system prompt for hot-patching
-	// (e.g. swapping identity mid-session). Returns nil if no agent is
-	// active. Mutations are visible on the next inference call.
-	System() core.System
-}
 
 // Options holds dependencies for initialization.
 type Options struct{}
 
-var _ Service = (*service)(nil)
-
-// ── singleton ──────────────────────────────────────────────
-
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
+// Initialize installs a fresh *Session as the package-level default.
 func Initialize(opts Options) {
-	mu.Lock()
-	instance = &service{}
-	mu.Unlock()
+	defaultSession = &Session{}
 }
 
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
+// Default returns the package-level *Session.
+func Default() *Session {
+	return defaultSession
+}
+
+// SetDefaultSession replaces the package-level *Session. Intended for
+// tests. A nil argument restores a fresh empty *Session.
+func SetDefaultSession(s *Session) {
 	if s == nil {
-		panic("agent: not initialized")
+		defaultSession = &Session{}
+		return
 	}
-	return s
+	defaultSession = s
 }
 
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultSession restores a fresh empty *Session. Intended for
+// tests.
+func ResetDefaultSession() {
+	defaultSession = &Session{}
 }
 
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultSession = &Session{}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -8,7 +8,7 @@ import (
 	"github.com/genai-io/gen-code/internal/core"
 )
 
-type Session struct {
+type Task struct {
 	mu                 sync.RWMutex
 	agent              core.Agent
 	permBridge         *PermissionBridge
@@ -16,7 +16,7 @@ type Session struct {
 	pendingPermRequest *PermBridgeRequest
 }
 
-func (s *Session) Start(params BuildParams, messages []core.Message) error {
+func (s *Task) Start(params BuildParams, messages []core.Message) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -42,13 +42,13 @@ func (s *Session) Start(params BuildParams, messages []core.Message) error {
 	return nil
 }
 
-func (s *Session) Stop() {
+func (s *Task) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stopLocked()
 }
 
-func (s *Session) stopLocked() {
+func (s *Task) stopLocked() {
 	if s.agent == nil {
 		return
 	}
@@ -65,13 +65,13 @@ func (s *Session) stopLocked() {
 	s.pendingPermRequest = nil
 }
 
-func (s *Session) Active() bool {
+func (s *Task) Active() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.agent != nil
 }
 
-func (s *Session) Send(content string, images []core.Image) {
+func (s *Task) Send(content string, images []core.Image) {
 	s.mu.RLock()
 	ag := s.agent
 	s.mu.RUnlock()
@@ -81,7 +81,7 @@ func (s *Session) Send(content string, images []core.Image) {
 	ag.Inbox() <- core.Message{Role: core.RoleUser, Content: content, Images: images}
 }
 
-func (s *Session) Outbox() <-chan core.Event {
+func (s *Task) Outbox() <-chan core.Event {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {
@@ -90,25 +90,25 @@ func (s *Session) Outbox() <-chan core.Event {
 	return s.agent.Outbox()
 }
 
-func (s *Session) PermissionBridge() *PermissionBridge {
+func (s *Task) PermissionBridge() *PermissionBridge {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.permBridge
 }
 
-func (s *Session) PendingPermission() *PermBridgeRequest {
+func (s *Task) PendingPermission() *PermBridgeRequest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.pendingPermRequest
 }
 
-func (s *Session) SetPendingPermission(req *PermBridgeRequest) {
+func (s *Task) SetPendingPermission(req *PermBridgeRequest) {
 	s.mu.Lock()
 	s.pendingPermRequest = req
 	s.mu.Unlock()
 }
 
-func (s *Session) System() core.System {
+func (s *Task) System() core.System {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -8,7 +8,7 @@ import (
 	"github.com/genai-io/gen-code/internal/core"
 )
 
-type service struct {
+type Session struct {
 	mu                 sync.RWMutex
 	agent              core.Agent
 	permBridge         *PermissionBridge
@@ -16,7 +16,7 @@ type service struct {
 	pendingPermRequest *PermBridgeRequest
 }
 
-func (s *service) Start(params BuildParams, messages []core.Message) error {
+func (s *Session) Start(params BuildParams, messages []core.Message) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -42,13 +42,13 @@ func (s *service) Start(params BuildParams, messages []core.Message) error {
 	return nil
 }
 
-func (s *service) Stop() {
+func (s *Session) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stopLocked()
 }
 
-func (s *service) stopLocked() {
+func (s *Session) stopLocked() {
 	if s.agent == nil {
 		return
 	}
@@ -65,13 +65,13 @@ func (s *service) stopLocked() {
 	s.pendingPermRequest = nil
 }
 
-func (s *service) Active() bool {
+func (s *Session) Active() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.agent != nil
 }
 
-func (s *service) Send(content string, images []core.Image) {
+func (s *Session) Send(content string, images []core.Image) {
 	s.mu.RLock()
 	ag := s.agent
 	s.mu.RUnlock()
@@ -81,7 +81,7 @@ func (s *service) Send(content string, images []core.Image) {
 	ag.Inbox() <- core.Message{Role: core.RoleUser, Content: content, Images: images}
 }
 
-func (s *service) Outbox() <-chan core.Event {
+func (s *Session) Outbox() <-chan core.Event {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {
@@ -90,25 +90,25 @@ func (s *service) Outbox() <-chan core.Event {
 	return s.agent.Outbox()
 }
 
-func (s *service) PermissionBridge() *PermissionBridge {
+func (s *Session) PermissionBridge() *PermissionBridge {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.permBridge
 }
 
-func (s *service) PendingPermission() *PermBridgeRequest {
+func (s *Session) PendingPermission() *PermBridgeRequest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.pendingPermRequest
 }
 
-func (s *service) SetPendingPermission(req *PermBridgeRequest) {
+func (s *Session) SetPendingPermission(req *PermBridgeRequest) {
 	s.mu.Lock()
 	s.pendingPermRequest = req
 	s.mu.Unlock()
 }
 
-func (s *service) System() core.System {
+func (s *Session) System() core.System {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -1,4 +1,4 @@
-// Agent session lifecycle: building params, delegating to agent.Service,
+// Agent session lifecycle: building params, delegating to *agent.Session,
 // and wrapping channels in tea.Cmds for the TUI.
 package app
 

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -1,4 +1,4 @@
-// Agent session lifecycle: building params, delegating to *agent.Session,
+// Agent session lifecycle: building params, delegating to *agent.Task,
 // and wrapping channels in tea.Cmds for the TUI.
 package app
 

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -47,7 +47,7 @@ type env struct {
 	CachedProjectInstructions string
 }
 
-func newEnv(llmSvc *llm.Hub, cwd string, isGit bool) env {
+func newEnv(llmSvc *llm.ClientFactory, cwd string, isGit bool) env {
 	return env{
 		CWD:   cwd,
 		IsGit: isGit,

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -47,7 +47,7 @@ type env struct {
 	CachedProjectInstructions string
 }
 
-func newEnv(llmSvc llm.Service, cwd string, isGit bool) env {
+func newEnv(llmSvc *llm.Hub, cwd string, isGit bool) env {
 	return env{
 		CWD:   cwd,
 		IsGit: isGit,

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -136,7 +136,7 @@ func pluginMCPServers() []mcp.PluginServer {
 	return servers
 }
 
-func commandSuggestionMatcher(cmdSvc command.Service) func(string) []suggest.Suggestion {
+func commandSuggestionMatcher(cmdSvc *command.Registry) func(string) []suggest.Suggestion {
 	return func(query string) []suggest.Suggestion {
 		cmds := cmdSvc.GetMatching(query)
 		result := make([]suggest.Suggestion, len(cmds))

--- a/internal/app/input/approval_flow.go
+++ b/internal/app/input/approval_flow.go
@@ -34,7 +34,7 @@ type ApprovalFlowDeps struct {
 	Actions            ApprovalRuntime
 	Input              *Model
 	HookEngine         hook.Handler
-	Settings           *setting.Settings
+	Settings           *setting.Data
 	SessionPermissions *setting.SessionPermissions
 	SetOperationMode   func(setting.OperationMode)
 	Tool               *conv.ToolExecState

--- a/internal/app/input/model.go
+++ b/internal/app/input/model.go
@@ -95,7 +95,7 @@ type SelectorDeps struct {
 	MCPRegistry      *coremcp.Registry
 	PluginRegistry   *coreplugin.Registry
 	IdentityRegistry *coreidentity.Registry
-	Setting          coresetting.Service
+	Setting          *coresetting.Manager
 	LoadDisabled     func(userLevel bool) map[string]bool
 	UpdateDisabled   func(disabled map[string]bool, userLevel bool) error
 }

--- a/internal/app/input/model.go
+++ b/internal/app/input/model.go
@@ -95,7 +95,7 @@ type SelectorDeps struct {
 	MCPRegistry      *coremcp.Registry
 	PluginRegistry   *coreplugin.Registry
 	IdentityRegistry *coreidentity.Registry
-	Setting          *coresetting.Manager
+	Setting          *coresetting.Settings
 	LoadDisabled     func(userLevel bool) map[string]bool
 	UpdateDisabled   func(disabled map[string]bool, userLevel bool) error
 }

--- a/internal/app/input/on_search.go
+++ b/internal/app/input/on_search.go
@@ -36,14 +36,14 @@ type SearchSelector struct {
 	width       int
 	height      int
 	store       *llm.Store
-	settingSvc  setting.Service
+	settingSvc  *setting.Manager
 
 	apiKeyActive bool
 	apiKeyEnvVar string
 	apiKeyInput  textinput.Model
 }
 
-func NewSearchSelector(settingSvc setting.Service) SearchSelector {
+func NewSearchSelector(settingSvc *setting.Manager) SearchSelector {
 	return SearchSelector{settingSvc: settingSvc}
 }
 

--- a/internal/app/input/on_search.go
+++ b/internal/app/input/on_search.go
@@ -36,14 +36,14 @@ type SearchSelector struct {
 	width       int
 	height      int
 	store       *llm.Store
-	settingSvc  *setting.Manager
+	settingSvc  *setting.Settings
 
 	apiKeyActive bool
 	apiKeyEnvVar string
 	apiKeyInput  textinput.Model
 }
 
-func NewSearchSelector(settingSvc *setting.Manager) SearchSelector {
+func NewSearchSelector(settingSvc *setting.Settings) SearchSelector {
 	return SearchSelector{settingSvc: settingSvc}
 }
 

--- a/internal/app/input/on_token_limits.go
+++ b/internal/app/input/on_token_limits.go
@@ -22,7 +22,7 @@ type TokenLimitDeps struct {
 	InputTokens  int
 	Cwd          string
 	SpinnerTick  tea.Cmd
-	ToolSvc      tool.Service
+	ToolSvc      *tool.Registry
 }
 
 // HandleTokenLimitCommand processes the /tokenlimit slash command.
@@ -97,7 +97,7 @@ type autoFetchTokenLimitsDeps struct {
 	Store        *llm.Store
 	CurrentModel *llm.CurrentModelInfo
 	Cwd          string
-	ToolSvc      tool.Service
+	ToolSvc      *tool.Registry
 }
 
 func autoFetchTokenLimits(ctx context.Context, deps autoFetchTokenLimitsDeps) (string, error) {
@@ -203,7 +203,7 @@ func getTokenLimitAgentTools() []llm.ToolSchema {
 	}
 }
 
-func appendToolCallMessages(ctx context.Context, messages []core.Message, toolCalls []core.ToolCall, cwd string, toolSvc tool.Service) []core.Message {
+func appendToolCallMessages(ctx context.Context, messages []core.Message, toolCalls []core.ToolCall, cwd string, toolSvc *tool.Registry) []core.Message {
 	messages = append(messages, core.AssistantMessage("", "", toolCalls))
 
 	for _, tc := range toolCalls {

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -47,9 +47,9 @@ type CommandDeps struct {
 	Plugin  *plugin.Registry
 	MCP     *mcp.Registry
 	Tracker tracker.Service
-	Cron    cron.Service
-	ToolSvc tool.Service
-	Command command.Service
+	Cron    *cron.Scheduler
+	ToolSvc *tool.Registry
+	Command *command.Registry
 
 	// State getters (values that may change during command execution)
 	GetSessionID      func() string
@@ -547,7 +547,7 @@ func (c *CommandController) handleLoopCommand(_ context.Context, args string) (s
 	return "", c.deps.StartProviderTurn(parsed.Prompt), nil
 }
 
-func handleLoopAdminCommand(cronSvc cron.Service, args string) (string, bool, error) {
+func handleLoopAdminCommand(cronSvc *cron.Scheduler, args string) (string, bool, error) {
 	fields := strings.Fields(args)
 	if len(fields) == 0 {
 		return "", false, nil
@@ -581,7 +581,7 @@ func handleLoopAdminCommand(cronSvc cron.Service, args string) (string, bool, er
 	}
 }
 
-func renderLoopJobList(cronSvc cron.Service) string {
+func renderLoopJobList(cronSvc *cron.Scheduler) string {
 	jobs := cronSvc.List()
 	if len(jobs) == 0 {
 		return "No scheduled loop tasks."

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -23,20 +23,20 @@ import (
 // model at construction time. Model methods access services through this
 // struct instead of calling Default() package-level accessors directly.
 type services struct {
-	Setting  setting.Service
-	LLM      llm.Service
-	Tool     tool.Service
+	Setting  *setting.Manager
+	LLM      *llm.Hub
+	Tool     *tool.Registry
 	Hook     *hook.Engine
 	Session  *session.Setup
 	Skill    *skill.Registry
 	Subagent *subagent.Registry
-	Command  command.Service
-	Task     task.Service
+	Command  *command.Registry
+	Task     *task.Tracker
 	Tracker  tracker.Service
-	Cron     cron.Service
+	Cron     *cron.Scheduler
 	MCP      *mcp.Registry
 	Plugin   *plugin.Registry
-	Agent    agent.Service
+	Agent    *agent.Session
 	Identity *identity.Registry
 	Reminder *reminder.Service
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -23,8 +23,8 @@ import (
 // model at construction time. Model methods access services through this
 // struct instead of calling Default() package-level accessors directly.
 type services struct {
-	Setting  *setting.Manager
-	LLM      *llm.Hub
+	Setting  *setting.Settings
+	LLM      *llm.ClientFactory
 	Tool     *tool.Registry
 	Hook     *hook.Engine
 	Session  *session.Setup
@@ -36,7 +36,7 @@ type services struct {
 	Cron     *cron.Scheduler
 	MCP      *mcp.Registry
 	Plugin   *plugin.Registry
-	Agent    *agent.Session
+	Agent    *agent.Task
 	Identity *identity.Registry
 	Reminder *reminder.Service
 }

--- a/internal/app/trigger/update.go
+++ b/internal/app/trigger/update.go
@@ -11,7 +11,7 @@ import (
 // Deps holds the app-level state and callbacks needed to process Source 3 input.
 type Deps struct {
 	StreamActive bool
-	Cron         cron.Service
+	Cron         *cron.Scheduler
 	InjectCron   func(string) tea.Cmd
 	InjectHook   func(AsyncHookRewake) tea.Cmd
 	AppendNotice func(string)
@@ -83,7 +83,7 @@ type CronResult struct {
 	Notices      []string
 }
 
-func (s *Model) HandleCronTick(cronSvc cron.Service, isIdle bool) CronResult {
+func (s *Model) HandleCronTick(cronSvc *cron.Scheduler, isIdle bool) CronResult {
 	var result CronResult
 
 	if cronSvc == nil || (cronSvc.Empty() && len(s.CronQueue) == 0) {

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -109,7 +109,7 @@ func (cc *CustomCommand) GetInstructions() string {
 }
 
 // service is the internal implementation of Service.
-type service struct {
+type Registry struct {
 	mu                   sync.RWMutex
 	cwd                  string
 	cachedCustomCommands []CustomCommand
@@ -117,7 +117,7 @@ type service struct {
 	pluginCommandPaths   func() []PluginCommandPath
 }
 
-func (s *service) BuiltinNames() map[string]Info {
+func (s *Registry) BuiltinNames() map[string]Info {
 	cmds := builtinCommands()
 	m := make(map[string]Info, len(cmds))
 	for _, c := range cmds {
@@ -126,7 +126,7 @@ func (s *service) BuiltinNames() map[string]Info {
 	return m
 }
 
-func (s *service) Get(name string) (Info, bool) {
+func (s *Registry) Get(name string) (Info, bool) {
 	// Check builtins first.
 	builtins := s.BuiltinNames()
 	if info, ok := builtins[name]; ok {
@@ -149,7 +149,7 @@ func (s *service) Get(name string) (Info, bool) {
 	return Info{}, false
 }
 
-func (s *service) List() []Info {
+func (s *Registry) List() []Info {
 	seen := make(map[string]bool)
 	var all []Info
 
@@ -181,11 +181,11 @@ func (s *service) List() []Info {
 	return all
 }
 
-func (s *service) ListCustom() []CustomCommand {
+func (s *Registry) ListCustom() []CustomCommand {
 	return s.loadAllCustomCommands()
 }
 
-func (s *service) GetMatching(prefix string) []Info {
+func (s *Registry) GetMatching(prefix string) []Info {
 	query := strings.ToLower(strings.TrimPrefix(prefix, "/"))
 	matches := make([]Info, 0)
 	seen := make(map[string]bool)
@@ -224,7 +224,7 @@ func (s *service) GetMatching(prefix string) []Info {
 	return matches
 }
 
-func (s *service) IsCustomCommand(cmd string) (*CustomCommand, bool) {
+func (s *Registry) IsCustomCommand(cmd string) (*CustomCommand, bool) {
 	for _, c := range s.loadAllCustomCommands() {
 		if c.FullName() == cmd || c.Name == cmd {
 			return &c, true
@@ -233,7 +233,7 @@ func (s *service) IsCustomCommand(cmd string) (*CustomCommand, bool) {
 	return nil, false
 }
 
-func (s *service) GetCustomCommands() []Info {
+func (s *Registry) GetCustomCommands() []Info {
 	cmds := s.loadAllCustomCommands()
 	infos := make([]Info, 0, len(cmds))
 	for _, c := range cmds {
@@ -245,7 +245,7 @@ func (s *service) GetCustomCommands() []Info {
 	return infos
 }
 
-func (s *service) getDynamicInfoProviders() []func() []Info {
+func (s *Registry) getDynamicInfoProviders() []func() []Info {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return append([]func() []Info(nil), s.dynamicInfoProviders...)
@@ -253,7 +253,7 @@ func (s *service) getDynamicInfoProviders() []func() []Info {
 
 // loadAllCustomCommands returns custom commands from all sources, using cache
 // when available. The cache is invalidated by Initialize.
-func (s *service) loadAllCustomCommands() []CustomCommand {
+func (s *Registry) loadAllCustomCommands() []CustomCommand {
 	s.mu.RLock()
 	if s.cachedCustomCommands != nil {
 		defer s.mu.RUnlock()
@@ -276,7 +276,7 @@ func (s *service) loadAllCustomCommands() []CustomCommand {
 // 3. .gen/plugins/*/commands/   (project-plugin)
 // 4. .gen/commands/          (project level, highest priority)
 // Higher-priority commands override lower-priority ones with the same full name.
-func (s *service) loadCustomCommandsFromDisk() []CustomCommand {
+func (s *Registry) loadCustomCommandsFromDisk() []CustomCommand {
 	cmdMap := make(map[string]CustomCommand)
 
 	homeDir, _ := os.UserHomeDir()

--- a/internal/command/registry_test.go
+++ b/internal/command/registry_test.go
@@ -9,37 +9,29 @@ import (
 // saveAndRestore saves current singleton state and restores it on cleanup.
 func saveAndRestore(t *testing.T) {
 	t.Helper()
-	mu.RLock()
-	prev := instance
-	mu.RUnlock()
-	t.Cleanup(func() {
-		mu.Lock()
-		instance = prev
-		mu.Unlock()
-	})
+	prev := defaultRegistry
+	t.Cleanup(func() { SetDefaultRegistry(prev) })
 }
 
 // initTestService creates a fresh service and sets it as the singleton.
-func initTestService(t *testing.T, cwd string, opts ...func(*service)) *service {
+func initTestService(t *testing.T, cwd string, opts ...func(*Registry)) *Registry {
 	t.Helper()
-	s := &service{cwd: cwd}
+	s := &Registry{cwd: cwd}
 	for _, opt := range opts {
 		opt(s)
 	}
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+	SetDefaultRegistry(s)
 	return s
 }
 
-func withDynamicProviders(providers ...func() []Info) func(*service) {
-	return func(s *service) {
+func withDynamicProviders(providers ...func() []Info) func(*Registry) {
+	return func(s *Registry) {
 		s.dynamicInfoProviders = append([]func() []Info(nil), providers...)
 	}
 }
 
-func withPluginCommandPaths(fn func() []PluginCommandPath) func(*service) {
-	return func(s *service) {
+func withPluginCommandPaths(fn func() []PluginCommandPath) func(*Registry) {
+	return func(s *Registry) {
 		s.pluginCommandPaths = fn
 	}
 }

--- a/internal/command/service.go
+++ b/internal/command/service.go
@@ -1,24 +1,6 @@
+// Package command is the registry of slash commands (built-in, dynamic,
+// custom, plugin-scoped). Exposes *Registry directly.
 package command
-
-import "sync"
-
-// Service is the public contract for the command module.
-type Service interface {
-	// Get returns a command by exact name (builtin, dynamic, or custom).
-	Get(name string) (Info, bool)
-	// List returns all commands (builtin + dynamic + custom).
-	List() []Info
-	// ListCustom returns all custom (user-defined) commands.
-	ListCustom() []CustomCommand
-	// GetMatching returns commands whose names fuzzy-match the given prefix.
-	GetMatching(prefix string) []Info
-	// IsCustomCommand checks whether the given command name matches a custom command.
-	IsCustomCommand(cmd string) (*CustomCommand, bool)
-	// BuiltinNames returns the set of built-in command names.
-	BuiltinNames() map[string]Info
-	// GetCustomCommands returns Info entries for all custom commands.
-	GetCustomCommands() []Info
-}
 
 // PluginCommandPath describes a custom command file provided by a plugin.
 type PluginCommandPath struct {
@@ -34,48 +16,34 @@ type Options struct {
 	PluginCommandPaths func() []PluginCommandPath // injected plugin callback
 }
 
-var _ Service = (*service)(nil)
-
-// Initialize creates the command service and sets the singleton.
+// Initialize creates and installs the package-level *Registry.
 func Initialize(opts Options) {
-	s := &service{
+	defaultRegistry = &Registry{
 		cwd:                  opts.CWD,
 		dynamicInfoProviders: opts.DynamicProviders,
 		pluginCommandPaths:   opts.PluginCommandPaths,
 	}
-	mu.Lock()
-	instance = s
-	mu.Unlock()
 }
 
-// ── singleton ──────────────────────────────────────────────
+// Default returns the package-level *Registry.
+func Default() *Registry {
+	return defaultRegistry
+}
 
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance. Panics if not initialized.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
+// SetDefaultRegistry replaces the package-level *Registry. Intended for
+// tests. A nil argument restores a fresh empty *Registry.
+func SetDefaultRegistry(s *Registry) {
 	if s == nil {
-		panic("command: not initialized")
+		defaultRegistry = &Registry{}
+		return
 	}
-	return s
+	defaultRegistry = s
 }
 
-// SetDefault replaces the singleton (for tests).
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultRegistry restores a fresh empty *Registry. Intended for
+// tests.
+func ResetDefaultRegistry() {
+	defaultRegistry = &Registry{}
 }
 
-// ResetService clears the singleton (for tests).
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultRegistry = &Registry{}

--- a/internal/cron/cron_test.go
+++ b/internal/cron/cron_test.go
@@ -71,7 +71,7 @@ func TestDescribe(t *testing.T) {
 }
 
 func TestStoreCreateAndList(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 	job, err := store.Create("*/5 * * * *", "test prompt", true, false)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
@@ -90,7 +90,7 @@ func TestStoreCreateAndList(t *testing.T) {
 }
 
 func TestStoreDelete(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 	job, _ := store.Create("*/5 * * * *", "to delete", true, false)
 	if err := store.Delete(job.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
@@ -101,7 +101,7 @@ func TestStoreDelete(t *testing.T) {
 }
 
 func TestStoreTick(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 	// Create a one-shot job
 	job, _ := store.Create("* * * * *", "fire me", false, false)
 
@@ -125,7 +125,7 @@ func TestStoreTick(t *testing.T) {
 }
 
 func TestStore_maxJobs(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 	for i := 0; i < maxJobs; i++ {
 		_, err := store.Create("*/5 * * * *", "job", true, false)
 		if err != nil {
@@ -162,7 +162,7 @@ func TestCron_InvalidExpression_ReturnsError(t *testing.T) {
 }
 
 func TestCron_Once_RemovedAfterFiring(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 
 	// Create a non-recurring (one-shot) job
 	job, err := store.Create("* * * * *", "fire once", false, false)
@@ -200,7 +200,7 @@ func TestStoreDurable(t *testing.T) {
 	tmpFile := t.TempDir() + "/scheduled_tasks.json"
 
 	// Create a store with durable job
-	store := NewStore()
+	store := NewScheduler()
 	store.SetStoragePath(tmpFile)
 	job, err := store.Create("*/10 * * * *", "durable prompt", true, true)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestStoreDurable(t *testing.T) {
 	}
 
 	// Load into a fresh store
-	store2 := NewStore()
+	store2 := NewScheduler()
 	store2.SetStoragePath(tmpFile)
 	if err := store2.LoadDurable(); err != nil {
 		t.Fatalf("LoadDurable failed: %v", err)
@@ -230,7 +230,7 @@ func TestStoreDurable(t *testing.T) {
 }
 
 func TestStoreTick_RecurringJobReschedulesAndTracksFireCount(t *testing.T) {
-	store := NewStore()
+	store := NewScheduler()
 	job, err := store.Create("* * * * *", "repeat me", true, false)
 	if err != nil {
 		t.Fatalf("Create recurring job failed: %v", err)
@@ -266,7 +266,7 @@ func TestStoreTick_RecurringJobReschedulesAndTracksFireCount(t *testing.T) {
 func TestStoreDelete_DurableRemovesPersistedJob(t *testing.T) {
 	tmpFile := t.TempDir() + "/scheduled_tasks.json"
 
-	store := NewStore()
+	store := NewScheduler()
 	store.SetStoragePath(tmpFile)
 	job, err := store.Create("*/10 * * * *", "durable prompt", true, true)
 	if err != nil {
@@ -294,7 +294,7 @@ func TestStoreDelete_DurableRemovesPersistedJob(t *testing.T) {
 func TestStoreTick_DurableRecurringPersistsUpdatedState(t *testing.T) {
 	tmpFile := t.TempDir() + "/scheduled_tasks.json"
 
-	store := NewStore()
+	store := NewScheduler()
 	store.SetStoragePath(tmpFile)
 	job, err := store.Create("* * * * *", "durable repeat", true, true)
 	if err != nil {
@@ -372,7 +372,7 @@ func TestComputeNextFire_OneShotDoesNotAddJitter(t *testing.T) {
 func TestLoadDurable_OneShotPastDueFiresOnNextTick(t *testing.T) {
 	tmpFile := t.TempDir() + "/scheduled_tasks.json"
 
-	store := NewStore()
+	store := NewScheduler()
 	store.SetStoragePath(tmpFile)
 	job, err := store.Create("30 9 28 2 *", "missed once", false, true)
 	if err != nil {
@@ -384,7 +384,7 @@ func TestLoadDurable_OneShotPastDueFiresOnNextTick(t *testing.T) {
 	store.saveDurableLocked()
 	store.mu.Unlock()
 
-	store2 := NewStore()
+	store2 := NewScheduler()
 	store2.SetStoragePath(tmpFile)
 	if err := store2.LoadDurable(); err != nil {
 		t.Fatalf("LoadDurable failed: %v", err)

--- a/internal/cron/service.go
+++ b/internal/cron/service.go
@@ -1,76 +1,39 @@
+// Package cron schedules recurring and one-shot jobs that fire user
+// prompts back into the agent loop. Exposes *Scheduler directly.
 package cron
 
-import "sync"
-
-// Service is the public contract for the cron module.
-type Service interface {
-	// CRUD
-	Add(job Job) error
-	Remove(id string) bool
-	Create(cronExpr, prompt string, recurring, durable bool) (*Job, error)
-	Delete(id string) error
-	List() []*Job
-
-	// runtime
-	Tick() []FiredJob // advance clock, return fired jobs
-
-	// query
-	Empty() bool
-
-	// lifecycle
-	Reset()
-	SetStoragePath(path string)
-	LoadDurable() error
-}
-
-// Compile-time check: *Store implements Service.
-var _ Service = (*Store)(nil)
-
-// ── singleton ──────────────────────────────────────────────
-
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Options configures the cron service singleton.
+// Options configures the package-level *Scheduler.
 type Options struct {
 	StoragePath string // file path for durable job persistence
 }
 
-// Initialize creates and configures the cron service singleton.
+// Initialize creates and configures the package-level *Scheduler.
 func Initialize(opts Options) {
-	s := NewStore()
+	s := NewScheduler()
 	if opts.StoragePath != "" {
 		s.SetStoragePath(opts.StoragePath)
 	}
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+	defaultScheduler = s
 }
 
-// Default returns the singleton Service instance.
-// Panics if not initialized.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
+// Default returns the package-level *Scheduler.
+func Default() *Scheduler {
+	return defaultScheduler
+}
+
+// SetDefaultScheduler replaces the package-level *Scheduler. Intended for tests.
+// A nil argument restores a fresh empty *Scheduler.
+func SetDefaultScheduler(s *Scheduler) {
 	if s == nil {
-		panic("cron: not initialized")
+		defaultScheduler = NewScheduler()
+		return
 	}
-	return s
+	defaultScheduler = s
 }
 
-// SetDefault sets the singleton Service instance (for tests).
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultScheduler restores a fresh empty *Scheduler. Intended for tests.
+func ResetDefaultScheduler() {
+	defaultScheduler = NewScheduler()
 }
 
-// ResetService clears the singleton (for tests).
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultScheduler = NewScheduler()

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -44,27 +44,24 @@ type Job struct {
 	expr *expression // parsed expression (not serialized)
 }
 
-// Store manages cron jobs with thread-safe access.
+// Scheduler manages cron jobs with thread-safe access.
 // Session-only jobs are cleared when the process exits.
 // Durable jobs persist to storagePath across sessions.
-type Store struct {
+type Scheduler struct {
 	mu          sync.RWMutex
 	jobs        map[string]*Job
 	storagePath string // file path for durable job persistence (empty = disabled)
 }
 
-// Compile-time check that *Store implements Service.
-var _ Service = (*Store)(nil)
-
-// NewStore creates a new in-memory cron store.
-func NewStore() *Store {
-	return &Store{
+// NewScheduler creates a new in-memory *Scheduler.
+func NewScheduler() *Scheduler {
+	return &Scheduler{
 		jobs: make(map[string]*Job),
 	}
 }
 
 // Create adds a new cron job and returns it.
-func (s *Store) Create(cronExpr, prompt string, recurring, durable bool) (*Job, error) {
+func (s *Scheduler) Create(cronExpr, prompt string, recurring, durable bool) (*Job, error) {
 	expr, err := parse(cronExpr)
 	if err != nil {
 		return nil, err
@@ -109,7 +106,7 @@ func (s *Store) Create(cronExpr, prompt string, recurring, durable bool) (*Job, 
 }
 
 // Delete removes a job by ID.
-func (s *Store) Delete(id string) error {
+func (s *Scheduler) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -127,7 +124,7 @@ func (s *Store) Delete(id string) error {
 }
 
 // List returns copies of all active jobs sorted by next fire time.
-func (s *Store) List() []*Job {
+func (s *Scheduler) List() []*Job {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -144,7 +141,7 @@ func (s *Store) List() []*Job {
 }
 
 // Empty returns true if the store has no jobs.
-func (s *Store) Empty() bool {
+func (s *Scheduler) Empty() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.jobs) == 0
@@ -152,7 +149,7 @@ func (s *Store) Empty() bool {
 
 // Tick checks all jobs and returns prompts for any that should fire now.
 // It advances fired jobs to their next fire time or removes one-shot/expired jobs.
-func (s *Store) Tick() []FiredJob {
+func (s *Scheduler) Tick() []FiredJob {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -223,7 +220,7 @@ type FiredJob struct {
 
 // Add adds a pre-built job to the store, satisfying the Service interface.
 // The job must have a valid cron expression in the Cron field.
-func (s *Store) Add(job Job) error {
+func (s *Scheduler) Add(job Job) error {
 	expr, err := parse(job.Cron)
 	if err != nil {
 		return err
@@ -269,7 +266,7 @@ func (s *Store) Add(job Job) error {
 
 // Remove removes a job by ID, satisfying the Service interface.
 // Returns true if the job was found and removed.
-func (s *Store) Remove(id string) bool {
+func (s *Scheduler) Remove(id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -287,7 +284,7 @@ func (s *Store) Remove(id string) bool {
 }
 
 // Reset removes all jobs.
-func (s *Store) Reset() {
+func (s *Scheduler) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.jobs = make(map[string]*Job)
@@ -296,14 +293,14 @@ func (s *Store) Reset() {
 
 // SetStoragePath sets the file path for durable job persistence.
 // Call LoadDurable() after this to restore previously saved jobs.
-func (s *Store) SetStoragePath(path string) {
+func (s *Scheduler) SetStoragePath(path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.storagePath = path
 }
 
 // LoadDurable reads durable jobs from the storage file and merges them into the store.
-func (s *Store) LoadDurable() error {
+func (s *Scheduler) LoadDurable() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -407,7 +404,7 @@ func estimateRecurringPeriod(expr *expression, base time.Time) time.Duration {
 
 // saveDurableLocked writes all durable jobs to the storage file.
 // Must be called with s.mu held.
-func (s *Store) saveDurableLocked() {
+func (s *Scheduler) saveDurableLocked() {
 	if s.storagePath == "" {
 		return
 	}

--- a/internal/hook/engine.go
+++ b/internal/hook/engine.go
@@ -39,7 +39,7 @@ const defaultTimeout = 600
 
 // Engine executes hooks from settings, plugins, and runtime/session registration.
 type Engine struct {
-	settings       *setting.Settings
+	settings       *setting.Data
 	sessionID      string
 	cwd            string
 	transcriptPath string
@@ -60,7 +60,7 @@ type Engine struct {
 }
 
 // NewEngine creates a new hook execution engine.
-func NewEngine(settings *setting.Settings, sessionID, cwd, transcriptPath string) *Engine {
+func NewEngine(settings *setting.Data, sessionID, cwd, transcriptPath string) *Engine {
 	return &Engine{
 		settings:       settings,
 		sessionID:      sessionID,
@@ -143,7 +143,7 @@ func (e *Engine) SetEnvProvider(fn func() []string) {
 
 // SetSettings swaps the settings-backed hook source used by the engine.
 // Callers should merge plugin hooks into settings before calling this.
-func (e *Engine) SetSettings(settings *setting.Settings) {
+func (e *Engine) SetSettings(settings *setting.Data) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.settings = settings

--- a/internal/hook/hooks_test.go
+++ b/internal/hook/hooks_test.go
@@ -123,7 +123,7 @@ func Test_eventSupportsMatcher(t *testing.T) {
 }
 
 func TestEngineNoHooks(t *testing.T) {
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	engine := NewEngine(settings, "test-session", "/tmp", "")
 
 	outcome := engine.Execute(context.Background(), PreToolUse, HookInput{ToolName: "Bash"})
@@ -147,7 +147,7 @@ func TestEngineNilSettings(t *testing.T) {
 }
 
 func TestEngineHasHooks(t *testing.T) {
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["Stop"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: "echo done"}}},
 	}
@@ -163,7 +163,7 @@ func TestEngineHasHooks(t *testing.T) {
 }
 
 func TestMatchesIfConditionMatchesBashSubcommands(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", "/tmp/repo", "")
+	engine := NewEngine(setting.NewData(), "test-session", "/tmp/repo", "")
 	cmd := setting.HookCmd{If: "Bash(git:*)"}
 	input := HookInput{
 		HookEventName: string(PreToolUse),
@@ -177,7 +177,7 @@ func TestMatchesIfConditionMatchesBashSubcommands(t *testing.T) {
 }
 
 func TestEngineRuntimeAndSessionHooks(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", "/tmp", "")
+	engine := NewEngine(setting.NewData(), "test-session", "/tmp", "")
 	engine.store.AddRuntimeHook(PreToolUse, "Bash", setting.HookCmd{Type: "command", Command: "echo runtime"})
 	engine.store.AddSessionHook(Stop, "", setting.HookCmd{Type: "command", Command: "echo session"})
 	engine.AddRuntimeFunctionHook(StopFailure, "", FunctionHook{
@@ -219,7 +219,7 @@ func TestEngineRuntimeAndSessionHooks(t *testing.T) {
 }
 
 func TestEngineSessionFunctionHook(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", "/tmp", "")
+	engine := NewEngine(setting.NewData(), "test-session", "/tmp", "")
 	id := engine.AddSessionFunctionHook(PreToolUse, "Bash", FunctionHook{
 		Callback: func(_ context.Context, input HookInput) (HookOutput, error) {
 			if input.ToolName != "Bash" {
@@ -245,7 +245,7 @@ func TestEngineSessionFunctionHook(t *testing.T) {
 }
 
 func TestEngineRemoveSessionFunctionHook(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", "/tmp", "")
+	engine := NewEngine(setting.NewData(), "test-session", "/tmp", "")
 	id := engine.AddSessionFunctionHook(Stop, "", FunctionHook{
 		ID: "fn-stop",
 		Callback: func(_ context.Context, _ HookInput) (HookOutput, error) {
@@ -277,7 +277,7 @@ echo '{"systemMessage":"hook executed"}'
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{
 			Matcher: "Bash",
@@ -310,7 +310,7 @@ echo '{"systemMessage":"hook executed"}'
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{
 			Hooks: []setting.HookCmd{{
@@ -351,7 +351,7 @@ exit 2
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -382,7 +382,7 @@ echo '{"continue":false,"stopReason":"Denied by hook"}'
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -416,7 +416,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":` + str
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -447,7 +447,7 @@ echo "{\"systemMessage\":\"GEN=$GEN_PROJECT_DIR CLAUDE=$CLAUDE_PROJECT_DIR\"}"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["Stop"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -463,7 +463,7 @@ echo "{\"systemMessage\":\"GEN=$GEN_PROJECT_DIR CLAUDE=$CLAUDE_PROJECT_DIR\"}"
 }
 
 func TestEnginePermissionMode(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", "/tmp", "")
+	engine := NewEngine(setting.NewData(), "test-session", "/tmp", "")
 
 	engine.SetPermissionMode("auto")
 
@@ -482,7 +482,7 @@ exec sleep 30
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	// Timeout of 1 second — the sleep process will be killed after 1s
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath, Timeout: 1}}},
@@ -521,7 +521,7 @@ echo -n "x" >> `+counterFile+`
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath, Once: true}}},
 	}
@@ -555,7 +555,7 @@ cat > `+captureFile+`
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -600,7 +600,7 @@ cat > `+captureFile+`
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionDenied"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -639,7 +639,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"R
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -656,7 +656,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"R
 }
 
 func TestHooks_ExtractWatchPaths(t *testing.T) {
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	engine := NewEngine(settings, "test-session", t.TempDir(), "")
 	engine.AddSessionFunctionHook(SessionStart, "", FunctionHook{
 		Callback: func(_ context.Context, _ HookInput) (HookOutput, error) {
@@ -679,7 +679,7 @@ func TestHooks_ExtractWatchPaths(t *testing.T) {
 }
 
 func TestHooks_MergeWatchPathsFromMultipleHooks(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", t.TempDir(), "")
+	engine := NewEngine(setting.NewData(), "test-session", t.TempDir(), "")
 	engine.AddSessionFunctionHook(SessionStart, "", FunctionHook{
 		ID: "watch-a",
 		Callback: func(_ context.Context, _ HookInput) (HookOutput, error) {
@@ -716,7 +716,7 @@ func TestHooks_MergeWatchPathsFromMultipleHooks(t *testing.T) {
 }
 
 func TestHooks_ExtractInitialUserMessage(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", t.TempDir(), "")
+	engine := NewEngine(setting.NewData(), "test-session", t.TempDir(), "")
 	engine.AddSessionFunctionHook(SessionStart, "", FunctionHook{
 		Callback: func(_ context.Context, _ HookInput) (HookOutput, error) {
 			return HookOutput{
@@ -735,7 +735,7 @@ func TestHooks_ExtractInitialUserMessage(t *testing.T) {
 }
 
 func TestHooks_CurrentStatusMessageTracksActiveHook(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", t.TempDir(), "")
+	engine := NewEngine(setting.NewData(), "test-session", t.TempDir(), "")
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
 	engine.AddSessionFunctionHook(Notification, "", FunctionHook{
@@ -776,7 +776,7 @@ func TestHooks_CurrentStatusMessageTracksActiveHook(t *testing.T) {
 }
 
 func TestHooks_ExtractPermissionDeniedRetry(t *testing.T) {
-	engine := NewEngine(setting.NewSettings(), "test-session", t.TempDir(), "")
+	engine := NewEngine(setting.NewData(), "test-session", t.TempDir(), "")
 	engine.AddSessionFunctionHook(PermissionDenied, "", FunctionHook{
 		Callback: func(_ context.Context, _ HookInput) (HookOutput, error) {
 			return HookOutput{
@@ -804,7 +804,7 @@ echo '{"systemMessage":"injected context from hook"}'
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -829,7 +829,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -849,7 +849,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"
 }
 
 func TestHooks_PromptHook(t *testing.T) {
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{
 			Type:   "prompt",
@@ -869,7 +869,7 @@ func TestHooks_PromptHook(t *testing.T) {
 }
 
 func TestHooks_AgentHook(t *testing.T) {
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{
 			Type:   "agent",
@@ -891,7 +891,7 @@ func TestHooks_AgentHook(t *testing.T) {
 func TestHooks_HTTPHook(t *testing.T) {
 	t.Setenv("HOOK_TOKEN", "token-123")
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{
 			Type:           "http",
@@ -933,7 +933,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -961,7 +961,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -987,7 +987,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1013,7 +1013,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1049,7 +1049,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1085,7 +1085,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1118,7 +1118,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"be
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PermissionRequest"] = []setting.Hook{
 		{Matcher: "*", Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1165,7 +1165,7 @@ fi
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1217,7 +1217,7 @@ fi
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1251,7 +1251,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1296,7 +1296,7 @@ fi
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1342,7 +1342,7 @@ echo "async_done" > `+markerFile+`
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1388,7 +1388,7 @@ exit 2
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath, AsyncRewake: true}}},
 	}
@@ -1429,7 +1429,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1461,7 +1461,7 @@ echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","decision":{"behavior"
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["PreToolUse"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}
@@ -1489,7 +1489,7 @@ cat > `+captureFile+`
 		t.Fatal(err)
 	}
 
-	settings := setting.NewSettings()
+	settings := setting.NewData()
 	settings.Hooks["SessionStart"] = []setting.Hook{
 		{Hooks: []setting.HookCmd{{Type: "command", Command: scriptPath}}},
 	}

--- a/internal/hook/service.go
+++ b/internal/hook/service.go
@@ -49,7 +49,7 @@ var _ Handler = (*Engine)(nil)
 // All fields must be supplied by the caller — the hook package does not reach into
 // global singletons.
 type Options struct {
-	Settings       *setting.Settings
+	Settings       *setting.Data
 	SessionID      string
 	CWD            string
 	TranscriptPath string
@@ -102,5 +102,5 @@ var defaultEngine = newEmptyEngine()
 // newEmptyEngine returns an Engine wired to empty settings — fires no
 // hooks until Initialize installs a real one.
 func newEmptyEngine() *Engine {
-	return NewEngine(setting.NewSettings(), "", "", "")
+	return NewEngine(setting.NewData(), "", "", "")
 }

--- a/internal/hook/store.go
+++ b/internal/hook/store.go
@@ -105,7 +105,7 @@ func (s *hookStore) ClearSessionHooks() {
 	s.executedOnce = make(map[string]struct{})
 }
 
-func (s *hookStore) CollectHooks(event EventType, settings *setting.Settings) []hookSource {
+func (s *hookStore) CollectHooks(event EventType, settings *setting.Data) []hookSource {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -170,7 +170,7 @@ func (s *hookStore) CheckOnce(key string) bool {
 	return true
 }
 
-func (s *hookStore) HasHooks(event EventType, settings *setting.Settings) bool {
+func (s *hookStore) HasHooks(event EventType, settings *setting.Data) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -1,37 +1,22 @@
+// Package llm holds the connected LLM provider plus the registry of
+// available providers/models. Exposes *Hub directly. *Hub
+// wraps the package-level *Setup (mutable provider/model/store under
+// a mutex).
 package llm
 
-import (
-	"context"
-	"sync"
-)
+import "context"
 
-// Service is the public contract for the llm module.
-type Service interface {
-	// connection
-	Provider() Provider              // current active provider
-	SetProvider(p Provider)          // switch provider
-	ModelID() string                 // current model identifier
-	CurrentModel() *CurrentModelInfo // full model metadata
-	SetCurrentModel(info *CurrentModelInfo)
-
-	// factory
-	NewClient(model string, maxTokens int) *Client
-
-	// store
-	Store() *Store // underlying provider persistence store
-
-	// registry
-	ListProviders() map[Name][]Info // all registered providers with status
+// Hub is the concrete handle callers hold. Methods are
+// mutex-protected views over the underlying *Setup.
+type Hub struct {
+	setup *Setup
 }
-
-// Compile-time check: *service implements Service.
-var _ Service = (*service)(nil)
 
 // Options holds configuration for Initialize.
 type Options struct{}
 
 // Initialize discovers and connects to the best available LLM provider,
-// then publishes the result as the singleton Service.
+// then publishes the result as the package-level *Hub.
 func Initialize(opts Options) {
 	store, _ := NewStore()
 	if store == nil {
@@ -72,84 +57,69 @@ func Initialize(opts Options) {
 	setSingleton()
 }
 
-// -- singleton ---------------------------------------------------------------
+// Default returns the package-level *Hub.
+func Default() *Hub {
+	return defaultHub
+}
 
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance.
-// Panics if Initialize has not been called.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
+// SetDefaultHub replaces the package-level *Hub. Intended for
+// tests. A nil argument restores a fresh empty *Hub.
+func SetDefaultHub(s *Hub) {
 	if s == nil {
-		panic("llm: not initialized")
+		defaultHub = &Hub{setup: &Setup{}}
+		return
 	}
-	return s
+	defaultHub = s
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultHub restores a fresh empty *Hub. Intended for
+// tests.
+func ResetDefaultHub() {
+	defaultHub = &Hub{setup: &Setup{}}
 }
 
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultHub = &Hub{setup: defaultSetup}
 
-// -- implementation ----------------------------------------------------------
+// --- methods (mutex-protected views over Setup) ---
 
-// service wraps the Setup struct to satisfy the Service interface.
-type service struct {
-	setup *Setup
-}
-
-func (s *service) Provider() Provider {
+func (s *Hub) Provider() Provider {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.Provider
 }
 
-func (s *service) SetProvider(p Provider) {
+func (s *Hub) SetProvider(p Provider) {
 	s.setup.mu.Lock()
 	defer s.setup.mu.Unlock()
 	s.setup.Provider = p
 }
 
-func (s *service) ModelID() string { return s.setup.ModelID() }
+func (s *Hub) ModelID() string { return s.setup.ModelID() }
 
-func (s *service) CurrentModel() *CurrentModelInfo {
+func (s *Hub) CurrentModel() *CurrentModelInfo {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.CurrentModel
 }
 
-func (s *service) SetCurrentModel(info *CurrentModelInfo) {
+func (s *Hub) SetCurrentModel(info *CurrentModelInfo) {
 	s.setup.mu.Lock()
 	defer s.setup.mu.Unlock()
 	s.setup.CurrentModel = info
 }
 
-func (s *service) Store() *Store {
+func (s *Hub) Store() *Store {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.Store
 }
 
-func (s *service) NewClient(model string, maxTokens int) *Client {
+func (s *Hub) NewClient(model string, maxTokens int) *Client {
 	p := s.Provider()
 	return NewClient(p, model, maxTokens)
 }
 
-func (s *service) ListProviders() map[Name][]Info {
+func (s *Hub) ListProviders() map[Name][]Info {
 	st := s.Store()
 	return GetProvidersWithStatus(st)
 }

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -1,14 +1,14 @@
 // Package llm holds the connected LLM provider plus the registry of
-// available providers/models. Exposes *Hub directly. *Hub
+// available providers/models. Exposes *ClientFactory directly. *ClientFactory
 // wraps the package-level *Setup (mutable provider/model/store under
 // a mutex).
 package llm
 
 import "context"
 
-// Hub is the concrete handle callers hold. Methods are
+// ClientFactory is the concrete handle callers hold. Methods are
 // mutex-protected views over the underlying *Setup.
-type Hub struct {
+type ClientFactory struct {
 	setup *Setup
 }
 
@@ -16,7 +16,7 @@ type Hub struct {
 type Options struct{}
 
 // Initialize discovers and connects to the best available LLM provider,
-// then publishes the result as the package-level *Hub.
+// then publishes the result as the package-level *ClientFactory.
 func Initialize(opts Options) {
 	store, _ := NewStore()
 	if store == nil {
@@ -57,69 +57,69 @@ func Initialize(opts Options) {
 	setSingleton()
 }
 
-// Default returns the package-level *Hub.
-func Default() *Hub {
-	return defaultHub
+// Default returns the package-level *ClientFactory.
+func Default() *ClientFactory {
+	return defaultClientFactory
 }
 
-// SetDefaultHub replaces the package-level *Hub. Intended for
-// tests. A nil argument restores a fresh empty *Hub.
-func SetDefaultHub(s *Hub) {
+// SetDefaultClientFactory replaces the package-level *ClientFactory. Intended for
+// tests. A nil argument restores a fresh empty *ClientFactory.
+func SetDefaultClientFactory(s *ClientFactory) {
 	if s == nil {
-		defaultHub = &Hub{setup: &Setup{}}
+		defaultClientFactory = &ClientFactory{setup: &Setup{}}
 		return
 	}
-	defaultHub = s
+	defaultClientFactory = s
 }
 
-// ResetDefaultHub restores a fresh empty *Hub. Intended for
+// ResetDefaultClientFactory restores a fresh empty *ClientFactory. Intended for
 // tests.
-func ResetDefaultHub() {
-	defaultHub = &Hub{setup: &Setup{}}
+func ResetDefaultClientFactory() {
+	defaultClientFactory = &ClientFactory{setup: &Setup{}}
 }
 
-var defaultHub = &Hub{setup: defaultSetup}
+var defaultClientFactory = &ClientFactory{setup: defaultSetup}
 
 // --- methods (mutex-protected views over Setup) ---
 
-func (s *Hub) Provider() Provider {
+func (s *ClientFactory) Provider() Provider {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.Provider
 }
 
-func (s *Hub) SetProvider(p Provider) {
+func (s *ClientFactory) SetProvider(p Provider) {
 	s.setup.mu.Lock()
 	defer s.setup.mu.Unlock()
 	s.setup.Provider = p
 }
 
-func (s *Hub) ModelID() string { return s.setup.ModelID() }
+func (s *ClientFactory) ModelID() string { return s.setup.ModelID() }
 
-func (s *Hub) CurrentModel() *CurrentModelInfo {
+func (s *ClientFactory) CurrentModel() *CurrentModelInfo {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.CurrentModel
 }
 
-func (s *Hub) SetCurrentModel(info *CurrentModelInfo) {
+func (s *ClientFactory) SetCurrentModel(info *CurrentModelInfo) {
 	s.setup.mu.Lock()
 	defer s.setup.mu.Unlock()
 	s.setup.CurrentModel = info
 }
 
-func (s *Hub) Store() *Store {
+func (s *ClientFactory) Store() *Store {
 	s.setup.mu.RLock()
 	defer s.setup.mu.RUnlock()
 	return s.setup.Store
 }
 
-func (s *Hub) NewClient(model string, maxTokens int) *Client {
+func (s *ClientFactory) NewClient(model string, maxTokens int) *Client {
 	p := s.Provider()
 	return NewClient(p, model, maxTokens)
 }
 
-func (s *Hub) ListProviders() map[Name][]Info {
+func (s *ClientFactory) ListProviders() map[Name][]Info {
 	st := s.Store()
 	return GetProvidersWithStatus(st)
 }

--- a/internal/llm/setup.go
+++ b/internal/llm/setup.go
@@ -3,7 +3,7 @@ package llm
 import "sync"
 
 // defaultSetup is the package-level LLM setup, initialized by Initialize().
-// External callers should use Default() to get the Service singleton.
+// External callers should use Default() to get the *Hub singleton.
 var defaultSetup = &Setup{}
 
 // Setup holds the initialized LLM provider state needed by the app layer.
@@ -14,11 +14,9 @@ type Setup struct {
 	CurrentModel *CurrentModelInfo
 }
 
-// setSingleton publishes defaultSetup as the singleton Service.
+// setSingleton publishes defaultSetup as the package-level *Hub.
 func setSingleton() {
-	mu.Lock()
-	instance = &service{setup: defaultSetup}
-	mu.Unlock()
+	defaultHub = &Hub{setup: defaultSetup}
 }
 
 // ModelID returns the current model ID, or empty string if none.

--- a/internal/llm/setup.go
+++ b/internal/llm/setup.go
@@ -3,7 +3,7 @@ package llm
 import "sync"
 
 // defaultSetup is the package-level LLM setup, initialized by Initialize().
-// External callers should use Default() to get the *Hub singleton.
+// External callers should use Default() to get the *ClientFactory singleton.
 var defaultSetup = &Setup{}
 
 // Setup holds the initialized LLM provider state needed by the app layer.
@@ -14,9 +14,9 @@ type Setup struct {
 	CurrentModel *CurrentModelInfo
 }
 
-// setSingleton publishes defaultSetup as the package-level *Hub.
+// setSingleton publishes defaultSetup as the package-level *ClientFactory.
 func setSingleton() {
-	defaultHub = &Hub{setup: defaultSetup}
+	defaultClientFactory = &ClientFactory{setup: defaultSetup}
 }
 
 // ModelID returns the current model ID, or empty string if none.

--- a/internal/plugin/integration.go
+++ b/internal/plugin/integration.go
@@ -71,7 +71,7 @@ func GetPluginHooks() map[string][]setting.Hook {
 
 // MergePluginHooksIntoSettings merges plugin hooks into application settings.
 // Plugin hooks are appended after the existing hooks for each event.
-func MergePluginHooksIntoSettings(settings *setting.Settings) {
+func MergePluginHooksIntoSettings(settings *setting.Data) {
 	if settings.Hooks == nil {
 		settings.Hooks = make(map[string][]setting.Hook)
 	}

--- a/internal/setting/clone_test.go
+++ b/internal/setting/clone_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 // TestClonePreservesAllScalarFields guards against the Clone() drift that
 // caused identity to silently revert to default at startup: every scalar
-// field on Settings must round-trip through Clone. New fields should be
+// field on Data must round-trip through Clone. New fields should be
 // added here at the same time they are added to Clone().
 func TestClonePreservesAllScalarFields(t *testing.T) {
 	yes := true
-	src := &Settings{
+	src := &Data{
 		Model:          "claude-opus-4-7",
 		Theme:          "dark",
 		SearchProvider: "exa",

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -74,7 +74,7 @@ func NewLoaderForCwd(cwd string) *Loader {
 //  4. .gen/settings.json
 //  5. .claude/settings.local.json
 //  6. .gen/settings.local.json
-func (l *Loader) Load() (*Settings, error) {
+func (l *Loader) Load() (*Data, error) {
 	homeDir, _ := os.UserHomeDir()
 
 	// Two-phase loading: first load Claude-compat settings, then GenCode-native.
@@ -109,13 +109,13 @@ func (l *Loader) Load() (*Settings, error) {
 	claudeHooks := make(map[string][]Hook)
 	nativeHooks := make(map[string][]Hook) // last write wins per event
 
-	settings := NewSettings()
+	settings := NewData()
 	for _, src := range sources {
 		data, err := os.ReadFile(src.path)
 		if err != nil {
 			continue
 		}
-		var s Settings
+		var s Data
 		if err := json.Unmarshal(data, &s); err != nil {
 			log.Logger().Warn("failed to parse config file", zap.String("path", src.path), zap.Error(err))
 			continue
@@ -164,12 +164,12 @@ func (l *Loader) Load() (*Settings, error) {
 }
 
 // LoadFile loads settings from a specific file.
-func (l *Loader) LoadFile(path string) (*Settings, error) {
+func (l *Loader) LoadFile(path string) (*Data, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	var s Settings
+	var s Data
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, err
 	}
@@ -177,19 +177,19 @@ func (l *Loader) LoadFile(path string) (*Settings, error) {
 }
 
 // SaveToProject saves settings to the project-level settings file, merging with existing.
-func (l *Loader) SaveToProject(settings *Settings) error {
+func (l *Loader) SaveToProject(settings *Data) error {
 	return l.saveToFile(filepath.Join(l.projectDir, "settings.json"), settings)
 }
 
 // SaveToUser saves settings to the user-level settings file, merging with existing.
-func (l *Loader) SaveToUser(settings *Settings) error {
+func (l *Loader) SaveToUser(settings *Data) error {
 	return l.saveToFile(filepath.Join(l.userDir, "settings.json"), settings)
 }
 
-func (l *Loader) saveToFile(path string, settings *Settings) error {
+func (l *Loader) saveToFile(path string, settings *Data) error {
 	toSave := settings
 	if data, err := os.ReadFile(path); err == nil {
-		existing := NewSettings()
+		existing := NewData()
 		if err := json.Unmarshal(data, existing); err == nil {
 			toSave = mergeSettings(existing, settings)
 		}
@@ -219,12 +219,12 @@ func writeJSONAtomic(path string, v any) error {
 }
 
 var (
-	loadedSettings   *Settings
+	loadedSettings   *Data
 	loadedSettingsMu sync.Mutex
 )
 
 // Load loads settings using the default loader (cached after first call).
-func Load() (*Settings, error) {
+func Load() (*Data, error) {
 	loadedSettingsMu.Lock()
 	defer loadedSettingsMu.Unlock()
 	if loadedSettings != nil {
@@ -239,7 +239,7 @@ func Load() (*Settings, error) {
 }
 
 // Reload clears the settings cache and reloads from disk.
-func Reload() (*Settings, error) {
+func Reload() (*Data, error) {
 	loadedSettingsMu.Lock()
 	defer loadedSettingsMu.Unlock()
 	s, err := NewLoader().Load()
@@ -252,19 +252,19 @@ func Reload() (*Settings, error) {
 
 // LoadForCwd loads settings for the provided working directory without using
 // the process-global cache. This is used when the session cwd changes.
-func LoadForCwd(cwd string) (*Settings, error) {
+func LoadForCwd(cwd string) (*Data, error) {
 	return NewLoaderForCwd(cwd).Load()
 }
 
-// defaultSettings returns default settings without loading from disk.
-func defaultSettings() *Settings {
-	return NewSettings()
+// defaultData returns default settings without loading from disk.
+func defaultData() *Data {
+	return NewData()
 }
 
 // UpdateDisabledToolsAt updates disabled tools at user level (true) or project level (false).
 func UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error {
 	loader := NewLoader()
-	settings := &Settings{DisabledTools: disabledTools}
+	settings := &Data{DisabledTools: disabledTools}
 
 	var err error
 	if userLevel {
@@ -336,7 +336,7 @@ func AddAllowRuleDirectlyAt(rule, cwd string) error {
 		return nil // already exists
 	}
 
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{rule},
 		},
@@ -361,7 +361,7 @@ func LoadTheme() string {
 
 // SaveTheme persists the chosen theme to ~/.gen/settings.json.
 func SaveTheme(t string) error {
-	if err := NewLoader().SaveToUser(&Settings{Theme: t}); err != nil {
+	if err := NewLoader().SaveToUser(&Data{Theme: t}); err != nil {
 		return err
 	}
 	loadedSettingsMu.Lock()
@@ -382,7 +382,7 @@ func SaveIdentity(name string) error {
 	}
 	path := filepath.Join(loader.userDir, "settings.json")
 
-	existing := NewSettings()
+	existing := NewData()
 	if data, err := os.ReadFile(path); err == nil {
 		_ = json.Unmarshal(data, existing)
 	}

--- a/internal/setting/merger.go
+++ b/internal/setting/merger.go
@@ -2,9 +2,9 @@ package setting
 
 import "maps"
 
-// mergeSettings merges two Settings, with overlay taking precedence over base.
+// mergeSettings merges two Data, with overlay taking precedence over base.
 // Slices (permission rules) are deduplicated unions. Maps are merged with overlay winning on conflicts.
-func mergeSettings(base, overlay *Settings) *Settings {
+func mergeSettings(base, overlay *Data) *Data {
 	if base == nil {
 		return overlay
 	}
@@ -12,7 +12,7 @@ func mergeSettings(base, overlay *Settings) *Settings {
 		return base
 	}
 
-	result := NewSettings()
+	result := NewData()
 	result.Permissions = mergePermissions(base.Permissions, overlay.Permissions)
 	result.Model = coalesce(overlay.Model, base.Model)
 	result.Theme = coalesce(overlay.Theme, base.Theme)

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -92,7 +92,7 @@ func decide(b PermissionBehavior, reason string) PermissionDecision {
 
 // HasPermissionToUseTool is the central permission gate that determines
 // whether a tool invocation should be allowed, denied, or prompted.
-func (s *Settings) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
+func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
 	rule := BuildRule(toolName, args)
 
 	// ── Step 1: Deny rules ──
@@ -138,7 +138,7 @@ func (s *Settings) HasPermissionToUseTool(toolName string, args map[string]any, 
 	return coerceAsk(modeDefaultDecision(toolName, session), session)
 }
 
-func (s *Settings) bypassImmunePromptReason(toolName string, args map[string]any, session *SessionPermissions) string {
+func (s *Data) bypassImmunePromptReason(toolName string, args map[string]any, session *SessionPermissions) string {
 	if reason := BypassImmuneReason(toolName, args); reason != "" {
 		return "bypass-immune: " + reason
 	}
@@ -195,7 +195,7 @@ func coerceAsk(decision PermissionDecision, session *SessionPermissions) Permiss
 // Returns false if a deny rule, bypass-immune safety check, or explicit ask
 // rule overrides the hook's decision. This implements the safety invariant:
 // deny rules > bypass-immune checks > ask rules > hook allow.
-func (s *Settings) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
+func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
 	rule := BuildRule(toolName, args)
 	for _, pattern := range s.Permissions.Deny {
 		if MatchesToolPattern(toolName, args, rule, pattern) {
@@ -214,7 +214,7 @@ func (s *Settings) ResolveHookAllow(toolName string, args map[string]any, sessio
 }
 
 // CheckPermission is a convenience wrapper returning just the behavior.
-func (s *Settings) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
+func (s *Data) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
 	return s.HasPermissionToUseTool(toolName, args, session).Behavior
 }
 

--- a/internal/setting/permission_test.go
+++ b/internal/setting/permission_test.go
@@ -104,7 +104,7 @@ func TestBuildRule(t *testing.T) {
 }
 
 func TestCheckPermission(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{
 				"Bash(cd:*)",
@@ -223,7 +223,7 @@ func TestCheckPermission(t *testing.T) {
 }
 
 func TestBashAllowRulesRequireEverySubcommand(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{"Bash(git:*)"},
 		},
@@ -312,7 +312,7 @@ func Test_isDestructiveCommand(t *testing.T) {
 }
 
 func TestDenyRulesPriorityOverSession(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Deny: []string{
 				"Read(**/.env)",
@@ -358,7 +358,7 @@ func TestDenyRulesPriorityOverSession(t *testing.T) {
 }
 
 func TestDestructiveCommandsRequireConfirmation(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{},
 	}
 
@@ -434,7 +434,7 @@ func Test_isSensitivePath(t *testing.T) {
 }
 
 func TestSensitivePathsBypassImmune(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{"Edit(**/*.json)"}, // Allow all JSON edits
 		},
@@ -539,7 +539,7 @@ func Test_checkBashSecurity(t *testing.T) {
 }
 
 func TestBashSecurityBypassImmune(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		AllowAllBash:    true,
 		AllowedTools:    make(map[string]bool),
@@ -570,7 +570,7 @@ func TestBashSecurityBypassImmune(t *testing.T) {
 }
 
 func TestCheckPermissionWithReason(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{"Bash(git:*)"},
 			Deny:  []string{"Read(**/.env)"},
@@ -625,7 +625,7 @@ func TestCheckPermissionWithReason(t *testing.T) {
 }
 
 func TestCheckPermissionWithReason_WorkingDirectoryConstraint(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		AllowAllEdits:      true,
 		WorkingDirectories: []string{"/home/user/project"},
@@ -678,7 +678,7 @@ func TestDenialTracking(t *testing.T) {
 }
 
 func TestBypassPermissionsMode(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		Mode:            ModeBypassPermissions,
 		AllowedTools:    make(map[string]bool),
@@ -729,7 +729,7 @@ func TestBypassPermissionsMode(t *testing.T) {
 }
 
 func TestDontAskMode(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		Mode:            ModeDontAsk,
 		AllowedTools:    make(map[string]bool),
@@ -775,7 +775,7 @@ func TestDontAskMode(t *testing.T) {
 }
 
 func TestAcceptEditsModeAllowsEditsButPromptsBash(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		Mode:            ModeAutoAccept,
 		AllowedTools:    make(map[string]bool),
@@ -791,7 +791,7 @@ func TestAcceptEditsModeAllowsEditsButPromptsBash(t *testing.T) {
 }
 
 func TestHeadlessCoercesAskToDeny(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		ShouldAvoidPrompts: true,
 		AllowedTools:       make(map[string]bool),
@@ -810,7 +810,7 @@ func TestHeadlessCoercesAskToDeny(t *testing.T) {
 }
 
 func TestDenyRuleBlocksBypass(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Deny: []string{"Read(**/.env)"},
 		},
@@ -829,7 +829,7 @@ func TestDenyRuleBlocksBypass(t *testing.T) {
 }
 
 func TestWorkingDirectoryConstraint(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 	session := &SessionPermissions{
 		AllowAllEdits:      true,
 		AllowAllWrites:     true,
@@ -892,7 +892,7 @@ func TestWorkingDirectoryConstraint(t *testing.T) {
 }
 
 func TestSafeToolAllowlist(t *testing.T) {
-	settings := &Settings{}
+	settings := &Data{}
 
 	// All safe tools, including read-only ones.
 	// Keep in sync with perm.safeTools (tool/perm/decision.go).
@@ -929,7 +929,7 @@ func TestPassthroughBehavior(t *testing.T) {
 }
 
 func TestResolveHookAllow(t *testing.T) {
-	settings := &Settings{
+	settings := &Data{
 		Permissions: PermissionSettings{
 			Allow: []string{"Bash(git:*)"},
 			Deny:  []string{"Read(**/.env)"},

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -1,130 +1,76 @@
+// Package setting owns the merged user+project settings and the
+// central permission decision gate. Exposes *Manager directly.
 package setting
 
 import "sync"
-
-// Service is the public contract for the setting module.
-type Service interface {
-	// Snapshot returns the current merged settings.
-	Snapshot() *Settings
-
-	// AllowBypass reports whether bypass mode is permitted.
-	AllowBypass() bool
-
-	// IsGitRepo checks if the given directory is a git repository.
-	IsGitRepo(cwd string) bool
-
-	// Reload re-reads all settings files for the given cwd and updates the singleton.
-	Reload(cwd string) error
-
-	// DisabledTools returns the merged disabled-tools map.
-	DisabledTools() map[string]bool
-
-	// SearchProvider returns the configured search provider string.
-	SearchProvider() string
-
-	// SetSearchProvider updates the search provider in the current settings.
-	SetSearchProvider(provider string)
-
-	// Hooks returns the merged hooks configuration.
-	Hooks() map[string][]Hook
-
-	// CheckPermission is a convenience wrapper returning just the permission behavior.
-	CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior
-
-	// HasPermissionToUseTool is the central permission gate.
-	HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision
-
-	// ResolveHookAllow checks if a hook's "allow" decision should be honored.
-	ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool
-
-	// GetDisabledToolsAt returns disabled tools from a single settings file.
-	// userLevel=true reads from ~/.gen/settings.json; false reads from .gen/settings.json.
-	GetDisabledToolsAt(userLevel bool) map[string]bool
-
-	// UpdateDisabledToolsAt updates disabled tools at user level (true) or project level (false).
-	UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error
-}
-
-// Compile-time check: *settingsService implements Service.
-var _ Service = (*settingsService)(nil)
 
 // Options holds configuration for Initialize.
 type Options struct {
 	CWD string
 }
 
-// Initialize loads settings for cwd and sets the Service singleton.
+// Initialize loads settings for cwd and installs the package-level *Manager.
 func Initialize(opts Options) {
 	s := InitForApp(opts.CWD)
-	SetDefault(&settingsService{settings: s})
+	defaultManager = &Manager{settings: s}
 }
 
-// ── singleton ──────────────────────────────────────────────
+// Default returns the package-level *Manager.
+func Default() *Manager {
+	return defaultManager
+}
 
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Default returns the singleton Service instance.
-// Panics if Initialize has not been called.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	if s == nil {
-		panic("setting: not initialized")
+// DefaultIfInit returns the package-level *Manager, or nil if it
+// has not been initialized with real settings yet.
+func DefaultIfInit() *Manager {
+	if defaultManager == nil || defaultManager.settings == nil {
+		return nil
 	}
-	return s
+	return defaultManager
 }
 
-// DefaultIfInit returns the singleton Service instance, or nil if not initialized.
-func DefaultIfInit() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	return s
+// SetDefaultManager replaces the package-level *Manager. Intended for
+// tests. A nil argument restores a fresh empty *Manager.
+func SetDefaultManager(s *Manager) {
+	if s == nil {
+		defaultManager = &Manager{}
+		return
+	}
+	defaultManager = s
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultManager restores a fresh empty *Manager. Intended for
+// tests.
+func ResetDefaultManager() {
+	defaultManager = &Manager{}
 }
 
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultManager = &Manager{}
 
-// ── implementation ─────────────────────────────────────────
-
-// settingsService wraps a *Settings to implement the Service interface.
-type settingsService struct {
+// Manager wraps a *Settings under a mutex. Methods are mutex-protected
+// views over the underlying settings.
+type Manager struct {
 	mu       sync.RWMutex
 	settings *Settings
 }
 
-func (s *settingsService) Snapshot() *Settings {
+func (s *Manager) Snapshot() *Settings {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.settings.Clone()
 }
 
-func (s *settingsService) AllowBypass() bool {
+func (s *Manager) AllowBypass() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.settings != nil && s.settings.AllowBypass != nil && *s.settings.AllowBypass
 }
 
-func (s *settingsService) IsGitRepo(cwd string) bool {
+func (s *Manager) IsGitRepo(cwd string) bool {
 	return IsGitRepo(cwd)
 }
 
-func (s *settingsService) Reload(cwd string) error {
+func (s *Manager) Reload(cwd string) error {
 	var (
 		newSettings *Settings
 		err         error
@@ -150,7 +96,7 @@ func (s *settingsService) Reload(cwd string) error {
 	return nil
 }
 
-func (s *settingsService) DisabledTools() map[string]bool {
+func (s *Manager) DisabledTools() map[string]bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil || s.settings.DisabledTools == nil {
@@ -163,7 +109,7 @@ func (s *settingsService) DisabledTools() map[string]bool {
 	return result
 }
 
-func (s *settingsService) SearchProvider() string {
+func (s *Manager) SearchProvider() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil {
@@ -172,7 +118,7 @@ func (s *settingsService) SearchProvider() string {
 	return s.settings.SearchProvider
 }
 
-func (s *settingsService) SetSearchProvider(provider string) {
+func (s *Manager) SetSearchProvider(provider string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.settings != nil {
@@ -180,7 +126,7 @@ func (s *settingsService) SetSearchProvider(provider string) {
 	}
 }
 
-func (s *settingsService) Hooks() map[string][]Hook {
+func (s *Manager) Hooks() map[string][]Hook {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil {
@@ -189,7 +135,7 @@ func (s *settingsService) Hooks() map[string][]Hook {
 	return s.settings.Hooks
 }
 
-func (s *settingsService) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
+func (s *Manager) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil {
@@ -198,7 +144,7 @@ func (s *settingsService) CheckPermission(toolName string, args map[string]any, 
 	return s.settings.CheckPermission(toolName, args, session)
 }
 
-func (s *settingsService) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
+func (s *Manager) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil {
@@ -207,7 +153,7 @@ func (s *settingsService) HasPermissionToUseTool(toolName string, args map[strin
 	return s.settings.HasPermissionToUseTool(toolName, args, session)
 }
 
-func (s *settingsService) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
+func (s *Manager) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.settings == nil {
@@ -216,10 +162,10 @@ func (s *settingsService) ResolveHookAllow(toolName string, args map[string]any,
 	return s.settings.ResolveHookAllow(toolName, args, session)
 }
 
-func (s *settingsService) GetDisabledToolsAt(userLevel bool) map[string]bool {
+func (s *Manager) GetDisabledToolsAt(userLevel bool) map[string]bool {
 	return GetDisabledToolsAt(userLevel)
 }
 
-func (s *settingsService) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error {
+func (s *Manager) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error {
 	return UpdateDisabledToolsAt(disabledTools, userLevel)
 }

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -1,5 +1,10 @@
 // Package setting owns the merged user+project settings and the
-// central permission decision gate. Exposes *Manager directly.
+// central permission decision gate. Exposes *Settings directly.
+//
+// *Settings is the live, mutex-protected handle (controller). *Data is
+// the on-disk schema (struct with the actual setting fields). The
+// controller wraps a *Data under a mutex and exposes mutex-protected
+// views.
 package setting
 
 import "sync"
@@ -9,163 +14,163 @@ type Options struct {
 	CWD string
 }
 
-// Initialize loads settings for cwd and installs the package-level *Manager.
+// Initialize loads settings for cwd and installs the package-level *Settings.
 func Initialize(opts Options) {
-	s := InitForApp(opts.CWD)
-	defaultManager = &Manager{settings: s}
+	d := InitForApp(opts.CWD)
+	defaultSettings = &Settings{data: d}
 }
 
-// Default returns the package-level *Manager.
-func Default() *Manager {
-	return defaultManager
+// Default returns the package-level *Settings.
+func Default() *Settings {
+	return defaultSettings
 }
 
-// DefaultIfInit returns the package-level *Manager, or nil if it
+// DefaultIfInit returns the package-level *Settings, or nil if it
 // has not been initialized with real settings yet.
-func DefaultIfInit() *Manager {
-	if defaultManager == nil || defaultManager.settings == nil {
+func DefaultIfInit() *Settings {
+	if defaultSettings == nil || defaultSettings.data == nil {
 		return nil
 	}
-	return defaultManager
+	return defaultSettings
 }
 
-// SetDefaultManager replaces the package-level *Manager. Intended for
-// tests. A nil argument restores a fresh empty *Manager.
-func SetDefaultManager(s *Manager) {
+// SetDefaultSettings replaces the package-level *Settings. Intended for
+// tests. A nil argument restores a fresh empty *Settings.
+func SetDefaultSettings(s *Settings) {
 	if s == nil {
-		defaultManager = &Manager{}
+		defaultSettings = &Settings{}
 		return
 	}
-	defaultManager = s
+	defaultSettings = s
 }
 
-// ResetDefaultManager restores a fresh empty *Manager. Intended for
+// ResetDefaultSettings restores a fresh empty *Settings. Intended for
 // tests.
-func ResetDefaultManager() {
-	defaultManager = &Manager{}
+func ResetDefaultSettings() {
+	defaultSettings = &Settings{}
 }
 
-var defaultManager = &Manager{}
+var defaultSettings = &Settings{}
 
-// Manager wraps a *Settings under a mutex. Methods are mutex-protected
-// views over the underlying settings.
-type Manager struct {
-	mu       sync.RWMutex
-	settings *Settings
+// Settings is the live handle: a *Data under a mutex. Methods are
+// mutex-protected views over the underlying *Data.
+type Settings struct {
+	mu   sync.RWMutex
+	data *Data
 }
 
-func (s *Manager) Snapshot() *Settings {
+func (s *Settings) Snapshot() *Data {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.settings.Clone()
+	return s.data.Clone()
 }
 
-func (s *Manager) AllowBypass() bool {
+func (s *Settings) AllowBypass() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.settings != nil && s.settings.AllowBypass != nil && *s.settings.AllowBypass
+	return s.data != nil && s.data.AllowBypass != nil && *s.data.AllowBypass
 }
 
-func (s *Manager) IsGitRepo(cwd string) bool {
+func (s *Settings) IsGitRepo(cwd string) bool {
 	return IsGitRepo(cwd)
 }
 
-func (s *Manager) Reload(cwd string) error {
+func (s *Settings) Reload(cwd string) error {
 	var (
-		newSettings *Settings
-		err         error
+		newData *Data
+		err     error
 	)
 	if cwd != "" {
-		newSettings, err = LoadForCwd(cwd)
+		newData, err = LoadForCwd(cwd)
 	} else {
-		newSettings, err = Load()
+		newData, err = Load()
 	}
 	if err != nil {
 		return err
 	}
-	if newSettings == nil {
-		newSettings = NewSettings()
+	if newData == nil {
+		newData = NewData()
 	}
-	mergeProviderPreferences(newSettings)
-	cloned := newSettings.Clone()
+	mergeProviderPreferences(newData)
+	cloned := newData.Clone()
 
 	s.mu.Lock()
-	s.settings = cloned
+	s.data = cloned
 	s.mu.Unlock()
 
 	return nil
 }
 
-func (s *Manager) DisabledTools() map[string]bool {
+func (s *Settings) DisabledTools() map[string]bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil || s.settings.DisabledTools == nil {
+	if s.data == nil || s.data.DisabledTools == nil {
 		return make(map[string]bool)
 	}
-	result := make(map[string]bool, len(s.settings.DisabledTools))
-	for k, v := range s.settings.DisabledTools {
+	result := make(map[string]bool, len(s.data.DisabledTools))
+	for k, v := range s.data.DisabledTools {
 		result[k] = v
 	}
 	return result
 }
 
-func (s *Manager) SearchProvider() string {
+func (s *Settings) SearchProvider() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil {
+	if s.data == nil {
 		return ""
 	}
-	return s.settings.SearchProvider
+	return s.data.SearchProvider
 }
 
-func (s *Manager) SetSearchProvider(provider string) {
+func (s *Settings) SetSearchProvider(provider string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.settings != nil {
-		s.settings.SearchProvider = provider
+	if s.data != nil {
+		s.data.SearchProvider = provider
 	}
 }
 
-func (s *Manager) Hooks() map[string][]Hook {
+func (s *Settings) Hooks() map[string][]Hook {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil {
+	if s.data == nil {
 		return nil
 	}
-	return s.settings.Hooks
+	return s.data.Hooks
 }
 
-func (s *Manager) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
+func (s *Settings) CheckPermission(toolName string, args map[string]any, session *SessionPermissions) PermissionBehavior {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil {
+	if s.data == nil {
 		return Ask
 	}
-	return s.settings.CheckPermission(toolName, args, session)
+	return s.data.CheckPermission(toolName, args, session)
 }
 
-func (s *Manager) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
+func (s *Settings) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil {
+	if s.data == nil {
 		return decide(Ask, "default: no settings loaded")
 	}
-	return s.settings.HasPermissionToUseTool(toolName, args, session)
+	return s.data.HasPermissionToUseTool(toolName, args, session)
 }
 
-func (s *Manager) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
+func (s *Settings) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.settings == nil {
+	if s.data == nil {
 		return true
 	}
-	return s.settings.ResolveHookAllow(toolName, args, session)
+	return s.data.ResolveHookAllow(toolName, args, session)
 }
 
-func (s *Manager) GetDisabledToolsAt(userLevel bool) map[string]bool {
+func (s *Settings) GetDisabledToolsAt(userLevel bool) map[string]bool {
 	return GetDisabledToolsAt(userLevel)
 }
 
-func (s *Manager) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error {
+func (s *Settings) UpdateDisabledToolsAt(disabledTools map[string]bool, userLevel bool) error {
 	return UpdateDisabledToolsAt(disabledTools, userLevel)
 }

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -1,5 +1,5 @@
 // Package config provides multi-level settings management for GenCode.
-// Settings are loaded from multiple sources with the following priority (lowest to highest):
+// Data are loaded from multiple sources with the following priority (lowest to highest):
 //  1. ~/.claude/settings.json (Claude user level - compatibility)
 //  2. ~/.gen/settings.json (Gen user level)
 //  3. .claude/settings.json (Claude project level - compatibility)
@@ -18,8 +18,8 @@ import (
 	"strings"
 )
 
-// Settings represents the complete GenCode configuration.
-type Settings struct {
+// Data represents the complete GenCode configuration.
+type Data struct {
 	Permissions    PermissionSettings `json:"permissions,omitempty"`
 	Model          string             `json:"model,omitempty"`
 	Hooks          map[string][]Hook  `json:"hooks,omitempty"`
@@ -210,8 +210,8 @@ func (m OperationMode) NextWithBypass(enabled bool) OperationMode {
 	return ModeNormal
 }
 
-func NewSettings() *Settings {
-	return &Settings{
+func NewData() *Data {
+	return &Data{
 		Hooks:          make(map[string][]Hook),
 		Env:            make(map[string]string),
 		EnabledPlugins: make(map[string]bool),
@@ -222,10 +222,10 @@ func NewSettings() *Settings {
 // InitForApp loads settings for cwd, deep-clones them, and returns
 // an isolated copy safe for mutation by the app layer.
 // It also merges external provider preferences (e.g., search provider
-// from providers.json) into the unified Settings struct.
-func InitForApp(cwd string) *Settings {
+// from providers.json) into the unified Data struct.
+func InitForApp(cwd string) *Data {
 	var (
-		settings *Settings
+		settings *Data
 		err      error
 	)
 	if cwd != "" {
@@ -235,17 +235,17 @@ func InitForApp(cwd string) *Settings {
 	}
 	_ = err
 	if settings == nil {
-		settings = defaultSettings()
+		settings = defaultData()
 	}
 	mergeProviderPreferences(settings)
 	return settings.Clone()
 }
 
 // mergeProviderPreferences reads external provider config files and merges
-// relevant preferences into Settings. Currently reads searchProvider from
+// relevant preferences into Data. Currently reads searchProvider from
 // ~/.gen/providers.json (owned by the llm package) so that search config
-// is accessible via the unified Settings struct.
-func mergeProviderPreferences(s *Settings) {
+// is accessible via the unified Data struct.
+func mergeProviderPreferences(s *Data) {
 	if s.SearchProvider != "" {
 		return
 	}
@@ -265,12 +265,12 @@ func mergeProviderPreferences(s *Settings) {
 	}
 }
 
-// Clone returns a deep copy of the Settings.
-func (s *Settings) Clone() *Settings {
+// Clone returns a deep copy of the Data.
+func (s *Data) Clone() *Data {
 	if s == nil {
-		return defaultSettings()
+		return defaultData()
 	}
-	dst := NewSettings()
+	dst := NewData()
 	dst.Permissions.DefaultMode = s.Permissions.DefaultMode
 	dst.Permissions.Allow = append([]string(nil), s.Permissions.Allow...)
 	dst.Permissions.Deny = append([]string(nil), s.Permissions.Deny...)

--- a/internal/task/hooks_test.go
+++ b/internal/task/hooks_test.go
@@ -24,7 +24,7 @@ func TestTaskLifecycleHandler(t *testing.T) {
 	SetLifecycleHandler(observer)
 	defer SetLifecycleHandler(nil)
 
-	mgr := NewManager()
+	mgr := NewTracker()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -10,21 +10,21 @@ import (
 	"time"
 )
 
-// Manager manages background tasks
-type Manager struct {
+// Tracker tracks background bash and subagent tasks.
+type Tracker struct {
 	mu    sync.RWMutex
 	tasks map[string]BackgroundTask
 }
 
-// NewManager creates a new task manager
-func NewManager() *Manager {
-	return &Manager{
+// NewTracker creates a new *Tracker.
+func NewTracker() *Tracker {
+	return &Tracker{
 		tasks: make(map[string]BackgroundTask),
 	}
 }
 
 // CreateBashTask creates and registers a new bash task
-func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
+func (m *Tracker) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -38,7 +38,7 @@ func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, ctx
 }
 
 // RegisterTask registers an existing task (used for agent tasks)
-func (m *Manager) RegisterTask(task BackgroundTask) {
+func (m *Tracker) RegisterTask(task BackgroundTask) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.tasks[task.GetID()] = task
@@ -55,7 +55,7 @@ func generateID() string {
 }
 
 // Get retrieves a task by ID
-func (m *Manager) Get(id string) (BackgroundTask, bool) {
+func (m *Tracker) Get(id string) (BackgroundTask, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	task, ok := m.tasks[id]
@@ -63,7 +63,7 @@ func (m *Manager) Get(id string) (BackgroundTask, bool) {
 }
 
 // getBashTask retrieves a bash task by ID (for backward compatibility)
-func (m *Manager) getBashTask(id string) (*BashTask, bool) {
+func (m *Tracker) getBashTask(id string) (*BashTask, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	task, ok := m.tasks[id]
@@ -75,7 +75,7 @@ func (m *Manager) getBashTask(id string) (*BashTask, bool) {
 }
 
 // List returns all tasks
-func (m *Manager) List() []BackgroundTask {
+func (m *Tracker) List() []BackgroundTask {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -87,7 +87,7 @@ func (m *Manager) List() []BackgroundTask {
 }
 
 // ListRunning returns all running tasks
-func (m *Manager) ListRunning() []BackgroundTask {
+func (m *Tracker) ListRunning() []BackgroundTask {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -101,7 +101,7 @@ func (m *Manager) ListRunning() []BackgroundTask {
 }
 
 // Kill terminates a task by ID
-func (m *Manager) Kill(id string) error {
+func (m *Tracker) Kill(id string) error {
 	m.mu.RLock()
 	task, ok := m.tasks[id]
 	m.mu.RUnlock()
@@ -141,14 +141,14 @@ func (m *Manager) Kill(id string) error {
 }
 
 // Remove removes a completed task from the manager
-func (m *Manager) Remove(id string) {
+func (m *Tracker) Remove(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.tasks, id)
 }
 
 // cleanup removes all completed tasks older than maxAge
-func (m *Manager) cleanup(maxAge time.Duration) {
+func (m *Tracker) cleanup(maxAge time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestManager_CreateAndGet(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -32,7 +32,7 @@ func TestManager_CreateAndGet(t *testing.T) {
 }
 
 func TestManager_GetNotFound(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	_, ok := m.Get("nonexistent")
 	if ok {
@@ -41,7 +41,7 @@ func TestManager_GetNotFound(t *testing.T) {
 }
 
 func TestManager_List(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -60,7 +60,7 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_ListRunning(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -84,7 +84,7 @@ func TestManager_ListRunning(t *testing.T) {
 }
 
 func TestManager_Remove(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -104,7 +104,7 @@ func TestManager_Remove(t *testing.T) {
 }
 
 func TestManager_Cleanup(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -131,7 +131,7 @@ func TestManager_Cleanup(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRecent(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -152,7 +152,7 @@ func TestManager_CleanupKeepsRecent(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRunning(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -172,7 +172,7 @@ func TestManager_CleanupKeepsRunning(t *testing.T) {
 }
 
 func TestManager_GenerateUniqueIDs(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -192,7 +192,7 @@ func TestManager_GenerateUniqueIDs(t *testing.T) {
 }
 
 func TestManager_RegisterTask(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -214,7 +214,7 @@ func TestManager_RegisterTask(t *testing.T) {
 }
 
 func TestManager_GetBashTask(t *testing.T) {
-	m := NewManager()
+	m := NewTracker()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/task/service.go
+++ b/internal/task/service.go
@@ -1,82 +1,46 @@
+// Package task tracks background bash and subagent tasks for the TUI's
+// task panel and the agent's TaskOutput / TaskList tools. Exposes
+// *Tracker directly.
 package task
-
-import (
-	"context"
-	"os/exec"
-	"sync"
-)
-
-// Service is the public contract for the task module.
-type Service interface {
-	// lifecycle
-	RegisterTask(t BackgroundTask)
-	CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask
-	Get(id string) (BackgroundTask, bool)
-	List() []BackgroundTask
-	ListRunning() []BackgroundTask
-	Kill(id string) error
-	Remove(id string)
-
-	// output
-	SetOutputDir(dir string) error
-}
-
-// Compile-time check: *Manager implements Service.
-var _ Service = (*Manager)(nil)
 
 // Options holds all dependencies for initialization.
 type Options struct {
 	OutputDir string
 }
 
-// ── singleton ──────────────────────────────────────────────
-
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Initialize creates a new Manager, applies options, and sets the singleton.
+// Initialize creates the package-level *Tracker and configures it.
 func Initialize(opts Options) {
-	m := NewManager()
+	m := NewTracker()
 	if opts.OutputDir != "" {
 		m.SetOutputDir(opts.OutputDir)
 	}
-	mu.Lock()
-	instance = m
-	mu.Unlock()
+	defaultTracker = m
 }
 
-// Default returns the singleton Service instance.
-// Panics if not initialized.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	if s == nil {
-		panic("task: not initialized")
+// Default returns the package-level *Tracker.
+func Default() *Tracker {
+	return defaultTracker
+}
+
+// SetDefaultTracker replaces the package-level *Tracker. Intended for
+// tests. A nil argument restores a fresh empty *Tracker.
+func SetDefaultTracker(m *Tracker) {
+	if m == nil {
+		defaultTracker = NewTracker()
+		return
 	}
-	return s
+	defaultTracker = m
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// ResetDefaultTracker restores a fresh empty *Tracker. Intended for
+// tests.
+func ResetDefaultTracker() {
+	defaultTracker = NewTracker()
 }
 
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
-}
+var defaultTracker = NewTracker()
 
-// ── Service methods on Manager ─────────────────────────────
-
-// SetOutputDir implements Service by delegating to the package-level
-// SetOutputDir function.
-func (m *Manager) SetOutputDir(dir string) error {
+// SetOutputDir on *Tracker delegates to the package-level setOutputDir.
+func (m *Tracker) SetOutputDir(dir string) error {
 	return setOutputDir(dir)
 }

--- a/internal/task/tracker/service.go
+++ b/internal/task/tracker/service.go
@@ -29,9 +29,6 @@ type Service interface {
 	Reset()
 }
 
-// Compile-time check: *Store implements Service.
-var _ Service = (*Store)(nil)
-
 // Options holds all dependencies for initialization.
 type Options struct{}
 

--- a/internal/tool/agent/sendmessage_test.go
+++ b/internal/tool/agent/sendmessage_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSendMessageTool_ResumesCompletedTask(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -44,7 +44,7 @@ func TestSendMessageTool_ResumesCompletedTask(t *testing.T) {
 
 func TestSendMessageTool_RejectsRunningTask(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/tool/service.go
+++ b/internal/tool/service.go
@@ -1,70 +1,39 @@
+// Package tool is the registry of built-in tools the agent can call.
+// Exposes *Registry directly — no Service interface.
 package tool
-
-import (
-	"context"
-	"sync"
-
-	"github.com/genai-io/gen-code/internal/tool/toolresult"
-)
-
-// Service is the public contract for the tool module.
-type Service interface {
-	// registration
-	Register(t Tool)
-	RegisterAlias(alias string, t Tool)
-	Get(name string) (Tool, bool)
-	List() []string
-
-	// execution
-	Execute(ctx context.Context, name string, params map[string]any, cwd string) toolresult.ToolResult
-
-	// side effects
-	PopSideEffect(toolCallID string) any
-}
-
-// Compile-time check: *Registry implements Service.
-var _ Service = (*Registry)(nil)
 
 // Options holds all dependencies for initialization.
 type Options struct{}
 
-// ── singleton ──────────────────────────────────────────────
-
-var (
-	mu       sync.RWMutex
-	instance Service
-)
-
-// Initialize sets the singleton to the default registry.
+// Initialize installs the package-level *Registry as the default.
+// Tools register at init time before Initialize runs; this is a
+// no-op trigger for consistency with other packages' Initialize.
 func Initialize(opts Options) {
-	mu.Lock()
-	instance = defaultRegistry
-	mu.Unlock()
+	defaultInstance = defaultRegistry
 }
 
-// Default returns the singleton Service instance.
-// Falls back to defaultRegistry if Initialize has not been called,
-// since tools register at init time before Initialize runs.
-func Default() Service {
-	mu.RLock()
-	s := instance
-	mu.RUnlock()
-	if s != nil {
-		return s
+// Default returns the package-level *Registry.
+func Default() *Registry {
+	if defaultInstance != nil {
+		return defaultInstance
 	}
 	return defaultRegistry
 }
 
-// SetDefault replaces the singleton instance. Intended for tests.
-func SetDefault(s Service) {
-	mu.Lock()
-	instance = s
-	mu.Unlock()
+// SetDefaultRegistry replaces the package-level registry. Intended for
+// tests. A nil argument restores the package default.
+func SetDefaultRegistry(r *Registry) {
+	if r == nil {
+		defaultInstance = defaultRegistry
+		return
+	}
+	defaultInstance = r
 }
 
-// ResetService clears the singleton instance. Intended for tests.
-func ResetService() {
-	mu.Lock()
-	instance = nil
-	mu.Unlock()
+// ResetDefaultRegistry restores the package default. Intended for
+// tests.
+func ResetDefaultRegistry() {
+	defaultInstance = defaultRegistry
 }
+
+var defaultInstance *Registry

--- a/internal/tool/task/taskoutput_test.go
+++ b/internal/tool/task/taskoutput_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestTaskOutputTool_StillRunning(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,7 +57,7 @@ func TestTaskOutputTool_StillRunning(t *testing.T) {
 
 func TestTaskOutputTool_Completed(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -105,7 +105,7 @@ func TestTaskOutputTool_Completed(t *testing.T) {
 
 func TestTaskOutputTool_NotFound(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	tool := &TaskOutputTool{}
 	result := tool.Execute(context.Background(), map[string]any{
@@ -124,7 +124,7 @@ func TestTaskOutputTool_NotFound(t *testing.T) {
 
 func TestTaskOutputTool_NonBlocking(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -162,7 +162,7 @@ func TestTaskOutputTool_NonBlocking(t *testing.T) {
 
 func TestTaskOutputTool_DefaultsToNonBlocking(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -195,7 +195,7 @@ func TestTaskOutputTool_DefaultsToNonBlocking(t *testing.T) {
 
 func TestTaskOutputTool_AllowsOlderRunningTaskInspection(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/worktree/hooks_test.go
+++ b/internal/worktree/hooks_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestWorktreeHooksFire(t *testing.T) {
-	hook.SetDefaultEngine(hook.NewEngine(&setting.Settings{}, "test", t.TempDir(), ""))
+	hook.SetDefaultEngine(hook.NewEngine(&setting.Data{}, "test", t.TempDir(), ""))
 	defer hook.ResetDefaultEngine()
 
 	repo := makeRepo(t)

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -24,12 +24,14 @@ This file tracks structural follow-ups that are not tied to a single feature.
   ~~`task` (8 methods)~~ — `*task.Tracker` direct (renamed from
   `*Manager`; tracks background bash/subagent tasks).
   ~~`command` (7 methods)~~ — `*command.Registry` direct.
-  ~~`llm` (8 methods)~~ — `*llm.Hub` direct (provider connection center
-  + Client factory). Wraps `*Setup` (Store + Provider + CurrentModel).
-  ~~`agent` (11 methods)~~ — `*agent.Session` direct (foreground agent
-  session lifecycle).
-  ~~`setting` (14 methods)~~ — `*setting.Manager` direct (settings +
-  permission decision gate).
+  ~~`llm` (8 methods)~~ — `*llm.ClientFactory` direct (active
+  provider/model handle + `*Client` factory). Wraps `*Setup`
+  (Store + Provider + CurrentModel).
+  ~~`agent` (11 methods)~~ — `*agent.Task` direct (foreground agent
+  task lifecycle).
+  ~~`setting` (14 methods)~~ — `*setting.Settings` direct (live,
+  mutex-protected handle over `*setting.Data`; also the permission
+  decision gate).
 - **Escape-hatch methods on Service interfaces.** All resolved:
   ~~`MCP.Registry()`~~, ~~`Hook.Engine()`~~, ~~`Session.GetStore()`~~
   / ~~`Session.SetStore()`~~ — Service interfaces deleted in their

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -10,25 +10,26 @@ This file tracks structural follow-ups that are not tied to a single feature.
 
 ### Code refactors flagged by `docs/packages/*/Known Violations`
 
-- **God `Service` interfaces.** Split per the per-package suggestions:
-  `setting` (14), `agent` (11), `cron` (10), `command` (7),
-  `llm` (8), `task` (8), `tool` (6). Define narrow consumer-defined
-  interfaces alongside the concrete `*service` / `*Registry`; let each
-  call site narrow to what it needs.
-  ~~`mcp` (9 methods)~~ — resolved (`Tools` + `Servers` + `*mcp.Registry`).
-  ~~`hook` (16 methods)~~ — resolved (`Handler` + `*hook.Engine`).
-  ~~`session` (11 methods)~~ — resolved by deleting `Service`, exposing
-  `*session.Setup` directly. No role interface — consumers don't share
-  a narrow common surface.
-  ~~`subagent` (9 methods)~~ — resolved by deleting `Service`,
-  exposing `*subagent.Registry` directly. No role interface — same
-  reason as session.
-  ~~`skill` (11 methods)~~ — resolved by deleting `Service`, exposing
-  `*skill.Registry` directly. No role interface — same reason.
-  ~~`plugin` (21 methods)~~ — resolved by deleting `Service`, exposing
-  `*plugin.Registry` directly + the existing package-level free
-  functions (`GetPlugin*Paths`, `SetActivePluginRoot`, etc.) that the
-  Service methods just wrapped.
+- **God `Service` interfaces.** All resolved.
+  ~~`mcp` (9 methods)~~ — `Tools` + `Servers` + `*mcp.Registry`.
+  ~~`hook` (16 methods)~~ — `Handler` + `*hook.Engine`.
+  ~~`session` (11 methods)~~ — `*session.Setup` direct.
+  ~~`subagent` (9 methods)~~ — `*subagent.Registry` direct.
+  ~~`skill` (11 methods)~~ — `*skill.Registry` direct.
+  ~~`plugin` (21 methods)~~ — `*plugin.Registry` direct + existing
+  package-level free functions.
+  ~~`tool` (6 methods)~~ — `*tool.Registry` direct.
+  ~~`cron` (10 methods)~~ — `*cron.Scheduler` direct (renamed from
+  `*Store`; methods schedule, persistence is a detail).
+  ~~`task` (8 methods)~~ — `*task.Tracker` direct (renamed from
+  `*Manager`; tracks background bash/subagent tasks).
+  ~~`command` (7 methods)~~ — `*command.Registry` direct.
+  ~~`llm` (8 methods)~~ — `*llm.Hub` direct (provider connection center
+  + Client factory). Wraps `*Setup` (Store + Provider + CurrentModel).
+  ~~`agent` (11 methods)~~ — `*agent.Session` direct (foreground agent
+  session lifecycle).
+  ~~`setting` (14 methods)~~ — `*setting.Manager` direct (settings +
+  permission decision gate).
 - **Escape-hatch methods on Service interfaces.** All resolved:
   ~~`MCP.Registry()`~~, ~~`Hook.Engine()`~~, ~~`Session.GetStore()`~~
   / ~~`Session.SetStore()`~~ — Service interfaces deleted in their

--- a/tests/integration/agent/agent_test.go
+++ b/tests/integration/agent/agent_test.go
@@ -270,7 +270,7 @@ func TestAgent_SubagentHooks_Fire(t *testing.T) {
 
 func TestAgent_BackgroundExecution(t *testing.T) {
 	task.Initialize(task.Options{})
-	t.Cleanup(task.ResetService)
+	t.Cleanup(task.ResetDefaultTracker)
 
 	mp := &testutil.MockProvider{
 		Responses: []llm.CompletionResponse{

--- a/tests/integration/agent/agent_test.go
+++ b/tests/integration/agent/agent_test.go
@@ -208,7 +208,7 @@ func TestAgent_SubagentHooks_Fire(t *testing.T) {
 
 	// Build a settings object with SubagentStart and SubagentStop hooks.
 	// Each hook writes to a temp file so we can verify it fired.
-	settings := &setting.Settings{
+	settings := &setting.Data{
 		Hooks: map[string][]setting.Hook{
 			string(hook.SubagentStart): {
 				{

--- a/tests/integration/hooks/hooks_test.go
+++ b/tests/integration/hooks/hooks_test.go
@@ -14,7 +14,7 @@ func TestHooks_BlockToolCall(t *testing.T) {
 		t.Skip("skipping on windows (no sh)")
 	}
 
-	settings := &setting.Settings{
+	settings := &setting.Data{
 		Hooks: map[string][]setting.Hook{
 			"PreToolUse": {
 				{
@@ -50,7 +50,7 @@ func TestHooks_ModifyToolInput(t *testing.T) {
 		t.Skip("skipping on windows (no sh)")
 	}
 
-	settings := &setting.Settings{
+	settings := &setting.Data{
 		Hooks: map[string][]setting.Hook{
 			"PreToolUse": {
 				{
@@ -86,7 +86,7 @@ func TestHooks_ModifyToolInput(t *testing.T) {
 
 func TestHooks_NoHooks_PassThrough(t *testing.T) {
 	// No hooks configured
-	engine := hook.NewEngine(&setting.Settings{}, "test-session", t.TempDir(), "")
+	engine := hook.NewEngine(&setting.Data{}, "test-session", t.TempDir(), "")
 
 	input := hook.HookInput{
 		ToolName:  "Read",
@@ -118,7 +118,7 @@ func TestHooks_NilSettings(t *testing.T) {
 }
 
 func TestHooks_HasHooks(t *testing.T) {
-	settings := &setting.Settings{
+	settings := &setting.Data{
 		Hooks: map[string][]setting.Hook{
 			"PreToolUse": {
 				{Hooks: []setting.HookCmd{{Command: "echo ok"}}},

--- a/tests/integration/testutil/helpers.go
+++ b/tests/integration/testutil/helpers.go
@@ -72,7 +72,7 @@ func RegisterFakeTool(t *testing.T, name, result string) {
 	tool.Register(&fakeTool{name: name, result: result})
 	t.Cleanup(func() {
 		tool.Unregister(name)
-		tool.ResetService()
+		tool.ResetDefaultRegistry()
 	})
 }
 


### PR DESCRIPTION
## Summary

Batch follow-up to PRs #27–#32. Removes the god `Service` interfaces (and the redundant `*service` struct) from the seven packages still using them and exposes each package's concrete handle directly. Handle names describe what each type **is**, not generic words like \"Service\"/\"Manager\":

| Package   | Handle       | Notes                                                                   |
| --------- | ------------ | ----------------------------------------------------------------------- |
| `tool`    | `*Registry`  | built-in tool registry                                                  |
| `cron`    | `*Scheduler` | was `*Store`; methods schedule, persistence is an implementation detail |
| `task`    | `*Tracker`   | was `*Manager`; tracks background bash/subagent tasks                   |
| `command` | `*Registry`  | slash command registry                                                  |
| `llm`     | `*Hub`       | provider connection center + `Client` factory; wraps `*Setup`           |
| `agent`   | `*Session`   | foreground agent session lifecycle                                      |
| `setting` | `*Manager`   | merged settings + central permission decision gate                      |

Each handle has the standard `Default()` accessor + test-only `SetDefault* / ResetDefault*` helpers, matching the pattern from the earlier per-package PRs. No new role interfaces — none of these surfaces is shared narrowly across multiple callers.

`docs/packages/{tool,cron,task,command,llm,agent,setting}.md` are updated to reflect the new handle types. `notes/tech-debt.md` marks every god-`Service` row resolved.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make lint-layers`
- [x] `make format`