### PR TITLE
refactor(app): clarify submit path, app/conv cleanup, concept docs

### DIFF
--- a/.gen/skills/simplify/SKILL.md
+++ b/.gen/skills/simplify/SKILL.md
@@ -22,7 +22,7 @@ Run `git diff` (or `git diff HEAD` if there are staged changes) to see what chan
 
 ## Phase 2: Launch Three Review Agents in Parallel
 
-Use the Agent tool to launch all three agents concurrently in a single message with `run_in_background=true`. Pass each agent the full diff so it has the complete context. After launching, briefly tell the user what you launched and end your response — you will be automatically notified as each agent completes. Do NOT poll, read output files, or check status manually.
+Use the Agent tool to launch all three agents concurrently in a single message (foreground — do NOT set `run_in_background`). Pass each agent the full diff so it has the complete context. All three agents run in parallel and return their results in the same turn.
 
 ### Agent 1: Code Reuse Review
 
@@ -59,6 +59,6 @@ Review the same changes for efficiency:
 
 ## Phase 3: Fix Issues
 
-Wait for all three agents to complete. Aggregate their findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on — do not argue with the finding, just skip it.
+Aggregate the three agents' findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on — do not argue with the finding, just skip it.
 
 When done, briefly summarize what was fixed (or confirm the code was already clean).

