### PR TITLE
feat(app): persist thinking effort per model across launches

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -182,7 +182,8 @@ func RenderThinkingIndicator(effort string) string {
 		return ""
 	}
 	style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent)
-	return "  " + style.Render("✦ "+effort)
+	hint := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted).Render(" (ctrl+t to cycle)")
+	return "  " + style.Render("✦ "+effort) + hint
 }
 
 // toolResultIcon returns the icon for tool results based on error state.

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -5,8 +5,11 @@ package app
 import (
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/genai-io/gen-code/internal/filecache"
 	"github.com/genai-io/gen-code/internal/llm"
+	"github.com/genai-io/gen-code/internal/log"
 	"github.com/genai-io/gen-code/internal/setting"
 )
 
@@ -45,10 +48,15 @@ type env struct {
 	FileCache                 *filecache.Cache
 	CachedUserInstructions    string
 	CachedProjectInstructions string
+
+	// ── Persistence handle (per-model thinking effort, etc.) ────
+	// Held as a field so env-level setters can write through without
+	// reaching for package globals; nil-safe in tests that bypass newEnv.
+	store *llm.Store
 }
 
 func newEnv(llmSvc *llm.ClientFactory, cwd string, isGit bool) env {
-	return env{
+	e := env{
 		CWD:   cwd,
 		IsGit: isGit,
 
@@ -59,7 +67,42 @@ func newEnv(llmSvc *llm.ClientFactory, cwd string, isGit bool) env {
 		CurrentModel: llmSvc.CurrentModel(),
 
 		FileCache: filecache.New(),
+		store:     llmSvc.Store(),
 	}
+	// Restore the user's prior per-model thinking-effort choice. Empty
+	// means "use provider default" — EffectiveThinkingEffort handles that.
+	if e.store != nil && e.CurrentModel != nil {
+		e.ThinkingEffort = e.store.GetThinkingEffort(e.CurrentModel.ModelID)
+	}
+	return e
+}
+
+// SetThinkingEffort updates the in-memory thinking-effort selection and
+// persists it for the current model. Call this for explicit user choices
+// (Ctrl+T, /think); keyword-driven auto-bumps stay in-memory only, so a
+// stray "ultrathink" in a prompt doesn't lock the model into the top tier.
+func (m *env) SetThinkingEffort(effort string) {
+	m.ThinkingEffort = effort
+	if m.store == nil || m.CurrentModel == nil {
+		return
+	}
+	if err := m.store.SetThinkingEffort(m.CurrentModel.ModelID, effort); err != nil {
+		log.Logger().Warn("persist thinking effort",
+			zap.String("model", m.CurrentModel.ModelID),
+			zap.String("effort", effort),
+			zap.Error(err))
+	}
+}
+
+// LoadThinkingEffortFromStore refreshes ThinkingEffort from the persisted
+// per-model preference. Called after switching models so each model recalls
+// its own last-chosen effort.
+func (m *env) LoadThinkingEffortFromStore() {
+	if m.store == nil || m.CurrentModel == nil {
+		m.ThinkingEffort = ""
+		return
+	}
+	m.ThinkingEffort = m.store.GetThinkingEffort(m.CurrentModel.ModelID)
 }
 
 func (m *env) GetModelID() string {

--- a/internal/app/model_subfeature_wiring.go
+++ b/internal/app/model_subfeature_wiring.go
@@ -1,8 +1,9 @@
-// Deps builders: every sub-feature (input, conv, trigger) takes its
-// dependencies via a struct rather than reaching for package globals. These
-// methods assemble those structs from the model's services + env state.
-// Putting them in one place keeps the call sites in update.go / model.go
-// concise and makes the surface each sub-feature uses explicit.
+// Sub-feature wiring: every sub-feature (input overlay, prompt suggestion,
+// trigger) declares the surface it uses via a Deps struct rather than
+// reaching for package globals. The functions here translate the model's
+// services + env state into those structs. Keeping the wiring in one file
+// keeps update.go / model.go concise and makes each sub-feature's surface
+// explicit at the call site.
 package app
 
 import (
@@ -38,6 +39,7 @@ func (m *model) overlayDeps() input.OverlayDeps {
 		},
 		SetCurrentModel: func(info *llm.CurrentModelInfo) {
 			m.env.CurrentModel = info
+			m.env.LoadThinkingEffortFromStore()
 		},
 		ClearCachedInstructions: m.env.ClearCachedInstructions,
 		RefreshMemoryContext:    m.refreshMemoryContext,

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -1,9 +1,8 @@
-// Sub-feature wiring: every sub-feature (input overlay, prompt suggestion,
-// trigger) declares the surface it uses via a Deps struct rather than
-// reaching for package globals. The functions here translate the model's
-// services + env state into those structs. Keeping the wiring in one file
-// keeps update.go / model.go concise and makes each sub-feature's surface
-// explicit at the call site.
+// Methods on *model that exist for sub-features (input overlay, prompt
+// suggestion, trigger) to consume. Most build the Deps struct each
+// sub-feature declares; a few expose model state (spinner tick, cron
+// queue reset) or actions (external editor) the sub-features need.
+// Centralized here so update.go / model.go stay focused on the main loop.
 package app
 
 import (

--- a/internal/app/update_command.go
+++ b/internal/app/update_command.go
@@ -35,7 +35,7 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 
 		// Env callbacks
 		GetThinkingEffort: func() string { return m.env.EffectiveThinkingEffort() },
-		SetThinkingEffort: func(effort string) { m.env.ThinkingEffort = effort },
+		SetThinkingEffort: m.env.SetThinkingEffort,
 		ResetTokens:       m.env.ResetTokens,
 
 		// Model actions

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -184,7 +184,7 @@ func (m *model) cycleThinkingEffort() tea.Cmd {
 		return kit.StatusTimer(3*time.Second, token)
 	}
 
-	m.env.ThinkingEffort = next
+	m.env.SetThinkingEffort(next)
 	status := "thinking: " + next
 	if current != "" && current == next {
 		status += " (only supported)"

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -43,11 +43,12 @@ type tokenLimitOverride struct {
 
 // storeData is the persisted data structure
 type storeData struct {
-	Connections    map[string]ConnectionInfo     `json:"connections"`              // key: provider
-	Models         map[string]modelCache         `json:"models"`                   // key: provider:authMethod
-	Current        *CurrentModelInfo             `json:"current"`                  // current model with provider info
-	SearchProvider *string                       `json:"searchProvider,omitempty"` // search provider name (exa, serper, brave)
-	TokenLimits    map[string]tokenLimitOverride `json:"tokenLimits,omitempty"`    // key: modelID
+	Connections     map[string]ConnectionInfo     `json:"connections"`               // key: provider
+	Models          map[string]modelCache         `json:"models"`                    // key: provider:authMethod
+	Current         *CurrentModelInfo             `json:"current"`                   // current model with provider info
+	SearchProvider  *string                       `json:"searchProvider,omitempty"`  // search provider name (exa, serper, brave)
+	TokenLimits     map[string]tokenLimitOverride `json:"tokenLimits,omitempty"`     // key: modelID
+	ThinkingEfforts map[string]string             `json:"thinkingEfforts,omitempty"` // key: modelID; value: provider-native effort label
 }
 
 // Store manages provider configuration persistence
@@ -114,6 +115,9 @@ func (s *Store) ensureMapsInitialized() {
 	}
 	if s.data.TokenLimits == nil {
 		s.data.TokenLimits = make(map[string]tokenLimitOverride)
+	}
+	if s.data.ThinkingEfforts == nil {
+		s.data.ThinkingEfforts = make(map[string]string)
 	}
 }
 
@@ -322,6 +326,29 @@ func (s *Store) SetTokenLimit(modelID string, inputLimit, outputLimit int) error
 		s.data.Models[key] = cache
 	}
 
+	return s.save()
+}
+
+// GetThinkingEffort returns the persisted thinking effort for modelID,
+// or "" when no preference has been saved (fall back to provider default).
+func (s *Store) GetThinkingEffort(modelID string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data.ThinkingEfforts[modelID]
+}
+
+// SetThinkingEffort saves the thinking effort for modelID.
+// Passing "" deletes the entry so future loads fall back to the provider default.
+func (s *Store) SetThinkingEffort(modelID, effort string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureMapsInitialized()
+	if effort == "" {
+		delete(s.data.ThinkingEfforts, modelID)
+	} else {
+		s.data.ThinkingEfforts[modelID] = effort
+	}
 	return s.save()
 }
 


### PR DESCRIPTION
## Summary

- Persist thinking effort per model in `~/.gen/providers.json` (keyed by modelID, sibling to `TokenLimits`); restore on startup and on model switch so each model recalls its own tier.
- `Ctrl+T` / `/think` write through; keyword auto-bumps (e.g. `ultrathink` in a prompt) stay in-memory only.
- Indicator gains a muted hint: `✦ high (ctrl+t to cycle)`, mirroring the mode-status pattern.
- Rename `model_deps.go` → `model_subfeatures.go` to match the existing `model_<aspect>.go` naming.

## Test plan

- [ ] `Ctrl+T` cycles; restart — same model comes back at the same tier
- [ ] Different models remember different tiers across model switches
- [ ] `ultrathink` in a prompt bumps for the session but does not persist
- [ ] Indicator shows the `(ctrl+t to cycle)` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)