### PR TITLE
docs(readme): add Chinese README and expand usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ mkdir -p ~/.local/bin && mv gen ~/.local/bin/
 
 ## Usage
 
-### Start
-
 ```bash
 gen                            # interactive
 gen "explain this function"    # one-shot
@@ -79,33 +77,15 @@ gen --continue                 # resume latest session
 gen --resume                   # pick a past session
 ```
 
-### Configure a model
+| What | How |
+|---|---|
+| Pick / switch model | `/model` — saved to `~/.gen/providers.json` |
+| Cycle thinking budget | `Ctrl+T` or `/think` (levels vary by provider) |
+| All slash commands | `/help` (`/identity`, `/search`, `/skills`, `/agents`, `/mcp`, `/compact`, …) |
+| Toggle permission mode | `Shift+Tab` (ask · auto-accept · plan) |
+| Expand tool · cancel · exit | `Ctrl+O` · `Ctrl+C` · `Ctrl+D` |
 
-On first launch, run `/model` to pick a provider and model. Gen Code will
-prompt for the API key — or you can set the matching env var (see the
-**Credentials** table below) and Gen Code will pick it up automatically.
-Switch models any time with `/model`; the choice is saved to
-`~/.gen/providers.json`.
-
-### Adjust thinking
-
-For models that support extended reasoning (Claude, GPT-5/o-series,
-Gemini, etc.), press `Ctrl+T` — or run `/think` — to cycle the thinking
-budget. The available levels are provider-specific (Claude:
-`off / normal / high / ultra`; OpenAI reasoning models:
-`none / low / medium / high / xhigh`). The current level is shown in
-the status bar; higher levels trade latency for deeper reasoning.
-
-### Other essentials
-
-- `/help` lists every slash command (`/identity`, `/search`, `/skills`, `/agents`, `/mcp`, `/compact`, `/resume`, …).
-- `Shift+Tab` cycles permission modes (ask · auto-accept · plan).
-- `Ctrl+O` expands tool details · `Ctrl+C` cancels the current turn · `Ctrl+D` exits.
-
-See [`docs/guides/getting-started.md`](docs/guides/getting-started.md)
-for a longer walkthrough and
-[`docs/reference/slash-commands.md`](docs/reference/slash-commands.md)
-for the full command list.
+For API keys, set the matching env var (see Credentials below) or paste when prompted on first launch. Full walkthrough: [`docs/guides/getting-started.md`](docs/guides/getting-started.md).
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
     <a href="https://pkg.go.dev/github.com/genai-io/gen-code"><img src="https://pkg.go.dev/badge/github.com/genai-io/gen-code.svg" alt="Go Reference"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
   </p>
