### PR TITLE
Rotate the thinking spinner; restore ● / ○ for agent icon

### DIFF
--- a/internal/app/conv/model.go
+++ b/internal/app/conv/model.go
@@ -40,9 +40,11 @@ func (m *OutputModel) ResizeMDRenderer(width int) {
 
 func newSpinner() spinner.Model {
 	sp := spinner.New()
+	// 4-pt → 6-pt → 8-pt → 6-pt stars read as a rotating sparkle while
+	// the model is thinking / streaming.
 	sp.Spinner = spinner.Spinner{
-		Frames: []string{"⋅", "·", "•", "●", "•", "·", "⋅"},
-		FPS:    120 * time.Millisecond,
+		Frames: []string{"✦", "✶", "✸", "✶"},
+		FPS:    360 * time.Millisecond,
 	}
 	sp.Style = lipgloss.NewStyle()
 	return sp

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -929,19 +929,16 @@ func agentColorForInput(input string, colors map[string]string) string {
 	return colors[strings.ToLower(parseAgentInput(input).Type)]
 }
 
-// agentBlinkTicks is the number of spinner ticks each frame is held for.
-// One spinner tick is ~120ms (see newSpinner in model.go).
-const agentBlinkTicks = 3
-
-// agentSpinFrames cycle 4-pt → 6-pt → 8-pt → 6-pt stars so the icon reads
-// as rotating while it runs.
-var agentSpinFrames = []string{"✦", "✶", "✸", "✶"}
+// agentBlinkTicks is the number of spinner ticks per ● / ○ swap.
+// One spinner tick is ~360ms (see newSpinner in model.go), so 2 ticks
+// gives the familiar ~720ms blink.
+const agentBlinkTicks = 2
 
 func agentIcon(tick int) string {
-	if tick < 0 {
-		tick = 0
+	if (tick/agentBlinkTicks)%2 == 0 {
+		return "●"
 	}
-	return agentSpinFrames[(tick/agentBlinkTicks)%len(agentSpinFrames)]
+	return "○"
 }
 
 func truncateToolLabel(label string, width int) string {


### PR DESCRIPTION
## Summary
- Move the four-frame rotating star (`✦ → ✶ → ✸ → ✶`) from the agent task indicator to the main thinking/streaming spinner — it now shows up next to the AI icon, in compact status, and on each tool row while a call is in flight. Frame rate slows to 360ms so the rotation reads cleanly instead of strobing.
- Revert the agent task icon back to the original `● / ○` binary blink. With one spinner tick now at 360ms, `agentBlinkTicks=2` keeps the wall-clock period at the familiar ~720ms.

## Follow-up to
Swaps the assignments from #42 (which had the star on the agent icon).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/conv/...`
- [ ] `./bin/gen` — send any prompt and watch the AI icon spin `✦ → ✶ → ✸ → ✶`; spawn an Agent subtask and confirm the line in front of it still does the `● / ○` blink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)