--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -264,6 +264,55 @@ OnTurnEnd                                    model_agent_events.go
         └─ agentEventHub batch ► injectNotification(merged hub.Message)
 ```
 
+### Waking the Update loop (idle path)
+
+`drainTurnQueues` only fires at `OnTurnEnd`, so an event that arrives
+*between* turns (the common case for a subagent that finishes minutes
+after launch) needs another way to wake the Update loop. The hub-side
+delivery is already a Go channel (`m.mainEvents`), so we use the same
+trick the agent outbox uses — a **blocking-receive `tea.Cmd`** that
+turns "next item on the chan" into a `tea.Msg`:
+
+```
+Init                                       model.go
+   └─ awaitMainEvent(m.mainEvents)         model_turn_queue.go
+        └─ blocks on chan, yields mainEventMsg{event} when one arrives
+
+Update                                     update.go
+   case mainEventMsg:
+        └─ onMainEvent(ev)                 model_turn_queue.go
+              ├─ append ev (+ chan peers) to m.pendingMainEvents
+              ├─ start awaitMainEvent again so the next publish wakes us
+              └─ if !Stream.Active:
+                   injectNotification(merge(pending)); clear pending
+```
+
+`onMainEvent` always starts a fresh `awaitMainEvent` — safe because
+the chan is empty when we restart, so the next firing waits for the
+next publish (no spin loop). There are two delivery paths depending
+on what the live agent is doing when the event arrives:
+
+| When the event arrives | Who delivers it | Latency |
+|---|---|---|
+| Mid-stream (agent answering) | `OnTurnEnd → drainTurnQueues` drains `m.pendingMainEvents` | next turn boundary |
+| Idle (between turns) | `onMainEvent` itself takes the `!Stream.Active` branch and injects directly | immediate |
+
+The idle branch is what handles the common case of a background
+subagent finishing long after the launching turn ended. `pendingMainEvents`
+exists only to bridge events that landed *during* a stream — those
+must wait so they don't collide with the answer in progress.
+
+The hub publisher side is unchanged: a subagent (or any background
+task) finishes → `notifyTaskCompleted` → the task-lifecycle handler
+registered in `wireTaskLifecycle` calls `agentEventHub.Publish` → the
+`Register("main", ...)` callback pushes onto `m.mainEvents`. So the
+producers are background tasks (`run_in_background: true` agents and
+bash commands); the only event type today is `"task.completed"`.
+
+Same pattern as `conv.DrainAgentOutbox` reading the agent outbox chan
+— two Go channels, two blocking-receive cmds, one Update loop. No
+polling, no tick, zero idle CPU.
+
 ### What inject* does
 
 Each inject* function has the same shape: tell the user what triggered
@@ -287,6 +336,83 @@ each inject*
 All three converge on **SubmitToAgent**. Same provider check, same
 `ensureAgentSession`, same `sendToAgent` push. There is no other way
 to reach the agent's inbox from the TUI.
+
+### End-to-end trace: subagent done → main agent inbox
+
+Putting all the pieces above together — this is exactly what happens
+between the moment a background subagent finishes and the moment its
+result hits the main agent's inbox to drive the next turn. Three
+goroutines are involved; each `─ ─ ─►` is a handoff across one.
+
+```
+   Subagent goroutine               TUI Update goroutine            Main Agent goroutine
+   ──────────────────               ────────────────────            ────────────────────
+   ① task.Run() returns
+       │
+       ▼
+   ② notifyTaskCompleted(info)
+       │   task/hooks.go
+       ▼
+   ③ lifecycleHandler.TaskCompleted
+       │   model_lifecycle.go:194
+       ▼
+   ④ agentEventHub.Publish(
+       Type: "task.completed",
+       Target: "main", ...)
+       │   model_lifecycle.go:203
+       ▼
+   ⑤ Register("main",...) callback
+       │   model_lifecycle.go:30
+       ▼
+   ⑥ m.mainEvents <- e  ─ ─ ─ ─ ─►  ⑦ awaitMainEvent unblocks
+                                       returns mainEventMsg{event}
+                                       (was parked on chan in own
+                                        goroutine spawned by Init)
+                                          │   bubbletea routes the
+                                          │   msg to Update loop
+                                          ▼
+                                       ⑧ Update case mainEventMsg:
+                                          → onMainEvent(ev)
+                                          │   model_turn_queue.go
+                                          ├─ append to pendingMainEvents
+                                          ├─ restart awaitMainEvent
+                                          ▼
+                                       ⑨ Stream.Active?
+                                          ├─ true → return; wait OnTurnEnd
+                                          │         to call drainTurnQueues
+                                          └─ false → fall through ↓
+                                          ▼
+                                      ⑩ injectNotification(merged)
+                                          ├─ conv.AddNotice("…completed")
+                                          └─ SubmitToAgent(content, nil)
+                                          │   update_submit.go
+                                          ├─ check LLMProvider
+                                          ├─ ensureAgentSession
+                                          ▼
+                                      ⑪ sendToAgent(content, images)
+                                          │   agent.go
+                                          ├─ attachPendingReminders
+                                          ▼
+                                      ⑫ m.services.Agent.Send(...)
+                                          ◄── ENTERS MAIN AGENT INBOX ──►  ⑬ agent picks up
+                                                                                from inbox,
+                                                                                runs a turn
+                                                                                (now → Path D)
+```
+
+Key handoffs:
+
+| Step | What crosses what | Mechanism |
+|---|---|---|
+| ⑥ → ⑦ | subagent goroutine → TUI Update goroutine | Go chan (`m.mainEvents`) + blocking-receive `tea.Cmd` |
+| ⑫ → ⑬ | TUI Update goroutine → main agent goroutine | `Agent.Send` writes the agent's internal inbox chan |
+
+Two chans, two goroutine boundaries. The TUI sits in the middle on
+purpose — that's where `AddNotice`, provider/session checks, and
+priority ordering happen. If a Stream.Active=true diverted us into
+the `pendingMainEvents` branch at ⑨, the same ⑩-⑫ sequence runs
+later from `drainTurnQueues` at the next OnTurnEnd; the only
+difference is *when*.
 
 ## Path D — Agent → render
 

--- a/docs/concepts/data-flow.zh.md
+++ b/docs/concepts/data-flow.zh.md
@@ -247,8 +247,53 @@ OnTurnEnd                                    model_agent_events.go
         ├─ 用户输入队列?     ─── 流式期间排过队的（直接发，不走 inject*）
         ├─ cron 队列?         ──► injectCronPrompt(prompt)
         ├─ 异步 hook 队列?    ──► injectAsyncHookContinuation(item)
-        └─ agentEventHub 批量 ──► injectNotification(merged hub.Message)
+        └─ m.pendingMainEvents ──► injectNotification(merged hub.Message)
 ```