+  <p>
+    <strong>English</strong> · <a href="README.zh.md">简体中文</a>
+  </p>
 </div>
 
 Gen Code is a terminal coding assistant with pluggable LLM providers, search engines, personas, and skill/extension surfaces — fully compatible with [Claude Code](https://claude.ai/code) skills, plugins, and MCP servers. Implemented in Go as a single binary with concurrent multi-agent orchestration.
@@ -66,6 +69,8 @@ mkdir -p ~/.local/bin && mv gen ~/.local/bin/
 
 ## Usage
 
+### Start
+
 ```bash
 gen                            # interactive
 gen "explain this function"    # one-shot
@@ -74,9 +79,33 @@ gen --continue                 # resume latest session
 gen --resume                   # pick a past session
 ```
 
-Run `/model` on first launch to connect a provider; `/help` lists all slash commands (`/identity`, `/search`, `/skills`, `/agents`, `/mcp`, `/compact`, `/resume`, …).
+### Configure a model
 
-Keyboard: `Shift+Tab` permission mode · `Ctrl+O` expand tool details · `Ctrl+C` cancel · `Ctrl+D` exit.
+On first launch, run `/model` to pick a provider and model. Gen Code will
+prompt for the API key — or you can set the matching env var (see the
+**Credentials** table below) and Gen Code will pick it up automatically.
+Switch models any time with `/model`; the choice is saved to
+`~/.gen/providers.json`.
+
+### Adjust thinking
+
+For models that support extended reasoning (Claude, GPT-5/o-series,
+Gemini, etc.), press `Ctrl+T` — or run `/think` — to cycle the thinking
+budget. The available levels are provider-specific (Claude:
+`off / normal / high / ultra`; OpenAI reasoning models:
+`none / low / medium / high / xhigh`). The current level is shown in
+the status bar; higher levels trade latency for deeper reasoning.
+
+### Other essentials
+
+- `/help` lists every slash command (`/identity`, `/search`, `/skills`, `/agents`, `/mcp`, `/compact`, `/resume`, …).
+- `Shift+Tab` cycles permission modes (ask · auto-accept · plan).
+- `Ctrl+O` expands tool details · `Ctrl+C` cancels the current turn · `Ctrl+D` exits.
+
+See [`docs/guides/getting-started.md`](docs/guides/getting-started.md)
+for a longer walkthrough and
+[`docs/reference/slash-commands.md`](docs/reference/slash-commands.md)
+for the full command list.
 
 ### Configuration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,8 +69,6 @@ mkdir -p ~/.local/bin && mv gen ~/.local/bin/
 
 ## 使用
 
-### 启动
-
 ```bash
 gen                            # 交互模式
 gen "解释这个函数"             # 一次性运行
@@ -79,31 +77,15 @@ gen --continue                 # 恢复最近的会话
 gen --resume                   # 选择历史会话恢复
 ```
 
-### 配置模型
+| 操作 | 命令 / 快捷键 |
+|---|---|
+| 选择 / 切换模型 | `/model` —— 保存到 `~/.gen/providers.json` |
+| 切换 thinking 级别 | `Ctrl+T` 或 `/think`（可选级别因提供商而异） |
+| 所有 slash 命令 | `/help`（`/identity`、`/search`、`/skills`、`/agents`、`/mcp`、`/compact` 等） |
+| 切换权限模式 | `Shift+Tab`（询问 · 自动接受 · 计划） |
+| 展开工具 · 取消 · 退出 | `Ctrl+O` · `Ctrl+C` · `Ctrl+D` |
 
-首次启动时执行 `/model` 选择提供商和模型。Gen Code 会提示输入 API
-Key —— 也可以提前设置好对应的环境变量（见下方 **凭据** 表格），
-Gen Code 会自动读取。随时可以再次运行 `/model` 切换模型，选择会保存
-到 `~/.gen/providers.json`。
-
-### 调整 thinking 级别
-
-对于支持扩展推理（extended thinking）的模型（Claude、GPT-5/o 系列、
-Gemini 等），按 `Ctrl+T` 或运行 `/think` 即可循环切换 thinking 预算。
-可选级别因提供商而异（Claude：`off / normal / high / ultra`；
-OpenAI 推理模型：`none / low / medium / high / xhigh`）。当前级别会
-显示在底部状态栏；级别越高，推理越深入，但延迟也会相应增加。
-
-### 其他常用功能
-
-- `/help` 列出所有 slash 命令（`/identity`、`/search`、`/skills`、`/agents`、`/mcp`、`/compact`、`/resume` 等等）。
-- `Shift+Tab` 切换权限模式（询问 · 自动接受 · 计划）。
-- `Ctrl+O` 展开工具详情 · `Ctrl+C` 取消当前回合 · `Ctrl+D` 退出。
-
-更长的入门说明见
-[`docs/guides/getting-started.md`](docs/guides/getting-started.md)，完整
-slash 命令列表见
-[`docs/reference/slash-commands.md`](docs/reference/slash-commands.md)。
+API Key：设置对应的环境变量（见下方凭据表）或在首次启动时按提示粘贴。完整入门：[`docs/guides/getting-started.md`](docs/guides/getting-started.md)。
 
 ### 配置文件
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,200 @@
+<div align="center">
+  <h1>&lt; GEN ✦ /&gt;</h1>
+  <p><strong>面向终端的开源 AI 编程助手</strong></p>
+  <p>
+    <a href="https://github.com/genai-io/gen-code/releases"><img src="https://img.shields.io/github/v/release/genai-io/gen-code?style=flat-square" alt="Release"></a>
+    <a href="https://goreportcard.com/report/github.com/genai-io/gen-code"><img src="https://goreportcard.com/badge/github.com/genai-io/gen-code?style=flat-square" alt="Go Report Card"></a>
+    <a href="https://pkg.go.dev/github.com/genai-io/gen-code"><img src="https://pkg.go.dev/badge/github.com/genai-io/gen-code.svg" alt="Go Reference"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
+  </p>
+  <p>
+    <a href="README.md">English</a> · <strong>简体中文</strong>
+  </p>
+</div>
+
+Gen Code 是一款终端 AI 编程助手，支持可插拔的模型提供商、搜索引擎、人设（Persona）以及技能/扩展体系 —— 完全兼容 [Claude Code](https://claude.ai/code) 的 skills、plugins 与 MCP servers。使用 Go 实现，单二进制分发，支持并发的多 Agent 编排。
+
+## 特性
+
+### 开放架构
+
+<p align="center">
+  <img src="docs/diagrams/open-architecture.svg" alt="Gen Code 开放架构 —— 四个可插拔维度：模型提供商、搜索引擎、角色切换、技能与扩展" width="100%">
+</p>
+
+- **模型提供商** —— Anthropic、OpenAI、Google、Moonshot、Alibaba、MiniMax、Z.ai（GLM）；通过 `/model` 切换。
+- **搜索后端** —— Exa、Tavily、Brave、Serper；通过 `/search` 切换。
+- **Persona 人设** —— 以 Markdown 定义身份，可在用户或项目作用域生效；通过 `/identity` 切换（[详情](docs/concepts/harness-channels.md#identity-custom-personas)）。
+- **技能与扩展** —— Claude Code 的 skills、plugins、MCP servers 无需改动即可运行；沙箱化 subagent；生命周期 hooks（shell、LLM、agent、HTTP）；项目记忆自动加载。
+
+### 工程实现
+
+- **原生性能** —— 单一 Go 二进制；实测数据见下方[基准测试](#基准测试gen-code-vs-claude-code)。
+- **事件驱动协同** —— 基于 pub/sub hub 的并行 subagent 执行（[架构说明](docs/packages/subagent.md)）。
+- **会话持久化** —— 自动保存、恢复、Fork 以及自动上下文压缩。
+- **Prompt 预测** —— 推测式地预生成可能的下一个 prompt 以降低延迟。
+
+
+## 安装
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/genai-io/gen-code/main/install.sh | bash
+```
+
+升级直接重新执行同样的命令。卸载：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/genai-io/gen-code/main/install.sh | bash -s uninstall
+```
+
+<details>
+<summary><b>其他安装方式</b></summary>
+
+**通过 Go Install**
+
+```bash
+go install github.com/genai-io/gen-code/cmd/gen@latest
+```
+
+**从源码构建**
+
+```bash
+git clone https://github.com/genai-io/gen-code.git
+cd gen-code
+go build -o gen ./cmd/gen
+mkdir -p ~/.local/bin && mv gen ~/.local/bin/
+```
+
+</details>
+
+## 使用
+
+### 启动
+
+```bash
+gen                            # 交互模式
+gen "解释这个函数"             # 一次性运行
+cat main.go | gen "review"     # 管道输入
+gen --continue                 # 恢复最近的会话
+gen --resume                   # 选择历史会话恢复
+```
+
+### 配置模型
+
+首次启动时执行 `/model` 选择提供商和模型。Gen Code 会提示输入 API
+Key —— 也可以提前设置好对应的环境变量（见下方 **凭据** 表格），
+Gen Code 会自动读取。随时可以再次运行 `/model` 切换模型，选择会保存
+到 `~/.gen/providers.json`。
+
+### 调整 thinking 级别
+
+对于支持扩展推理（extended thinking）的模型（Claude、GPT-5/o 系列、
+Gemini 等），按 `Ctrl+T` 或运行 `/think` 即可循环切换 thinking 预算。
+可选级别因提供商而异（Claude：`off / normal / high / ultra`；
+OpenAI 推理模型：`none / low / medium / high / xhigh`）。当前级别会
+显示在底部状态栏；级别越高，推理越深入，但延迟也会相应增加。
+
+### 其他常用功能
+
+- `/help` 列出所有 slash 命令（`/identity`、`/search`、`/skills`、`/agents`、`/mcp`、`/compact`、`/resume` 等等）。
+- `Shift+Tab` 切换权限模式（询问 · 自动接受 · 计划）。
+- `Ctrl+O` 展开工具详情 · `Ctrl+C` 取消当前回合 · `Ctrl+D` 退出。
+
+更长的入门说明见
+[`docs/guides/getting-started.md`](docs/guides/getting-started.md)，完整
+slash 命令列表见
+[`docs/reference/slash-commands.md`](docs/reference/slash-commands.md)。
+
+### 配置文件
+
+配置位于 `~/.gen/`（用户级）与 `<项目>/.gen/`（项目级，覆盖用户级）。项目根目录下的 `GEN.md` 或 `CLAUDE.md` 会被自动加载到系统 prompt。
+
+<details>
+<summary><b>凭据</b></summary>
+
+| 服务 | 环境变量 |
+|:--------|:---------|
+| **Anthropic** (Claude) | `ANTHROPIC_API_KEY` 或 [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude) |
+| **OpenAI** (GPT, o 系列, Codex) | `OPENAI_API_KEY` |
+| **Google** (Gemini) | `GOOGLE_API_KEY` |
+| **Moonshot** (Kimi) | `MOONSHOT_API_KEY` |
+| **Alibaba** (Qwen, DeepSeek) | `DASHSCOPE_API_KEY` |
+| **MiniMax** | `MINIMAX_API_KEY` |
+| **Z.ai** (GLM) | `BIGMODEL_API_KEY` |
+| **Exa** 搜索 | _无需_（默认） |
+| **Tavily** 搜索 | `TAVILY_API_KEY` |
+| **Brave** 搜索 | `BRAVE_API_KEY` |
+| **Serper** 搜索 | `SERPER_API_KEY` |
+
+</details>
+
+<details>
+<summary><b>目录结构</b></summary>
+
+用户级（`~/.gen/`）：
+
+```
+providers.json    # 提供商连接信息与当前模型
+settings.json     # 权限、hooks、env、identity
+skills.json       # 技能状态
+identities/       # 自定义人设（参见 /identity）
+skills/           # 自定义技能定义
+agents/           # 自定义 agent 定义
+commands/         # 自定义 slash 命令
+plugins/          # 已安装插件
+projects/         # 会话记录与索引
+```
+
+项目级（`.gen/`）：
+
+```
+settings.json      # 权限、hooks、禁用工具
+mcp.json           # MCP server 定义
+identities/*.md    # 项目级 persona（覆盖用户级）
+agents/*.md        # Subagent 定义
+skills/*/SKILL.md  # 技能
+commands/*.md      # Slash 命令
+```
+
+</details>
+
+## 基准测试：Gen Code vs Claude Code
+
+在 Apple Silicon 上对比 [Claude Code](https://claude.ai/code) v2.1.112，使用相同模型（`claude-sonnet-4-6`）：
+
+| 指标 | Gen Code | Claude Code | 优势 |
+|--------|---------|-------------|-----------|
+| 下载大小 | 12 MB | 63 MB（+ Node.js 112 MB） | **小 5 倍** |
+| 磁盘占用 | 38 MB | 175 MB | **小 4.6 倍** |
+| 启动耗时 | ~0.01s | ~0.20s | **快 20 倍** |
+| 启动内存 | ~32 MB | ~189 MB | **省 5.8 倍** |
+| 简单任务 | ~2.4s / 39 MB | ~10.4s / 286 MB | **快 4.3 倍、省内存 7.3 倍** |
+| 工具调用任务 | ~3.3s / 39 MB | ~26.0s / 285 MB | **快 7.9 倍、省内存 7.2 倍** |
+
+两者特性大体可比（hooks、skills、plugins、session、MCP 等）。性能差距来自 Go 的原生编译、精简的架构设计和克制的 prompt 工程 —— 对比 Node.js 的 V8/JIT/GC 运行时开销。
+
+完整数据见：[docs/operations/benchmark.md](docs/operations/benchmark.md)
+
+## 文档
+
+- [文档索引](docs/index.md) —— 架构、特性、运维、参考资料的入口
+- [架构](docs/architecture.md) —— 架构入口与阅读顺序
+- [包结构图](docs/reference/package-map.md) —— 包归属与依赖边界
+- [系统 Prompt](docs/concepts/harness-channels.md) —— Slot 模型、identity、技能/agent 注入
+- [Subagents](docs/packages/subagent.md) · [Skills](docs/packages/skill.md) · [Plugins](docs/packages/plugin.md) · [MCP](docs/packages/mcp.md)
+- [Hooks](docs/packages/hook.md) · [Permissions](docs/concepts/permission-model.md) · [Tasks](docs/packages/task.md)
+- 每个包的设计文档见 [`docs/packages/`](docs/packages/)，从[包索引](docs/packages/index.md)开始
+
+## 相关项目
+
+- [Claude Code](https://claude.ai/code) —— Anthropic 的 AI 编程助手
+- [Aider](https://github.com/paul-gauthier/aider) —— 终端中的 AI 结对编程
+- [Continue](https://github.com/continuedev/continue) —— 开源 AI 编程助手
+
+## 贡献
+
+欢迎贡献！请阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 中的指南。
+
+## 许可证
+
+Apache License 2.0 —— 详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary

Closes #49.

- Add `README.zh.md` as a Simplified Chinese mirror of the README; English remains the default. Both files carry a language-switcher strip at the top.
- Restructure the **Usage** section into four subsections so the three asks from #49 each have their own anchor:
  - **Start** — invocation modes (`gen`, one-shot, piped, `--continue`, `--resume`).
  - **Configure a model** — `/model` flow, env-var fallback, persistence in `~/.gen/providers.json`.
  - **Adjust thinking** — newly documented `Ctrl+T` / `/think` flow with provider-specific level lists (Claude: `off / normal / high / ultra`; OpenAI reasoning: `none / low / medium / high / xhigh`).
  - **Other essentials** — `/help`, permission modes, key bindings, links to the longer guide and the full slash-command reference.

## Test plan

- [ ] Render `README.md` and `README.zh.md` on GitHub; verify the language-switcher links resolve both ways.
- [ ] Verify in-page links to `docs/guides/getting-started.md` and `docs/reference/slash-commands.md` work.
- [ ] Sanity-check that the documented thinking levels match `internal/llm/anthropic/catalog.go` and `internal/llm/openai/catalog.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)