### PR TITLE
Rotate the agent task indicator instead of flickering

### DIFF
--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -300,7 +300,8 @@ func TestRenderToolCallsShowsGapForPendingAgent(t *testing.T) {
 	}
 
 	rendered := RenderToolCalls(params)
-	if !strings.Contains(rendered, "○ Agent - Explorer: HA code structure") {
+	want := agentIcon(params.Blink) + " Agent - Explorer: HA code structure"
+	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want a single visible gap before explicit agent label", rendered)
 	}
 }
@@ -322,7 +323,8 @@ func TestRenderToolCallsNamesGeneralAgentByMode(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "○ Agent - Explorer: audit git changes") {
+	want := agentIcon(params.Blink) + " Agent - Explorer: audit git changes"
+	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want mode-based agent label", rendered)
 	}
 }
@@ -357,7 +359,8 @@ func TestRenderToolCallsShowsSingleAgentRuntimeProgress(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "○ Agent - Explorer: audit git changes before review") {
+	want := agentIcon(params.Blink) + " Agent - Explorer: audit git changes before review"
+	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want agent header", rendered)
 	}
 	if !strings.Contains(rendered, "model: gpt-5.4-mini") || !strings.Contains(rendered, "mode: explore") || !strings.Contains(rendered, "tools: 4") {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -929,13 +929,19 @@ func agentColorForInput(input string, colors map[string]string) string {
 	return colors[strings.ToLower(parseAgentInput(input).Type)]
 }
 
-const agentBlinkTicks = 6
+// agentBlinkTicks is the number of spinner ticks each frame is held for.
+// One spinner tick is ~120ms (see newSpinner in model.go).
+const agentBlinkTicks = 3
+
+// agentSpinFrames cycle 4-pt → 6-pt → 8-pt → 6-pt stars so the icon reads
+// as rotating while it runs.
+var agentSpinFrames = []string{"✦", "✶", "✸", "✶"}
 
 func agentIcon(tick int) string {
-	if (tick/agentBlinkTicks)%2 == 0 {
-		return "●"
+	if tick < 0 {
+		tick = 0
 	}
-	return "○"
+	return agentSpinFrames[(tick/agentBlinkTicks)%len(agentSpinFrames)]
 }
 
 func truncateToolLabel(label string, width int) string {


### PR DESCRIPTION
## Summary
- Replace the binary `●` ↔ `○` toggle on the agent task line with a four-frame star rotation (`✦ → ✶ → ✸ → ✶`) at ~360ms/frame, so the icon reads as a spinning star rather than a flicker.
- Decouple the three agent-label assertions in `message_test.go` from the specific frame characters by building the expected prefix via `agentIcon(...)`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/conv/...`
- [ ] Run the app, spawn an Agent subtask, and confirm the indicator next to the agent label spins smoothly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)