+
+### 唤醒 Update 循环（idle 路径）
+
+`drainTurnQueues` 只在 `OnTurnEnd` 跑一次，所以两个 turn **之间**到达
+的事件（subagent 启动几分钟后才完成的常见情况）需要另一条路径唤醒
+Update 循环。Hub 那一侧的投递本来就是 Go channel（`m.mainEvents`），
+所以直接借用 agent outbox 的同款套路——一个**阻塞接收的 `tea.Cmd`**，
+把 "chan 上的下一条消息" 转成 `tea.Msg`：
+
+```
+Init                                       model.go
+   └─ awaitMainEvent(m.mainEvents)         model_turn_queue.go
+        └─ 阻塞读 chan，到一条就 yield mainEventMsg{event}
+
+Update                                     update.go
+   case mainEventMsg:
+        └─ onMainEvent(ev)                 model_turn_queue.go
+              ├─ 把 ev（连同 chan 上的同伴）追加到 m.pendingMainEvents
+              ├─ 重新挂一次 awaitMainEvent，等下次 publish 唤醒
+              └─ 如果 !Stream.Active:
+                   injectNotification(merge(pending))；清空 pending
+```
+
+`onMainEvent` 每次都重新挂一次 `awaitMainEvent`——安全的，因为重新挂
+时 chan 已经被读空，下一次触发会一直阻塞等下次 publish（不会自旋）。
+事件到达时根据 agent 状态走两条不同路径：
+
+| 事件什么时候到 | 谁来交付 | 延迟 |
+|---|---|---|
+| 流式期间（agent 正在回答） | `OnTurnEnd → drainTurnQueues` 读 `m.pendingMainEvents` | 当前 turn 结束 |
+| 闲着（turn 之间） | `onMainEvent` 自己走 `!Stream.Active` 分支直接 inject | 立刻 |
+
+idle 分支正是处理你最常遇到的情况：后台 subagent 在启动它的那一轮
+turn 结束很久之后才完成。`pendingMainEvents` 只为"流式期间到的"事件
+存在 —— 那种必须等，免得跟正在生成的回答撞车。
+
+Hub 的 publisher 侧没有变化：subagent（或任何后台 task）完成 →
+`notifyTaskCompleted` → `wireTaskLifecycle` 里注册的 lifecycle handler
+调用 `agentEventHub.Publish` → `Register("main", ...)` 回调推入
+`m.mainEvents`。所以 producer 就是后台 task（`run_in_background: true`
+的 agent 和 bash 命令）；当前只有一种事件 `"task.completed"`。
+
+跟 `conv.DrainAgentOutbox` 读 agent outbox chan 是同一个套路——两个
+Go channel、两个 block-receive cmd、一个 Update 循环。没有 polling、
+没有 tick、idle 时 0 CPU。
 
 ### inject* 在干啥
 
@@ -273,6 +318,80 @@ OnTurnEnd                                    model_agent_events.go
 三条路径都汇聚到 **SubmitToAgent**。一样的 provider 检查、一样的
 `ensureAgentSession`、一样的 `sendToAgent` 推入。**没有别的途径**
 能进 agent 的 inbox。
