### PR TITLE
🐛 fix: /agent and /skills tab switching skips empty tabs despite help hint

### DIFF
--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -251,15 +251,9 @@ func (s *AgentSelector) cycleTab(delta int) {
 		}
 	}
 	n := len(tabs)
-	for step := 1; step <= n; step++ {
-		next := tabs[((idx+delta*step)%n+n)%n]
-		s.activeTab = next
-		s.applyFilters()
-		// Allow landing on empty tabs only when no other tab has items.
-		if len(s.filteredAgents) > 0 || s.tabCount(next) > 0 {
-			return
-		}
-	}
+	next := tabs[((idx+delta)%n+n)%n]
+	s.activeTab = next
+	s.applyFilters()
 }
 
 func (s *AgentSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {

--- a/internal/app/kit/panel.go
+++ b/internal/app/kit/panel.go
@@ -94,10 +94,7 @@ func RenderPanelTabs(tabs []PanelTab, active int) string {
 		if !t.Show {
 			continue
 		}
-		label := t.Name
-		if t.Count > 0 {
-			label = fmt.Sprintf("%s %d", t.Name, t.Count)
-		}
+		label := fmt.Sprintf("%s %d", t.Name, t.Count)
 		switch {
 		case t.Disable:
 			parts = append(parts, disabledStyle.Render(label))


### PR DESCRIPTION
## Summary
- The help line says "←/→/Tab switch tab", but `cycleTab` skipped tabs with zero items, so when only Built-in agents existed the user was stuck and could never reach Project or User
- Also always render tab counts (including 0) so empty tabs don't look like they were simply omitted

## Test plan
- [x] Open `/agent` with only Built-in agents defined — verify Tab/→ switches to Project and User tabs (showing "No Project agents" / "No User agents")
- [x] Open `/skills` — verify tabs show count (e.g., "Project 5  User 0") and switching works on empty tabs