### PR TITLE
Welcome splash: single-line brand mark + lighter ❭ prompt

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -36,21 +36,6 @@ const (
 	agentContentIndent = "    "
 )
 
-// RenderWelcome renders the welcome screen.
-func RenderWelcome() string {
-	genStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.AI).Bold(true)
-	bracketStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Primary).Bold(true)
-	slashStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true)
-
-	icon := bracketStyle.Render("   < ") +
-		genStyle.Render("GEN") +
-		slashStyle.Render(" ✦ ") +
-		slashStyle.Render("/") +
-		bracketStyle.Render(">")
-
-	return "\n" + icon
-}
-
 // OperationModeParams holds the parameters needed for rendering mode status.
 type OperationModeParams struct {
 	Mode             OperationMode
@@ -277,7 +262,7 @@ var inlineImageTokenPattern = regexp.MustCompile(`\[Image #\d+\]`)
 // RenderUserMessage renders a user message with prompt and optional images.
 func RenderUserMessage(content, displayContent string, images []core.Image, mdRenderer *MDRenderer, width int) string {
 	var sb strings.Builder
-	prompt := InputPromptStyle.Render("❯ ")
+	prompt := InputPromptStyle.Render("❭ ")
 	if displayContent == "" {
 		displayContent = content
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -32,6 +32,16 @@ func Run(opts setting.RunOptions) error {
 		return err
 	}
 
+	// Fresh sessions get the splash screen before Bubbletea takes over.
+	// Resumed sessions skip it — commitAllMessages will reprint the
+	// conversation immediately, so a splash would just be churn.
+	if len(m.conv.Messages) == 0 {
+		printWelcome(welcomeInfo{
+			Model: m.services.LLM.ModelID(),
+			CWD:   m.env.CWD,
+		})
+	}
+
 	finalModel, err := tea.NewProgram(m).Run()
 	if err != nil {
 		return fmt.Errorf("failed to run TUI: %w", err)

--- a/internal/app/update_resize.go
+++ b/internal/app/update_resize.go
@@ -23,11 +23,11 @@ func (m *model) handleWindowResize(msg tea.WindowSizeMsg) tea.Cmd {
 	if !m.env.Ready {
 		m.env.Ready = true
 
+		// Welcome banner is drawn before tea.NewProgram (see run.go); here
+		// we only need to commit any resumed conversation.
 		var cmds []tea.Cmd
 		if len(m.conv.Messages) > 0 {
 			cmds = append(cmds, m.commitAllMessages()...)
-		} else {
-			cmds = append(cmds, tea.Println(conv.RenderWelcome()))
 		}
 
 		if m.userInput.Session.PendingSelector {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -105,7 +105,7 @@ func separatorWrapped(trackerPrefix, separator, content string) string {
 }
 
 func (m model) renderInputView() string {
-	prompt := conv.InputPromptStyle.Render("❯ ")
+	prompt := conv.InputPromptStyle.Render("❭ ")
 	if m.userInput.PromptSuggestion.Text != "" && m.userInput.Textarea.Value() == "" &&
 		!m.conv.Stream.Active && !m.userInput.Suggestions.IsVisible() {
 		return prompt + ghostTextStyle.Render(m.userInput.PromptSuggestion.Text)

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -1,0 +1,96 @@
+// Interactive-mode splash: a single-line brand mark + cwd-basename + model,
+// nothing else. Called once at startup, before tea.NewProgram(m).Run() —
+// Bubbletea draws inline, so the splash stays in scrollback above the
+// live view.
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+)
+
+// Three-hue palette: teal for the brand mark, star blue for the ✦ accent
+// inside the logo, dim gray for everything else. Each token has Dark and
+// Light variants so contrast holds either way.
+var (
+	welcomeTeal = lipgloss.AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"}
+	welcomeStar = lipgloss.AdaptiveColor{Dark: "#7FD4FF", Light: "#0284C7"}
+	welcomeDim  = lipgloss.AdaptiveColor{Dark: "#65707A", Light: "#9CA3AF"}
+)
+
+type welcomeInfo struct {
+	Model string
+	CWD   string
+}
+
+// printWelcome writes the splash to stdout. Falls back to plain text when
+// stdout is not a TTY or NO_COLOR is set.
+func printWelcome(info welcomeInfo) {
+	if !welcomeUseColor() {
+		printWelcomePlain(info)
+		return
+	}
+	fmt.Println(renderWelcome(info))
+}
+
+func welcomeUseColor() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func renderWelcome(info welcomeInfo) string {
+	var (
+		star    = lipgloss.NewStyle().Foreground(welcomeStar)
+		brand   = lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
+		bracket = lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
+		dim     = lipgloss.NewStyle().Foreground(welcomeDim)
+	)
+
+	header := bracket.Render("< ") + brand.Render("GEN") + " " + star.Render("✦") + " " + bracket.Render("/>")
+
+	parts := []string{header}
+	if proj := projectName(info.CWD); proj != "" {
+		parts = append(parts, dim.Render(proj))
+	}
+	if info.Model != "" {
+		parts = append(parts, dim.Render(info.Model))
+	}
+	return "\n" + strings.Join(parts, dim.Render("  ·  "))
+}
+
+// projectName returns a compact, human-friendly label for the working
+// directory — basename of the path, with $HOME folded to "~".
+func projectName(p string) string {
+	if p == "" {
+		return ""
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if p == home {
+			return "~"
+		}
+	}
+	base := filepath.Base(p)
+	if base == "." || base == "/" {
+		return ""
+	}
+	return base
+}
+
+func printWelcomePlain(info welcomeInfo) {
+	parts := []string{"< GEN ✦ />"}
+	if proj := projectName(info.CWD); proj != "" {
+		parts = append(parts, proj)
+	}
+	if info.Model != "" {
+		parts = append(parts, info.Model)
+	}
+	fmt.Println()
+	fmt.Println(strings.Join(parts, "  ·  "))
+}


### PR DESCRIPTION
## Summary
- Replace the old conv-scrollback welcome string with a dedicated pre-Bubbletea splash in `internal/app/welcome.go`. New format: `< GEN ✦ />  ·  <project>  ·  <model>`, printed once on fresh-session startup. Project is `filepath.Base(cwd)` (with `$HOME` → `~`); resumed sessions skip the splash; `NO_COLOR` / non-TTY paths fall back to a plain text line.
- Three-hue adaptive palette: **teal** for the brand mark, **star blue** for the `✦` accent, **dim gray** for project + model + separators. Each token has Dark / Light variants so contrast holds on either terminal background.
- Swap the input-prompt glyph `❯` → `❭` (lighter weight) in both `renderInputView` and `RenderUserMessage`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/...`
- [ ] `make build && ./bin/gen` on a dark terminal — splash colors readable, single line, leading blank line.
- [ ] Same on a light terminal — palette stays readable.
- [ ] `./bin/gen | cat` — verify plain-text fallback fires when stdout isn't a TTY.
- [ ] Resume an existing session via `--session` — verify splash does NOT appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)