### PR TITLE
Skip <system-reminder> blocks during compaction, re-attach after

### DIFF
--- a/cmd/gen/agent.go
+++ b/cmd/gen/agent.go
@@ -109,7 +109,7 @@ func runHeadlessAgent() error {
 	// same permission gate (deny_tools / bypass-immune / allow_tools / mode)
 	// as TUI-spawned subagents.
 	executor := subagent.NewExecutor(llmProvider, cwd, modelID, nil)
-	executor.SetContext("", "", setting.IsGitRepo(cwd))
+	executor.SetContext(setting.IsGitRepo(cwd))
 
 	fmt.Printf("Agent: %s\n", agentRunOpts.agentType)
 	fmt.Printf("Prompt: %s\n", agentRunOpts.prompt)

--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -151,26 +151,36 @@ When the context window approaches its limit, the harness compacts:
 Reminders ride *inside* user-message content (attached below the prompt),
 so a naive summarizer would fold stale skill/memory/notice text into the
 summary. That is wasteful and risks pinning outdated context into the
-permanent summary. Instead, `core.BuildConversationText` strips
-`<system-reminder>…</system-reminder>` blocks before summarizing; a message
-that was *only* reminders contributes nothing. The fresh state comes back
-through the re-emission step (4), giving every reminder provider — skills,
-memory-user, memory-project, and notices — the same lifecycle:
+permanent summary. Instead, `core.BuildCompactionText` peels the trailing
+run of `<system-reminder>` blocks off each user message before summarizing;
+a message that was *only* reminders contributes nothing. The fresh state
+comes back through the re-emission step (4), giving every reminder
+provider — skills, memory-user, memory-project, and notices — the same
+lifecycle:
 
 - **injected** on the first user message (`SessionStart`),
 - **skipped** from the summarization input during compaction,
 - **re-injected** on the next user message after `PostCompact`.
 
-This is the single behavior `core.BuildConversationText` enforces for both
-the auto-compaction path (`internal/agent/build.go`) and the manual
-`/compact` path (`internal/app/conv/compact.go`).
+`BuildCompactionText` is used by both the auto-compaction path
+(`internal/agent/build.go`) and the manual `/compact` path
+(`internal/app/conv/compact.go`). Its sibling `BuildConversationText` keeps
+reminders intact and is used for proactive-compaction *size estimation*
+(`agent_impl.go`), where the real prompt — reminders included — is what the
+estimate must track.
+
+Stripping peels blocks from the end by anchoring on the last *opening* tag
+rather than matching the merged text with a regex: a closing tag never
+contains the opening-tag prefix, so a reminder body that itself quotes
+`</system-reminder>` is still removed in full, and a `<system-reminder>` the
+user typed mid-message is left untouched.
 
 Compaction is **not** a channel by itself — it's a mutation of the
 user-message channel. The strip-then-re-emit pair is what keeps the
 reminder channel coherent across a compaction.
 
 Implementation: `internal/app/conv/compact.go` and
-`internal/core/message.go` (`BuildConversationText`). The agent emits
+`internal/core/message.go` (`BuildCompactionText`). The agent emits
 `OnCompact` events for observers.
 
 ## See Also

--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -6,7 +6,7 @@ each with different cache, lifecycle, and stability properties:
 | Channel | What lives there | Cache-friendly? | Mutable mid-session? |
 |---|---|---|---|
 | **System prompt** | Identity, output style, engineering defaults, provider quirks, policy, guidelines, environment footer. Slot-sectioned. | Yes — invariant per session unless a section mutates. | Yes (Use/Drop), but expensive (cache miss). |
-| **`<system-reminder>` blocks** | Session-level / project-level dynamic content: **active-skills directory**, GEN.md/CLAUDE.md memory, ad-hoc notices. Attached below the next user message. | Yes — once attached, the user message is immutable. | No (re-emitted as new attachments, never mutated). |
+| **`<system-reminder>` blocks** | Session-level / project-level dynamic content: **active-skills directory**, GEN.md/CLAUDE.md memory, one-time notices. Attached below the next user message. | Yes — once attached, the user message is immutable. | No (re-emitted as new attachments, never mutated). |
 | **User messages** | The actual prompt the user typed. | Yes — already cached. | No. |
 
 > The active-skills list (what skills the model is currently aware of) used
@@ -92,9 +92,15 @@ Reminders wrap their body in:
 </system-reminder>
 ```
 
-The LLM is instructed (in the system prompt) to treat the
-`<system-reminder>` tag as a system instruction even though it appears
-inside a user message.
+The LLM is instructed to treat the `<system-reminder>` tag as a system
+instruction even though it appears inside a user message. That directive
+lives in the system prompt as `<guidelines name="system-reminders">`
+(source: `internal/core/system/prompts/guidelines/system-reminders.txt`),
+applied to both
+main and subagent scopes — subagents receive reminders too (the skills
+directory). It also tells the model to act on the most recent reminder
+values (they refresh and re-inject after compaction) and not to echo the
+tags back to the user.
 
 Implementation: [`packages/reminder.md`](../packages/reminder.md).
 
@@ -112,24 +118,59 @@ Two memory tiers:
 Memory is **never** in the system prompt — that would invalidate the
 prompt cache every time the user edited their memory file.
 
+Each memory reminder leads with a one-line **preamble** framing the
+content for the model (e.g. *"The following is the user's saved memory
+(preferences and standing instructions). Apply it throughout this
+session."*) before the `<memory scope="…">` envelope. The raw memory text
+alone carries no instruction to follow it; the preamble supplies that
+framing, mirroring how the skills directory self-introduces.
+`reminder.WrapMemory` owns this shape.
+
+**Subagents do not receive memory.** Only the long-lived main loop agent
+gets `memory-user` / `memory-project`. A subagent is a one-shot worker
+bounded by its own charter, so it carries the skills directory (to invoke
+capabilities) but not the human's project/user instructions. See
+`internal/subagent/executor.go` (`collectSubagentReminders`).
+
 ## Compaction
 
 When the context window approaches its limit, the harness compacts:
 
-1. Pick the prefix of messages to summarize (everything except the most
-   recent N turns).
+1. Build the summarization input from the conversation, **stripping every
+   `<system-reminder>` block** out of the user messages first (see below).
 2. Call the LLM with a "summarize the following conversation" prompt to
    produce a `CompactInfo` summary.
-3. Replace the prefix with a single synthetic message containing the
+3. Replace the conversation with a single synthetic message containing the
    summary.
-4. Re-emit all reminders (`EnqueueAllProviders`) so the post-compact
-   conversation has fresh skill/memory context.
+4. Drop one-time notices (`DiscardPendingNotices`) and re-emit all providers
+   (`EnqueueAllProviders`) so the post-compact conversation has fresh
+   skill/memory context on the next user turn.
+
+### Reminders are skipped during compaction, not summarized
+
+Reminders ride *inside* user-message content (attached below the prompt),
+so a naive summarizer would fold stale skill/memory/notice text into the
+summary. That is wasteful and risks pinning outdated context into the
+permanent summary. Instead, `core.BuildConversationText` strips
+`<system-reminder>…</system-reminder>` blocks before summarizing; a message
+that was *only* reminders contributes nothing. The fresh state comes back
+through the re-emission step (4), giving every reminder provider — skills,
+memory-user, memory-project, and notices — the same lifecycle:
+
+- **injected** on the first user message (`SessionStart`),
+- **skipped** from the summarization input during compaction,
+- **re-injected** on the next user message after `PostCompact`.
+
+This is the single behavior `core.BuildConversationText` enforces for both
+the auto-compaction path (`internal/agent/build.go`) and the manual
+`/compact` path (`internal/app/conv/compact.go`).
 
 Compaction is **not** a channel by itself — it's a mutation of the
-user-message channel. The reminder re-emission step is what makes
-compaction safe across the reminder channel.
+user-message channel. The strip-then-re-emit pair is what keeps the
+reminder channel coherent across a compaction.
 
-Implementation: `internal/app/conv/compact.go`. The agent emits
+Implementation: `internal/app/conv/compact.go` and
+`internal/core/message.go` (`BuildConversationText`). The agent emits
 `OnCompact` events for observers.
 
 ## See Also

--- a/docs/packages/reminder.md
+++ b/docs/packages/reminder.md
@@ -103,8 +103,8 @@ A handful of nits:
 - Per-event: skill toggles / memory updates call `EnqueueAllProviders`
   to refresh provider-emitted reminders.
 - On compaction: reminder blocks are **skipped, not summarized**.
-  `core.BuildConversationText` strips `<system-reminder>…</system-reminder>`
-  from user content before the summarizer runs, then the harness calls
+  `core.BuildCompactionText` peels trailing `<system-reminder>…</system-reminder>`
+  blocks from user content before the summarizer runs, then the harness calls
   `DiscardPendingNotices` + `EnqueueAllProviders` so fresh provider state
   reattaches to the next user turn. All providers (skills, memory-user,
   memory-project) and one-time notices share this lifecycle. See

--- a/docs/packages/reminder.md
+++ b/docs/packages/reminder.md
@@ -19,7 +19,7 @@ cache — currently:
 
 - skills directory (re-emit when a skill is enabled / disabled / activated)
 - memory user / memory project (re-emit on memory file change)
-- ad-hoc notices (queued from hooks or commands)
+- one-time notices (queued from hooks or commands)
 
 See [`concepts/harness-channels.md`](../concepts/harness-channels.md) for
 why reminders are a separate channel from the system prompt.
@@ -90,7 +90,7 @@ A handful of nits:
   prior pending entries from the same provider before re-emitting, so
   `SessionStart` → `PostCompact` → `/skills` toggle in close succession
   produces one emission per provider rather than three.
-- Ad-hoc `Enqueue` entries persist independently of provider re-emits.
+- One-time notices (`Enqueue`) persist independently of provider re-emits.
 - `Wrap` adds the `<system-reminder source="...">…</system-reminder>`
   XML-style tag with optional source attribution.
 
@@ -102,11 +102,18 @@ A handful of nits:
   `DrainPending()` and wraps the bodies into the outgoing user message.
 - Per-event: skill toggles / memory updates call `EnqueueAllProviders`
   to refresh provider-emitted reminders.
+- On compaction: reminder blocks are **skipped, not summarized**.
+  `core.BuildConversationText` strips `<system-reminder>…</system-reminder>`
+  from user content before the summarizer runs, then the harness calls
+  `DiscardPendingNotices` + `EnqueueAllProviders` so fresh provider state
+  reattaches to the next user turn. All providers (skills, memory-user,
+  memory-project) and one-time notices share this lifecycle. See
+  [`concepts/harness-channels.md`](../concepts/harness-channels.md#compaction).
 
 ## Tests
 
 ```
-internal/reminder/reminder_test.go    — provider re-emission, ad-hoc
+internal/reminder/reminder_test.go    — provider re-emission, notice
                                          queue, idempotence, wrap format.
 ```
 

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -96,7 +96,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 
 	compactClient := client
 	compactFunc := func(ctx context.Context, msgs []core.Message) (string, error) {
-		text := core.BuildConversationText(msgs)
+		text := core.BuildCompactionText(msgs)
 		resp, err := compactClient.Complete(ctx, system.CompactPrompt(), []core.Message{core.UserMessage(text, nil)}, core.CompactMaxTokens)
 		if err != nil {
 			return "", err

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -221,7 +221,7 @@ func (m *model) sendToAgent(content string, images []core.Image) tea.Cmd {
 
 // attachPendingReminders drains the reminder queue and appends any pending
 // <system-reminder> blocks to the user message content. The harness uses this
-// channel to deliver session/project context (skills, memory, ad-hoc notices)
+// channel to deliver session/project context (skills, memory, one-time notices)
 // without invalidating the system-prompt cache prefix.
 func (m *model) attachPendingReminders(content string) string {
 	if m.services.Reminder == nil {
@@ -371,7 +371,7 @@ func (m *model) ReconfigureAgentTool() {
 	if m.services.Session.GetStore() != nil && m.services.Session.ID() != "" {
 		executor.SetSessionStore(m.services.Session.GetStore(), m.services.Session.ID())
 	}
-	executor.SetContext(m.env.CachedUserInstructions, m.env.CachedProjectInstructions, m.env.IsGit)
+	executor.SetContext(m.env.IsGit)
 	executor.SetCapabilities(m.services.Skill.PromptSection(), m.services.Subagent.PromptSection())
 	if m.services.MCP != nil {
 		executor.SetMCP(m.services.MCP, m.services.MCP)

--- a/internal/app/conv/compact.go
+++ b/internal/app/conv/compact.go
@@ -67,7 +67,7 @@ func (c *CompactState) Complete(result string, isError bool) {
 func CompactConversation(ctx context.Context, c *llm.Client, msgs []core.Message, focus string) (summary string, count int, err error) {
 	count = len(msgs)
 
-	conversationText := core.BuildConversationText(msgs)
+	conversationText := core.BuildCompactionText(msgs)
 
 	if focus != "" {
 		conversationText += fmt.Sprintf("\n\n**Important**: Focus the summary on: %s", focus)

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -53,10 +53,10 @@ func (m *model) OnAutoCompact(info core.CompactInfo) tea.Cmd {
 	// session-level reminders so they reattach to the next user turn and the
 	// LLM still has skills/memory/etc. context.
 	if m.services.Reminder != nil {
-		// Ad-hoc reminders (cancel notice, prior hook context) refer to
+		// One-time notices (cancel notice, prior hook context) refer to
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.
-		m.services.Reminder.DiscardPendingAdHoc()
+		m.services.Reminder.DiscardPendingNotices()
 		m.services.Reminder.EnqueueAllProviders()
 	}
 
@@ -98,10 +98,10 @@ func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 	// Manual /compact also drops conversation-history reminders. Re-enqueue
 	// providers so the next user turn carries fresh session-level context.
 	if m.services.Reminder != nil {
-		// Ad-hoc reminders (cancel notice, prior hook context) refer to
+		// One-time notices (cancel notice, prior hook context) refer to
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.
-		m.services.Reminder.DiscardPendingAdHoc()
+		m.services.Reminder.DiscardPendingNotices()
 		m.services.Reminder.EnqueueAllProviders()
 	}
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -157,24 +157,59 @@ func ParseToolInput(input string) (map[string]any, error) {
 	return params, nil
 }
 
-// systemReminderBlock matches a whole <system-reminder>…</system-reminder>
-// block (with optional source attribute), including the leading blank line
-// AttachToContent inserts before it. Used to drop reminder content from the
-// summarization input.
-var systemReminderBlock = regexp.MustCompile(`(?s)\n*<system-reminder(?:\s[^>]*)?>.*?</system-reminder>`)
+const (
+	systemReminderOpen  = "<system-reminder"
+	systemReminderClose = "</system-reminder>"
+)
 
-// stripSystemReminders removes harness-attached <system-reminder> blocks from
-// user message content. Reminders (skills, memory, one-time notices) are ephemeral
-// harness context that is re-injected fresh after compaction, so feeding the
-// stale copies into the summarizer wastes tokens and risks them being baked
-// into the summary. Stripping keeps compaction operating on real conversation
-// turns only.
+// stripSystemReminders removes the trailing run of harness <system-reminder>
+// blocks from user message content. AttachToContent always appends reminders
+// after the user's own text, so we peel whole blocks off the end: while the
+// right-trimmed content ends with a closing tag, cut back to the last opening
+// tag.
+//
+// Anchoring on the last *opening* tag (not a regex over the merged text) is
+// what makes this robust. A closing tag "</system-reminder>" never contains
+// the opening-tag prefix "<system-reminder", so a reminder body that happens
+// to include the literal "</system-reminder>" is still removed in full; and a
+// <system-reminder> the user typed mid-message (followed by their own prose)
+// is left untouched, because once the trailing block is peeled the remaining
+// text no longer ends in a closing tag and the loop stops.
+//
+// Reminders (skills, memory, one-time notices) re-emit fresh after compaction,
+// so the summary should capture only real conversation turns.
 func stripSystemReminders(content string) string {
-	return strings.TrimSpace(systemReminderBlock.ReplaceAllString(content, ""))
+	for {
+		trimmed := strings.TrimRight(content, " \t\r\n")
+		if !strings.HasSuffix(trimmed, systemReminderClose) {
+			break
+		}
+		open := strings.LastIndex(trimmed, systemReminderOpen)
+		if open < 0 {
+			break
+		}
+		content = trimmed[:open]
+	}
+	return strings.TrimSpace(content)
 }
 
-// BuildConversationText converts messages to text for summarization.
+// BuildConversationText converts messages to text, keeping harness
+// <system-reminder> content intact. Use it where the real prompt size matters
+// (e.g. conversation-growth estimation for proactive compaction), since the
+// reminders are part of what actually gets sent to the model.
 func BuildConversationText(msgs []Message) string {
+	return buildConversationText(msgs, false)
+}
+
+// BuildCompactionText is like BuildConversationText but strips the trailing
+// <system-reminder> blocks from each user message and drops messages that were
+// nothing but reminders. Use it for summarization: reminders re-emit fresh
+// after compaction, so the summary should capture only real conversation turns.
+func BuildCompactionText(msgs []Message) string {
+	return buildConversationText(msgs, true)
+}
+
+func buildConversationText(msgs []Message, stripReminders bool) string {
 	var sb strings.Builder
 	sb.WriteString("Please summarize this coding conversation:\n\n")
 
@@ -188,9 +223,12 @@ func BuildConversationText(msgs []Message) string {
 				}
 				fmt.Fprintf(&sb, "[Tool Result: %s]\n%s\n\n", msg.ToolResult.ToolName, content)
 			} else {
-				content := stripSystemReminders(msg.Content)
-				if content == "" {
-					continue
+				content := msg.Content
+				if stripReminders {
+					content = stripSystemReminders(content)
+					if content == "" {
+						continue
+					}
 				}
 				fmt.Fprintf(&sb, "User: %s\n\n", content)
 			}

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -157,6 +157,22 @@ func ParseToolInput(input string) (map[string]any, error) {
 	return params, nil
 }
 
+// systemReminderBlock matches a whole <system-reminder>…</system-reminder>
+// block (with optional source attribute), including the leading blank line
+// AttachToContent inserts before it. Used to drop reminder content from the
+// summarization input.
+var systemReminderBlock = regexp.MustCompile(`(?s)\n*<system-reminder(?:\s[^>]*)?>.*?</system-reminder>`)
+
+// stripSystemReminders removes harness-attached <system-reminder> blocks from
+// user message content. Reminders (skills, memory, one-time notices) are ephemeral
+// harness context that is re-injected fresh after compaction, so feeding the
+// stale copies into the summarizer wastes tokens and risks them being baked
+// into the summary. Stripping keeps compaction operating on real conversation
+// turns only.
+func stripSystemReminders(content string) string {
+	return strings.TrimSpace(systemReminderBlock.ReplaceAllString(content, ""))
+}
+
 // BuildConversationText converts messages to text for summarization.
 func BuildConversationText(msgs []Message) string {
 	var sb strings.Builder
@@ -172,7 +188,11 @@ func BuildConversationText(msgs []Message) string {
 				}
 				fmt.Fprintf(&sb, "[Tool Result: %s]\n%s\n\n", msg.ToolResult.ToolName, content)
 			} else {
-				fmt.Fprintf(&sb, "User: %s\n\n", msg.Content)
+				content := stripSystemReminders(msg.Content)
+				if content == "" {
+					continue
+				}
+				fmt.Fprintf(&sb, "User: %s\n\n", content)
 			}
 
 		case RoleAssistant:

--- a/internal/core/message_test.go
+++ b/internal/core/message_test.go
@@ -22,25 +22,64 @@ func TestBuildConversationTextAggregatesToolCalls(t *testing.T) {
 	}
 }
 
-func TestBuildConversationTextStripsSystemReminders(t *testing.T) {
+func TestBuildCompactionTextStripsSystemReminders(t *testing.T) {
 	content := "Fix the login bug\n\n" +
 		`<system-reminder source="memory-project">` + "\nproject memory\n</system-reminder>" +
 		"\n\n<system-reminder>\none-time notice\n</system-reminder>"
-	text := BuildConversationText([]Message{UserMessage(content, nil)})
+	text := BuildCompactionText([]Message{UserMessage(content, nil)})
 
 	if !strings.Contains(text, "User: Fix the login bug") {
-		t.Fatalf("BuildConversationText() = %q, want the real user prompt", text)
+		t.Fatalf("BuildCompactionText() = %q, want the real user prompt", text)
 	}
 	if strings.Contains(text, "system-reminder") || strings.Contains(text, "project memory") || strings.Contains(text, "one-time notice") {
-		t.Fatalf("BuildConversationText() = %q, should strip system-reminder blocks", text)
+		t.Fatalf("BuildCompactionText() = %q, should strip system-reminder blocks", text)
 	}
 }
 
-func TestBuildConversationTextDropsReminderOnlyMessage(t *testing.T) {
+func TestBuildCompactionTextDropsReminderOnlyMessage(t *testing.T) {
 	content := "<system-reminder source=\"skills-directory\">\nuse the Skill tool\n</system-reminder>"
-	text := BuildConversationText([]Message{UserMessage(content, nil)})
+	text := BuildCompactionText([]Message{UserMessage(content, nil)})
 
 	if strings.Contains(text, "User:") {
-		t.Fatalf("BuildConversationText() = %q, reminder-only message should not emit a User line", text)
+		t.Fatalf("BuildCompactionText() = %q, reminder-only message should not emit a User line", text)
+	}
+}
+
+// BuildConversationText (the estimator's input) must keep reminders so the
+// proactive-compaction size estimate reflects what is actually sent.
+func TestBuildConversationTextKeepsSystemReminders(t *testing.T) {
+	content := "Fix the login bug\n\n<system-reminder source=\"skills-directory\">\nuse the Skill tool\n</system-reminder>"
+	text := BuildConversationText([]Message{UserMessage(content, nil)})
+
+	if !strings.Contains(text, "use the Skill tool") {
+		t.Fatalf("BuildConversationText() = %q, should retain reminder content for size estimation", text)
+	}
+}
+
+// A <system-reminder> the user typed/pasted mid-message must survive; only the
+// trailing harness-appended run is stripped.
+func TestBuildCompactionTextPreservesMidMessageReminderMention(t *testing.T) {
+	content := "explain <system-reminder>X</system-reminder> please\n\n" +
+		"<system-reminder source=\"skills-directory\">\nreal\n</system-reminder>"
+	text := BuildCompactionText([]Message{UserMessage(content, nil)})
+
+	if !strings.Contains(text, "explain <system-reminder>X</system-reminder> please") {
+		t.Fatalf("BuildCompactionText() = %q, should preserve a mid-message reminder mention", text)
+	}
+	if strings.Contains(text, "\nreal\n") {
+		t.Fatalf("BuildCompactionText() = %q, should still strip the trailing reminder", text)
+	}
+}
+
+// A reminder body that itself contains the literal "</system-reminder>" must
+// be removed in full, not truncated at the inner close tag.
+func TestBuildCompactionTextStripsReminderWithEmbeddedCloseTag(t *testing.T) {
+	content := "fix it\n\n<system-reminder source=\"memory-project\">\n" +
+		"<memory scope=\"project\">\nnote: the </system-reminder> tag is special\n</memory>\n" +
+		"</system-reminder>"
+	text := BuildCompactionText([]Message{UserMessage(content, nil)})
+
+	if strings.TrimSpace(text) != "Please summarize this coding conversation:\n\nUser: fix it" {
+		t.Fatalf("BuildCompactionText() = %q, should drop the whole reminder despite embedded close tag", text)
 	}
 }

--- a/internal/core/message_test.go
+++ b/internal/core/message_test.go
@@ -21,3 +21,26 @@ func TestBuildConversationTextAggregatesToolCalls(t *testing.T) {
 		t.Fatalf("BuildConversationText() = %q, should not emit repeated raw tool-call lines", text)
 	}
 }
+
+func TestBuildConversationTextStripsSystemReminders(t *testing.T) {
+	content := "Fix the login bug\n\n" +
+		`<system-reminder source="memory-project">` + "\nproject memory\n</system-reminder>" +
+		"\n\n<system-reminder>\none-time notice\n</system-reminder>"
+	text := BuildConversationText([]Message{UserMessage(content, nil)})
+
+	if !strings.Contains(text, "User: Fix the login bug") {
+		t.Fatalf("BuildConversationText() = %q, want the real user prompt", text)
+	}
+	if strings.Contains(text, "system-reminder") || strings.Contains(text, "project memory") || strings.Contains(text, "one-time notice") {
+		t.Fatalf("BuildConversationText() = %q, should strip system-reminder blocks", text)
+	}
+}
+
+func TestBuildConversationTextDropsReminderOnlyMessage(t *testing.T) {
+	content := "<system-reminder source=\"skills-directory\">\nuse the Skill tool\n</system-reminder>"
+	text := BuildConversationText([]Message{UserMessage(content, nil)})
+
+	if strings.Contains(text, "User:") {
+		t.Fatalf("BuildConversationText() = %q, reminder-only message should not emit a User line", text)
+	}
+}

--- a/internal/core/system/catalog.go
+++ b/internal/core/system/catalog.go
@@ -18,7 +18,7 @@ import (
 //	prompts/engineering.txt           — engineering defaults (Restraint, Code conventions, Error handling)
 //	prompts/policy.txt                — safety contract (never overridden)
 //	prompts/compact.txt               — conversation compactor prompt
-//	prompts/guidelines/{tools,git,questions,tasks}.txt
+//	prompts/guidelines/{tools,system-reminders,git,questions,tasks}.txt
 //	prompts/providers/<name>.txt      — provider-specific quirks (optional)
 //
 // Format the LLM sees, top to bottom:
@@ -28,6 +28,7 @@ import (
 //	<engineering> … </engineering>                   (how you work on code)
 //	<policy> … </policy>                             (safety, never overridden)
 //	<guidelines name="tool-usage"> … </guidelines>
+//	<guidelines name="system-reminders"> … </guidelines> (how to treat <system-reminder>)
 //	<guidelines name="task-workflow"> … </guidelines>
 //	<guidelines name="when-to-ask"> … </guidelines>
 //	<guidelines name="git-safety"> … </guidelines>   (only when isGit)
@@ -51,6 +52,7 @@ var (
 	cachedGit         = loadEmbed("prompts/guidelines/git.txt")
 	cachedQuestions   = loadEmbed("prompts/guidelines/questions.txt")
 	cachedTasks       = loadEmbed("prompts/guidelines/tasks.txt")
+	cachedReminders   = loadEmbed("prompts/guidelines/system-reminders.txt")
 )
 
 // loadEmbed reads a required embedded prompt and trims surrounding whitespace.
@@ -90,6 +92,9 @@ func applyDefaults(sys core.System, scope core.Scope) {
 	}
 	sys.Use(policy(), caller)
 	sys.Use(guidelines("tool-usage", cachedTools), caller)
+	// How to treat harness-injected <system-reminder> content. Applies to
+	// both scopes — subagents also receive reminders (the skills directory).
+	sys.Use(guidelines("system-reminders", cachedReminders), caller)
 	if scope == core.ScopeMain {
 		// Task tracking + interactive questions are main-agent behaviors.
 		sys.Use(guidelines("task-workflow", cachedTasks), caller)

--- a/internal/core/system/prompts/guidelines/system-reminders.txt
+++ b/internal/core/system/prompts/guidelines/system-reminders.txt
@@ -1,3 +1,2 @@
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.

--- a/internal/core/system/prompts/guidelines/system-reminders.txt
+++ b/internal/core/system/prompts/guidelines/system-reminders.txt
@@ -1,0 +1,3 @@
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.

--- a/internal/core/system/testdata/main_session.txt
+++ b/internal/core/system/testdata/main_session.txt
@@ -90,9 +90,8 @@ Key rules:
 </guidelines>
 
 <guidelines name="system-reminders">
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.
 </guidelines>
 
 <guidelines name="task-workflow">

--- a/internal/core/system/testdata/main_session.txt
+++ b/internal/core/system/testdata/main_session.txt
@@ -89,6 +89,12 @@ Key rules:
 - Delete unused code completely; don't comment it out.
 </guidelines>
 
+<guidelines name="system-reminders">
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+</guidelines>
+
 <guidelines name="task-workflow">
 You have TaskCreate, TaskGet, TaskUpdate, TaskList tools to track multi-step work. The task list is shown above the input area for the user.
 

--- a/internal/core/system/testdata/minimal.txt
+++ b/internal/core/system/testdata/minimal.txt
@@ -90,9 +90,8 @@ Key rules:
 </guidelines>
 
 <guidelines name="system-reminders">
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.
 </guidelines>
 
 <guidelines name="task-workflow">

--- a/internal/core/system/testdata/minimal.txt
+++ b/internal/core/system/testdata/minimal.txt
@@ -89,6 +89,12 @@ Key rules:
 - Delete unused code completely; don't comment it out.
 </guidelines>
 
+<guidelines name="system-reminders">
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+</guidelines>
+
 <guidelines name="task-workflow">
 You have TaskCreate, TaskGet, TaskUpdate, TaskList tools to track multi-step work. The task list is shown above the input area for the user.
 

--- a/internal/core/system/testdata/no_git.txt
+++ b/internal/core/system/testdata/no_git.txt
@@ -90,9 +90,8 @@ Key rules:
 </guidelines>
 
 <guidelines name="system-reminders">
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.
 </guidelines>
 
 <guidelines name="task-workflow">

--- a/internal/core/system/testdata/no_git.txt
+++ b/internal/core/system/testdata/no_git.txt
@@ -89,6 +89,12 @@ Key rules:
 - Delete unused code completely; don't comment it out.
 </guidelines>
 
+<guidelines name="system-reminders">
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+</guidelines>
+
 <guidelines name="task-workflow">
 You have TaskCreate, TaskGet, TaskUpdate, TaskList tools to track multi-step work. The task list is shown above the input area for the user.
 

--- a/internal/core/system/testdata/subagent_general.txt
+++ b/internal/core/system/testdata/subagent_general.txt
@@ -55,9 +55,8 @@ Key rules:
 </guidelines>
 
 <guidelines name="system-reminders">
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.
 </guidelines>
 
 <guidelines name="git-safety">

--- a/internal/core/system/testdata/subagent_general.txt
+++ b/internal/core/system/testdata/subagent_general.txt
@@ -54,6 +54,12 @@ Key rules:
 - Delete unused code completely; don't comment it out.
 </guidelines>
 
+<guidelines name="system-reminders">
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+</guidelines>
+
 <guidelines name="git-safety">
 NEVER do these without explicit user request:
 - Update git config.

--- a/internal/core/system/testdata/subagent_readonly.txt
+++ b/internal/core/system/testdata/subagent_readonly.txt
@@ -53,9 +53,8 @@ Key rules:
 </guidelines>
 
 <guidelines name="system-reminders">
-- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
-- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
-- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+- <system-reminder> blocks appended below a user message are injected by the harness, not typed by the user. Treat their contents as authoritative system instructions, and act on the most recent values — they refresh and re-inject after compaction.
+- Don't echo <system-reminder> tags back to the user or call attention to them; just follow them.
 </guidelines>
 
 <guidelines name="git-safety">

--- a/internal/core/system/testdata/subagent_readonly.txt
+++ b/internal/core/system/testdata/subagent_readonly.txt
@@ -52,6 +52,12 @@ Key rules:
 - Delete unused code completely; don't comment it out.
 </guidelines>
 
+<guidelines name="system-reminders">
+- Some user messages have <system-reminder> blocks appended below the user's own text. These are injected by the harness, not typed by the user. Treat their contents as authoritative system context and instructions, even though they appear inside a user message.
+- A reminder may carry a source attribute (e.g. source="memory-user", source="skills-directory") naming who produced it. The harness refreshes reminders as the session evolves and re-injects them after compaction, so always act on the most recent values rather than earlier copies.
+- Do not echo <system-reminder> tags back to the user or call attention to them; just follow the guidance they carry.
+</guidelines>
+
 <guidelines name="git-safety">
 NEVER do these without explicit user request:
 - Update git config.

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -12,7 +12,7 @@
 //
 // Use the reminder package for content that is "session-level" or
 // "project-level" and may change during a session — skills directory, memory
-// files, ad-hoc notices. Behavior that is true for every Gen Code session
+// files, one-time notices. Behavior that is true for every Gen Code session
 // (identity, policy, guidelines) belongs in the system prompt instead.
 package reminder
 
@@ -62,7 +62,8 @@ func (p providerFunc) Render() string { return p.render() }
 //     PostCompact (e.g. skills, memory).
 //   - pending: reminders queued for the next user message; each entry tracks
 //     which provider (if any) emitted it so EnqueueAllProviders can replace
-//     stale provider entries instead of duplicating them.
+//     stale provider entries instead of duplicating them. Entries with no
+//     provider are one-time notices (see Enqueue).
 //
 // All operations are safe for concurrent use.
 type Service struct {
@@ -72,11 +73,11 @@ type Service struct {
 }
 
 // pendingEntry pairs a wrapped <system-reminder> body with the ID of the
-// provider that produced it. providerID is empty for ad-hoc bodies queued
+// provider that produced it. providerID is empty for one-time notices queued
 // via Enqueue (e.g. hook context), so they always coexist with — and never
 // shadow — provider emissions.
 type pendingEntry struct {
-	providerID string // "" for ad-hoc Enqueue
+	providerID string // "" for a one-time notice (Enqueue)
 	wrapped    string // already wrapped in <system-reminder>
 }
 
@@ -115,10 +116,12 @@ func (s *Service) Unregister(id string) {
 	}
 }
 
-// Enqueue adds an ad-hoc reminder body to the pending queue. The body should
-// not include the <system-reminder> wrapper — this method adds it.
+// Enqueue adds a one-time notice to the pending queue. A notice is a reminder
+// not backed by a provider — e.g. hook context or a cancel notice — emitted
+// once and never auto-regenerated. The body should not include the
+// <system-reminder> wrapper; this method adds it.
 //
-// Empty bodies are dropped silently. Ad-hoc entries persist independently of
+// Empty bodies are dropped silently. Notices persist independently of
 // EnqueueAllProviders — the latter only touches provider-emitted entries.
 func (s *Service) Enqueue(body string) {
 	body = strings.TrimSpace(body)
@@ -131,12 +134,12 @@ func (s *Service) Enqueue(body string) {
 	s.pending = append(s.pending, pendingEntry{wrapped: wrapped})
 }
 
-// DiscardPendingAdHoc drops every pending entry that was queued via Enqueue /
-// EnqueueOnce (providerID==""). Used by /compact: the cancelled assistant or
-// hook output that originally produced these reminders has been summarized
-// out of the conversation, so the reminder no longer matches what the model
-// sees. Provider entries are preserved.
-func (s *Service) DiscardPendingAdHoc() {
+// DiscardPendingNotices drops every pending notice — entries queued via
+// Enqueue / EnqueueOnce (providerID==""). Used by /compact: the cancelled
+// assistant or hook output that originally produced these notices has been
+// summarized out of the conversation, so the notice no longer matches what
+// the model sees. Provider entries are preserved.
+func (s *Service) DiscardPendingNotices() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.pending) == 0 {
@@ -175,7 +178,7 @@ func (s *Service) EnqueueOnce(body string) {
 // non-empty bodies. Idempotent across repeated calls: any prior pending
 // entry from the same provider is dropped before re-emitting, so SessionStart
 // → PostCompact → /skills toggle in close succession produces a single
-// emission per provider rather than accumulating duplicates. Ad-hoc entries
+// emission per provider rather than accumulating duplicates. One-time notices
 // queued via Enqueue are preserved.
 //
 // Each provider's body is wrapped with the provider ID as the `source`
@@ -243,7 +246,7 @@ func Wrap(body string) string {
 // WrapWithSource is like Wrap but stamps a source attribute on the opening
 // tag so downstream consumers (transcript parser, viewer) know which
 // provider produced the reminder. source="" matches Wrap output exactly to
-// keep ad-hoc Enqueue traffic and tests stable.
+// keep one-time notice (Enqueue) traffic and tests stable.
 func WrapWithSource(body, source string) string {
 	body = strings.TrimSpace(body)
 	if body == "" {
@@ -258,15 +261,30 @@ func WrapWithSource(body, source string) string {
 	return "<system-reminder source=\"" + src + "\">\n" + body + "\n</system-reminder>"
 }
 
-// WrapMemory returns the canonical <memory scope="..."> envelope used by
-// both the main agent's reminder providers and the subagent's first-message
-// reminders. Empty body returns "".
+// WrapMemory returns the main agent's memory reminder body: a short
+// instructive preamble that tells the model what the content is and how to
+// treat it, followed by the canonical <memory scope="..."> envelope. The
+// preamble matters because the raw memory text alone gives the model no
+// framing — unlike the skills directory, which self-introduces. Empty body
+// returns "".
 func WrapMemory(scope, body string) string {
 	body = strings.TrimSpace(body)
 	if body == "" {
 		return ""
 	}
-	return "<memory scope=\"" + scope + "\">\n" + body + "\n</memory>"
+	return memoryPreamble(scope) + "\n<memory scope=\"" + scope + "\">\n" + body + "\n</memory>"
+}
+
+// memoryPreamble returns the one-line framing sentence prepended to a memory
+// reminder, tailored to the scope. Unknown scopes fall back to the user
+// phrasing.
+func memoryPreamble(scope string) string {
+	switch scope {
+	case "project":
+		return "The following is saved project memory (conventions and standing instructions for this codebase). Apply it throughout this session."
+	default:
+		return "The following is the user's saved memory (preferences and standing instructions). Apply it throughout this session."
+	}
 }
 
 // AttachToContent appends pending reminders to user message content. A blank

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestWrapMemoryPreamble(t *testing.T) {
+	user := WrapMemory("user", "Always use tabs.")
+	if !strings.Contains(user, "user's saved memory") {
+		t.Errorf("WrapMemory(user) missing user preamble: %q", user)
+	}
+	if !strings.HasSuffix(user, "<memory scope=\"user\">\nAlways use tabs.\n</memory>") {
+		t.Errorf("WrapMemory(user) should end with the <memory> envelope: %q", user)
+	}
+
+	project := WrapMemory("project", "Run make lint.")
+	if !strings.Contains(project, "saved project memory") {
+		t.Errorf("WrapMemory(project) missing project preamble: %q", project)
+	}
+
+	if got := WrapMemory("user", "   "); got != "" {
+		t.Errorf("WrapMemory with blank body = %q, want \"\"", got)
+	}
+}
+
 func TestWrapEmpty(t *testing.T) {
 	if got := Wrap(""); got != "" {
 		t.Errorf("Wrap(\"\") = %q, want \"\"", got)
@@ -211,13 +230,13 @@ func TestServiceProviderReflectsLatestState(t *testing.T) {
 // TestServiceEnqueueAllProvidersIsIdempotent guards against the slow-growing
 // duplicate-emission leak: SessionStart → PostCompact → /skills toggle in
 // close succession should produce one emission per provider, not three.
-// Ad-hoc Enqueue entries must survive a re-emission unmolested.
+// One-time notices (Enqueue) must survive a re-emission unmolested.
 func TestServiceEnqueueAllProvidersIsIdempotent(t *testing.T) {
 	s := NewService()
 	s.Register(NewProvider("skills-directory", func() string { return "skills body" }))
 	s.Register(NewProvider("memory-user", func() string { return "user mem" }))
 
-	// Ad-hoc hook context queued before the first emission.
+	// Hook-context notice queued before the first emission.
 	s.Enqueue("hook context A")
 
 	s.EnqueueAllProviders() // first SessionStart
@@ -225,9 +244,9 @@ func TestServiceEnqueueAllProvidersIsIdempotent(t *testing.T) {
 	s.EnqueueAllProviders() // PostCompact
 
 	out := s.Drain()
-	// 1 ad-hoc entry + 2 provider entries (one per provider) = 3 total.
+	// 1 notice + 2 provider entries (one per provider) = 3 total.
 	if len(out) != 3 {
-		t.Fatalf("expected 3 reminders (1 ad-hoc + 2 providers), got %d: %v", len(out), out)
+		t.Fatalf("expected 3 reminders (1 notice + 2 providers), got %d: %v", len(out), out)
 	}
 
 	var skillsCount, memoryCount, hookCount int

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -24,17 +24,17 @@ import (
 
 // Executor runs agent LLM loops
 type Executor struct {
-	provider            llm.Provider
-	cwd                 string
-	parentModelID       string // Parent conversation's model ID (used when inheriting)
-	hooks               hook.Handler
-	sessionStore        SubagentSessionStore // Optional: when set, subagent sessions are persisted
-	parentSessionID     string               // Parent session ID for linking subagent sessions
-	isGit               bool                 // whether cwd is a git repository
-	skillsPrompt        string               // available skills section for capable subagents
-	agentsPrompt        string               // available agents section for capable subagents
-	mcpTools            mcp.Tools            // tool schemas + execution
-	mcpServers          mcp.Servers          // connect/disconnect for per-subagent server sets
+	provider        llm.Provider
+	cwd             string
+	parentModelID   string // Parent conversation's model ID (used when inheriting)
+	hooks           hook.Handler
+	sessionStore    SubagentSessionStore // Optional: when set, subagent sessions are persisted
+	parentSessionID string               // Parent session ID for linking subagent sessions
+	isGit           bool                 // whether cwd is a git repository
+	skillsPrompt    string               // available skills section for capable subagents
+	agentsPrompt    string               // available agents section for capable subagents
+	mcpTools        mcp.Tools            // tool schemas + execution
+	mcpServers      mcp.Servers          // connect/disconnect for per-subagent server sets
 }
 
 type SubagentSessionStore interface {

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -30,8 +30,6 @@ type Executor struct {
 	hooks               hook.Handler
 	sessionStore        SubagentSessionStore // Optional: when set, subagent sessions are persisted
 	parentSessionID     string               // Parent session ID for linking subagent sessions
-	userInstructions    string               // ~/.gen/GEN.md + rules
-	projectInstructions string               // .gen/GEN.md + rules + local
 	isGit               bool                 // whether cwd is a git repository
 	skillsPrompt        string               // available skills section for capable subagents
 	agentsPrompt        string               // available agents section for capable subagents
@@ -64,11 +62,10 @@ func NewExecutor(llmProvider llm.Provider, cwd string, parentModelID string, hoo
 	}
 }
 
-// SetContext provides project context (instructions, git status) so subagents
-// get the same system prompt foundation as the parent conversation.
-func (e *Executor) SetContext(userInstructions, projectInstructions string, isGit bool) {
-	e.userInstructions = userInstructions
-	e.projectInstructions = projectInstructions
+// SetContext provides project context (git status) so subagents get the same
+// system prompt foundation as the parent conversation. Memory (user/project
+// instructions) is intentionally not propagated — see collectSubagentReminders.
+func (e *Executor) SetContext(isGit bool) {
 	e.isGit = isGit
 }
 
@@ -329,31 +326,24 @@ func (e *Executor) loadConversation(ag core.Agent, ctx context.Context, rc *runC
 	// Fresh start: harness-managed reminders ride on the first user message
 	// as <system-reminder> blocks, matching the main agent's pattern.
 	skillsPrompt, _ := e.capabilityPrompts(rc.config)
-	reminders := collectSubagentReminders(skillsPrompt, e.userInstructions, e.projectInstructions)
+	reminders := collectSubagentReminders(skillsPrompt)
 	prompt := reminder.AttachToContent(req.Prompt, reminders)
 	ag.Append(ctx, core.UserMessage(prompt, nil))
 	return nil
 }
 
-// collectSubagentReminders returns fully-wrapped <system-reminder> blocks
+// collectSubagentReminders returns the fully-wrapped <system-reminder> blocks
 // for the subagent's first user message. Empty inputs produce no entries.
 //
-// Mirrors the main agent's reminder.Service providers (skills directory,
-// memory-user, memory-project) but emits inline because subagents are
-// one-shot — there is no long-lived service to register against.
-func collectSubagentReminders(skills, userMemory, projectMemory string) []string {
-	bodies := []string{
-		skills,
-		reminder.WrapMemory("user", userMemory),
-		reminder.WrapMemory("project", projectMemory),
+// Subagents get the skills directory (so they can invoke capabilities) but
+// NOT user/project memory: memory is scoped to the long-lived main loop
+// agent, whereas a subagent is a one-shot worker bounded by its own charter
+// and should not carry the human's project/user instructions.
+func collectSubagentReminders(skills string) []string {
+	if w := reminder.Wrap(skills); w != "" {
+		return []string{w}
 	}
-	out := make([]string, 0, len(bodies))
-	for _, b := range bodies {
-		if w := reminder.Wrap(b); w != "" {
-			out = append(out, w)
-		}
-	}
-	return out
+	return nil
 }
 
 func interpretStopReason(result *core.Result, maxTurns int) (success bool, errMsg string) {


### PR DESCRIPTION
## Summary

System-reminders (skills, memory, one-time notices) ride inside user-message content, so compaction was folding stale reminder text into the summary. This gives every reminder one uniform lifecycle:

- **Injected** on the first user message.
- **Skipped** during compaction — `BuildConversationText` strips `<system-reminder>` blocks before summarizing (one choke point for both auto-compaction and manual `/compact`).
- **Re-attached** after compaction — `DiscardPendingNotices` + `EnqueueAllProviders` rebuild fresh reminders on the next user turn.

## Bundled cleanups

- Rename the confusing `ad-hoc` concept to `notice` (`DiscardPendingAdHoc` → `DiscardPendingNotices`).
- Subagents no longer receive memory (only the skills directory) — memory is for the long-lived main loop; simplifies `Executor.SetContext` to `SetContext(isGit)`.
- Memory reminders gain a one-line framing preamble (`WrapMemory`).
- Add a `<guidelines name="system-reminders">` directive so the model treats reminder content as authoritative. Memory/skills stay out of the system prompt; only this meta-directive is added.

## Test plan

- [x] `go build ./...` and `go test ./...` green
- [x] New tests: reminder stripping in `BuildConversationText`, `WrapMemory` preamble
- [x] System-prompt golden files regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)