+
+### 端到端走一遍：subagent 完成 → 主 agent inbox
+
+把上面这些拼起来 —— 一个后台 subagent 完成，到它的产出落进主 agent
+inbox 触发下一轮，中间发生的就是这一串。**涉及三条 goroutine**，每条
+`─ ─ ─►` 都是一次跨 goroutine 的交付。
+
+```
+   Subagent goroutine               TUI Update goroutine            主 Agent goroutine
+   ──────────────────               ────────────────────            ────────────────────
+   ① task.Run() 返回
+       │
+       ▼
+   ② notifyTaskCompleted(info)
+       │   task/hooks.go
+       ▼
+   ③ lifecycleHandler.TaskCompleted
+       │   model_lifecycle.go:194
+       ▼
+   ④ agentEventHub.Publish(
+       Type: "task.completed",
+       Target: "main", ...)
+       │   model_lifecycle.go:203
+       ▼
+   ⑤ Register("main",...) 回调触发
+       │   model_lifecycle.go:30
+       ▼
+   ⑥ m.mainEvents <- e  ─ ─ ─ ─ ─►  ⑦ awaitMainEvent 解阻塞
+                                       返回 mainEventMsg{event}
+                                       (Init 时挂在 chan 上的那个
+                                        goroutine，此刻才醒)
+                                          │   bubbletea 把这条 msg
+                                          │   送回 Update 循环
+                                          ▼
+                                       ⑧ Update case mainEventMsg:
+                                          → onMainEvent(ev)
+                                          │   model_turn_queue.go
+                                          ├─ append 到 pendingMainEvents
+                                          ├─ 重启 awaitMainEvent
+                                          ▼
+                                       ⑨ Stream.Active?
+                                          ├─ true  → return; 等 OnTurnEnd
+                                          │           调 drainTurnQueues
+                                          └─ false → 继续 ↓
+                                          ▼
+                                      ⑩ injectNotification(merged)
+                                          ├─ conv.AddNotice("…completed")
+                                          └─ SubmitToAgent(content, nil)
+                                          │   update_submit.go
+                                          ├─ 检查 LLMProvider
+                                          ├─ ensureAgentSession
+                                          ▼
+                                      ⑪ sendToAgent(content, images)
+                                          │   agent.go
+                                          ├─ attachPendingReminders
+                                          ▼
+                                      ⑫ m.services.Agent.Send(...)
+                                          ◄── 进入主 AGENT INBOX ──►  ⑬ agent 从 inbox 取出
+                                                                          运行新一轮 turn
+                                                                          （后面就是 Path D）
+```
+
+关键的跨 goroutine 交付：
+
+| 步骤 | 从哪儿到哪儿 | 机制 |
+|---|---|---|
+| ⑥ → ⑦ | subagent goroutine → TUI Update goroutine | Go chan (`m.mainEvents`) + 阻塞接收的 `tea.Cmd` |
+| ⑫ → ⑬ | TUI Update goroutine → 主 agent goroutine | `Agent.Send` 写 agent 自己的 inbox chan |
+
+**两条 chan、两道 goroutine 边界**。TUI 故意夹在中间 —— `AddNotice`、
+provider/session 检查、优先级排序，这些都是 TUI 该干的事。如果 ⑨
+那里碰上 Stream.Active=true 走了 `pendingMainEvents` 分支，⑩-⑫ 这串
+完全一样的步骤会在下一次 `OnTurnEnd` 由 `drainTurnQueues` 触发，
+**唯一的差别就是早一点还是晚一点**。
 
 ## Path D —— Agent → 渲染
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -35,13 +35,14 @@ const defaultWidth = 80
 
 type model struct {
 	// ── Sub-models (one per event source / concern) ─────────────
-	userInput     input.Model    // Source 1: user keyboard input
-	agentEventHub *hub.Hub       // Source 2: inter-agent event routing (pure pub/sub)
-	mainEvents    chan hub.Event // TUI turn-boundary buffer: batches async events (task completions, agent messages) for priority-ordered drain
-	systemInput   trigger.Model  // Source 3: system events (cron/hooks/watcher)
-	conv          conv.Model     // Agent Outbox: conversation + output rendering
-	env           env            // Shared app state: provider, session, permission, plan, config
-	services      services       // Domain service singletons, injected at construction
+	userInput         input.Model    // Source 1: user keyboard input
+	agentEventHub     *hub.Hub       // Source 2: inter-agent event routing (pure pub/sub)
+	mainEvents        chan hub.Event // hub-side delivery chan; awaitMainEvent reads it
+	pendingMainEvents []hub.Event    // events that arrived mid-stream, drained at OnTurnEnd
+	systemInput       trigger.Model  // Source 3: system events (cron/hooks/watcher)
+	conv              conv.Model     // Agent Outbox: conversation + output rendering
+	env               env            // Shared app state: provider, session, permission, plan, config
+	services          services       // Domain service singletons, injected at construction
 }
 
 var (
@@ -56,6 +57,7 @@ func (m *model) Init() tea.Cmd {
 		trigger.TriggerCronTickNow(),
 		trigger.StartCronTicker(),
 		trigger.StartAsyncHookTicker(),
+		awaitMainEvent(m.mainEvents),
 	}
 	if m.env.InitialPrompt != "" {
 		prompt := m.env.InitialPrompt

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -74,9 +74,15 @@ func (m *model) drainTurnQueues() (tea.Cmd, bool) {
 		}
 	}
 
-	if events := drainEvents(m.mainEvents, maxEventsPerDrain); len(events) > 0 {
-		msgs := eventsToMessages(events)
-		return m.injectNotification(hub.Merge(msgs)), true
+	if len(m.pendingMainEvents) > 0 {
+		events := m.pendingMainEvents
+		m.pendingMainEvents = nil
+		// Listener may have just re-armed during OnTurnEnd processing;
+		// catch any chan events that landed in that window too.
+		if extra := drainEvents(m.mainEvents, maxEventsPerDrain-len(events)); len(extra) > 0 {
+			events = append(events, extra...)
+		}
+		return m.injectHubEvents(events), true
 	}
 
 	return nil, false
@@ -106,6 +112,35 @@ func drainEvents(ch <-chan hub.Event, max int) []hub.Event {
 		}
 	}
 	return out
+}
+
+// mainEventMsg wraps a hub.Event for delivery to the Update loop.
+// Counterpart to AgentOutboxMsg for the agent outbox chan.
+type mainEventMsg struct{ event hub.Event }
+
+// awaitMainEvent blocks until one event arrives on the chan, then
+// yields a mainEventMsg. onMainEvent re-arms after handling.
+func awaitMainEvent(ch <-chan hub.Event) tea.Cmd {
+	return func() tea.Msg {
+		return mainEventMsg{event: <-ch}
+	}
+}
+
+// onMainEvent injects the event immediately when idle, or queues it
+// in pendingMainEvents for drainTurnQueues at the next turn boundary
+// (mid-stream). Re-arming is unconditional: after the read the chan
+// is empty, so the next firing waits for the next publish.
+func (m *model) onMainEvent(ev hub.Event) tea.Cmd {
+	next := awaitMainEvent(m.mainEvents)
+	if m.conv.Stream.Active {
+		m.pendingMainEvents = append(m.pendingMainEvents, ev)
+		return next
+	}
+	return tea.Batch(m.injectHubEvents([]hub.Event{ev}), next)
+}
+
+func (m *model) injectHubEvents(events []hub.Event) tea.Cmd {
+	return m.injectNotification(hub.Merge(eventsToMessages(events)))
 }
 
 func eventsToMessages(events []hub.Event) []hub.Message {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -110,6 +110,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case stopHookResultMsg:
 		return m, m.handleStopHookResult(msg)
+	case mainEventMsg:
+		return m, m.onMainEvent(msg.event)
 	}
 
 	if cmd, handled := m.routeToSubModel(msg); handled {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -121,7 +121,10 @@ func (m model) renderChatSection(activeContent, trackerView string) string {
 	}
 
 	if trackerView != "" {
-		parts = append(parts, strings.TrimSuffix(trackerView, "\n"))
+		// Leading "\n" forces a blank line between the assistant content
+		// (often flushed to scrollback via tea.Println) and the tracker
+		// block that anchors the bottom of the active view.
+		parts = append(parts, "\n"+strings.TrimSuffix(trackerView, "\n"))
 	}
 
 	if m.userInput.Provider.FetchingLimits {


### PR DESCRIPTION
## Summary

Branch built up across three loosely-related threads — all in the `internal/app` area + supporting docs. No behavior change for end users except the bug fix at the end.

### Submit path refactor
Collapse the indirection layers around "send to agent" so all callers (Enter key, slash command, skill button, cron fire, hook continuation, hub notification) converge on one entry point:
- `StartProviderTurn` → `SubmitToAgent`
- Centralize agent submission; merge `inject*` + skill paths through `SubmitToAgent`
- Dispatch lives on `*model` directly (no separate handler struct)
- Slim `CommandDeps`: services in, snapshot fields out
- `Command*` → `SlashCommand*` (the package is about slash commands, not generic ones)

### App / conv internal cleanup
- `overlay` → `popup` (matches what it actually is); document keypress priority stack
- Normalize event-callback names; pair up keypress twins (`On*` / `handle*`)
- `eventHub` → `agentEventHub`, `deps` → `env` (clearer at call sites)
- `Pairs` → `InlinedResults` in conv; pairing logic moves to a dedicated `pairToolResults`
- `RenderContext` consolidates the parameter sprawl; tighten `View()` shape

### Concept docs (new)
Two long-form architecture docs explaining the runtime end-to-end. Both have Chinese translations.

- **`docs/concepts/data-flow.md`** — every path a message can take: user input, slash commands, background triggers (cron / async hook / hub events), agent → render. Includes worked example for the streaming reply path and an end-to-end trace of subagent done → main agent inbox (newly added).
- **`docs/concepts/rendering.md`** — how the TUI assembles output: scrollback vs repaint zone, `View()` shape, `Render*` contract.

### Bug fix
- **Wake Update loop on background hub events** (`96a582f`): `m.mainEvents` was published into but had no idle consumer, so a subagent finishing between turns would sit buffered until the user typed something. Add a blocking-receive `tea.Cmd` (`awaitMainEvent`) mirroring the `DrainAgentOutbox` pattern. Idle events inject immediately; mid-stream events stash in `pendingMainEvents` for `drainTurnQueues` at the turn boundary.
- **Tracker view blank line**: prepend `\n` so the Tasks block has visual separation from the assistant content above (which is often flushed to scrollback).

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] Manual: launch background subagent(s), confirm the completion notification fires after the launching turn ends (without needing user input to wake the UI)
- [ ] Manual: confirm tracker list shows a blank line above it
- [ ] Manual: smoke-test slash commands, skill invocation, /clear, /compact — submit paths all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)