### PR TITLE
Record compaction summary + boundary in transcript; refresh memory on PostCompact

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -1,0 +1,176 @@
+# Compaction
+
+When a conversation approaches the model's input limit, Gen Code **compacts**
+it: an LLM summarizes the history, and that summary replaces the old turns so
+the conversation can keep going within the window.
+
+This page covers the mechanism end to end — what happens to each
+[harness channel](harness-channels.md) (system prompt, `<system-reminder>`
+blocks, messages), how the summary is recorded for replay, and how the two
+entry points (automatic and manual `/compact`) differ and agree.
+
+## What compaction touches (and what it doesn't)
+
+The three channels are treated very differently. The whole design hinges on
+leaving the cacheable prefix alone and only rewriting the volatile tail.
+
+```
+            BEFORE compaction                      AFTER compaction
+  ┌──────────────────────────────┐       ┌──────────────────────────────┐
+  │ SYSTEM PROMPT (cached)         │      │ SYSTEM PROMPT (same bytes,     │
+  │  identity / policy / guideline │ ===> │  reused straight from cache)   │  ← never rebuilt
+  ├──────────────────────────────┤       ├──────────────────────────────┤
+  │ MESSAGES                       │      │ MESSAGES                       │
+  │  user  "hi"                    │      │  user  "Previous context:      │
+  │  asst  ...                     │ ===> │         <summary>"             │  ← whole chain → 1 msg
+  │  user  ...   (20+ turns)       │      │                                │
+  ├──────────────────────────────┤       ├──────────────────────────────┤
+  │ <system-reminder> on the last  │      │ (nothing here yet — reminders  │
+  │  user message (skills, memory) │ ===> │  re-emit on the NEXT user msg) │  ← stripped, re-rendered
+  └──────────────────────────────┘       └──────────────────────────────┘
+```
+
+- **System prompt — not rebuilt.** Compaction never calls `System.Use` /
+  `Refresh`, so `System.Prompt()` returns the same cached string. The prompt is
+  session-invariant (identity, policy, guidelines, environment), so there is
+  nothing to recompute, and reusing it keeps the provider's prompt-cache prefix
+  valid across the compaction.
+- **Messages — replaced by one summary.** The entire chain becomes a single
+  **plain user message**, `core.FormatCompactSummary(summary)` =
+  `"Previous context:\n" + summary`. Not a system-reminder, not the system
+  prompt — durable conversation state belongs in the message channel.
+- **`<system-reminder>` blocks — skipped, then re-rendered fresh.** Reminders
+  ride *inside* the last user message's content, so the summarizer would
+  otherwise bake stale skills/memory text into the permanent summary.
+  `core.BuildCompactionText` strips them before summarizing; afterwards the
+  harness re-emits them so they reattach to the *next* user turn (see
+  [Reminder freshness](#reminder-freshness)).
+
+## The common pipeline
+
+Both entry points run the same core steps:
+
+```
+  trigger
+    │
+    ▼
+  summarize  ── system.CompactPrompt() over BuildCompactionText(msgs)
+    │            (reminders stripped; reminder-only turns dropped)
+    ▼
+  replace    ── messages := [ UserMessage("Previous context:\n"+summary) ]
+    │
+    ├─▶ record    message.appended(summary, stable ID)
+    │             session.compacted(boundary = summary ID)
+    │
+    ├─▶ refresh   re-read memory from disk (refreshMemoryContext)
+    │
+    └─▶ reminders DiscardPendingNotices() + EnqueueAllProviders()
+                  → skills/memory reattach on the next user message
+```
+
+The summary text itself is identical between the two paths (same
+`FormatCompactSummary`), so a reader/replayer cannot tell which path produced a
+given summary.
+
+## Auto-compact vs. manual `/compact`
+
+```
+AUTO  (core agent, inside the ThinkAct loop)
+  ┌────────────────────────────────────────────────────────────┐
+  │ each turn:                                                   │
+  │   estimate next prompt size (BuildConversationText length)   │
+  │        │                                                     │
+  │        ├─ ≥ 95% of input limit ──▶ compact() ──▶ continue ───┼─▶ re-infer NOW
+  │        │                                          (in-loop)  │   with [summary]
+  │   streamInfer()                                              │
+  │        └─ "prompt too long" error ─▶ compact() ─▶ continue ──┼─▶ retry
+  └────────────────────────────────────────────────────────────┘
+
+MANUAL  (/compact [focus], app layer)
+  user: /compact [focus]
+     │  PreCompact hook  (focus += AdditionalContext)
+     │  summarize ──▶ stop the agent ──▶ conv := [summary]
+     │                                ──▶ restore recently-accessed files
+     └─ next user message ──▶ ensureAgentSession reseeds the agent from conv ──▶ Run
+```
+
+### Commonalities
+
+- Summarize with the same compaction prompt over reminder-stripped text.
+- Replace the chain with one `Previous context:` user message.
+- Re-read memory from disk, then `DiscardPendingNotices` + `EnqueueAllProviders`
+  so the next user turn carries fresh skills/memory.
+- Fire the `PostCompact` hook.
+- The system prompt is reused from cache (neither path rebuilds it).
+
+### Differences
+
+| Aspect | Auto-compact | Manual `/compact` |
+|---|---|---|
+| Trigger | proactive size estimate (≥95% of limit) or reactive *prompt-too-long* retry | user runs `/compact [focus]` |
+| Driver | core agent `compact()` — runs **in-loop** | app layer; summary computed, then agent **stopped** |
+| Continuation | `continue` re-infers immediately with `[summary]` | agent stopped; **next** user message reseeds it from the conversation |
+| Focus | none | optional focus string; `PreCompact` hook can add context |
+| Recent-file restore | not performed | restores recently-accessed files after the summary |
+| Transcript boundary | recorded (summary append + `session.compacted`) | not yet recorded — tracked with the post-compaction unification work |
+
+> The remaining divergences (file restore, env-reset call, and manual-path
+> transcript recording) are being unified so both paths share one
+> post-compaction routine. See the unification follow-up.
+
+## Transcript recording & replay
+
+Compaction does not delete the old turns from the transcript — that history
+stays on disk for audit and scroll-back. Instead it records a **boundary** so
+replay knows where the active chain begins.
+
+The core agent gives the summary a stable ID, records it as a normal
+`message.appended` (parented to the last pre-compaction message), and emits a
+`session.compacted` record whose `boundaryId` is that summary's ID:
+
+```
+transcript (append-only)            replay: walk leaf → parent, STOP at boundary
+  appended  m1                        m1   ─ excluded (ancestor of boundary)
+  appended  m2                        m2   ─ excluded
+  ...                                 ...
+  appended  SUM   ◀── boundary        SUM  ◀── stop ┐
+  appended  m8  (parent = SUM)        m8            ├─ active chain = [SUM, m8, m9]
+  appended  m9                        m9  (leaf)    ┘
+  session.compacted  boundaryId=SUM
+```
+
+Without the boundary, replay would walk all the way back through `m1…m2…` and
+reconstruct the *pre*-compaction chain — which is exactly the
+"`messageIds — 2 expected vs 7 replayed`" mismatch the inspector reports when
+the summary append and boundary are missing. `materializeActiveChain`
+(`internal/session/transcript/projector.go`) stops at the boundary so the
+reconstructed chain matches what the live agent actually sent.
+
+## Reminder freshness
+
+Reminder providers render from cached instructions
+(`env.CachedUserInstructions` / `CachedProjectInstructions`). On PostCompact the
+harness calls `refreshMemoryContext` to **re-read the memory files from disk
+before** re-emitting, so a `GEN.md`/`CLAUDE.md` edited mid-session re-injects
+its *latest* content rather than a stale cached copy. This is the key asymmetry
+with the system prompt: the prompt is reused from cache (it cannot have
+changed), but reminders are deliberately rebuilt.
+
+## Implementation
+
+| Concern | Location |
+|---|---|
+| Trigger + in-loop compaction | `internal/core/agent_impl.go` (`ThinkAct`, `compact`) |
+| Summary text (reminders stripped) | `internal/core/message.go` (`BuildCompactionText`) |
+| Compaction LLM call | `internal/agent/build.go`, `internal/app/conv/compact.go` |
+| Boundary recording | `internal/session/recorder.go` (`onCompact`) → `transcript.FileStore.Compact` |
+| Replay truncation | `internal/session/transcript/projector.go` (`materializeActiveChain`) |
+| App-side handlers + memory refresh | `internal/app/model_compact.go` |
+
+## See Also
+
+- [`concepts/harness-channels.md`](harness-channels.md) — the system-prompt /
+  reminder / message channels compaction operates on.
+- [`packages/reminder.md`](../packages/reminder.md) — reminder providers and
+  re-emission.
+- [`packages/session.md`](../packages/session.md) — transcript records and replay.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -64,7 +64,7 @@ Both entry points run the same core steps:
     │
     ├─▶ refresh   re-read memory from disk (refreshMemoryContext)
     │
-    └─▶ reminders DiscardPendingNotices() + RefreshSystemReminders()
+    └─▶ reminders DiscardPendingNotices() + RequeueSystemReminders()
                   → skills/memory reattach on the next user message
 ```
 
@@ -98,7 +98,7 @@ MANUAL  (/compact [focus], app layer)
 
 - Summarize with the same compaction prompt over reminder-stripped text.
 - Replace the chain with one `Previous context:` user message.
-- Re-read memory from disk, then `DiscardPendingNotices` + `RefreshSystemReminders`
+- Re-read memory from disk, then `DiscardPendingNotices` + `RequeueSystemReminders`
   so the next user turn carries fresh skills/memory.
 - Fire the `PostCompact` hook.
 - The system prompt is reused from cache (neither path rebuilds it).

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -64,7 +64,7 @@ Both entry points run the same core steps:
     │
     ├─▶ refresh   re-read memory from disk (refreshMemoryContext)
     │
-    └─▶ reminders DiscardPendingNotices() + EnqueueAllProviders()
+    └─▶ reminders DiscardPendingNotices() + RefreshSystemReminders()
                   → skills/memory reattach on the next user message
 ```
 
@@ -98,7 +98,7 @@ MANUAL  (/compact [focus], app layer)
 
 - Summarize with the same compaction prompt over reminder-stripped text.
 - Replace the chain with one `Previous context:` user message.
-- Re-read memory from disk, then `DiscardPendingNotices` + `EnqueueAllProviders`
+- Re-read memory from disk, then `DiscardPendingNotices` + `RefreshSystemReminders`
   so the next user turn carries fresh skills/memory.
 - Fire the `PostCompact` hook.
 - The system prompt is reused from cache (neither path rebuilds it).

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -126,7 +126,8 @@ replay knows where the active chain begins.
 
 The core agent gives the summary a stable ID, records it as a normal
 `message.appended` (parented to the last pre-compaction message), and emits a
-`session.compacted` record whose `boundaryId` is that summary's ID:
+`session.compacted` record whose `summaryMessageId` is that summary's ID. Replay
+uses that ID as the boundary to stop walking parents at:
 
 ```
 transcript (append-only)            replay: walk leaf → parent, STOP at boundary
@@ -136,7 +137,7 @@ transcript (append-only)            replay: walk leaf → parent, STOP at bounda
   appended  SUM   ◀── boundary        SUM  ◀── stop ┐
   appended  m8  (parent = SUM)        m8            ├─ active chain = [SUM, m8, m9]
   appended  m9                        m9  (leaf)    ┘
-  session.compacted  boundaryId=SUM
+  session.compacted  summaryMessageId=SUM
 ```
 
 Without the boundary, replay would walk all the way back through `m1…m2…` and

--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -134,54 +134,24 @@ capabilities) but not the human's project/user instructions. See
 
 ## Compaction
 
-When the context window approaches its limit, the harness compacts:
-
-1. Build the summarization input from the conversation, **stripping every
-   `<system-reminder>` block** out of the user messages first (see below).
-2. Call the LLM with a "summarize the following conversation" prompt to
-   produce a `CompactInfo` summary.
-3. Replace the conversation with a single synthetic message containing the
-   summary.
-4. Drop one-time notices (`DiscardPendingNotices`) and re-emit all providers
-   (`EnqueueAllProviders`) so the post-compact conversation has fresh
-   skill/memory context on the next user turn.
-
-### Reminders are skipped during compaction, not summarized
-
-Reminders ride *inside* user-message content (attached below the prompt),
-so a naive summarizer would fold stale skill/memory/notice text into the
-summary. That is wasteful and risks pinning outdated context into the
-permanent summary. Instead, `core.BuildCompactionText` peels the trailing
-run of `<system-reminder>` blocks off each user message before summarizing;
-a message that was *only* reminders contributes nothing. The fresh state
-comes back through the re-emission step (4), giving every reminder
-provider — skills, memory-user, memory-project, and notices — the same
-lifecycle:
-
-- **injected** on the first user message (`SessionStart`),
-- **skipped** from the summarization input during compaction,
-- **re-injected** on the next user message after `PostCompact`.
-
-`BuildCompactionText` is used by both the auto-compaction path
-(`internal/agent/build.go`) and the manual `/compact` path
-(`internal/app/conv/compact.go`). Its sibling `BuildConversationText` keeps
-reminders intact and is used for proactive-compaction *size estimation*
-(`agent_impl.go`), where the real prompt — reminders included — is what the
-estimate must track.
-
-Stripping peels blocks from the end by anchoring on the last *opening* tag
-rather than matching the merged text with a regex: a closing tag never
-contains the opening-tag prefix, so a reminder body that itself quotes
-`</system-reminder>` is still removed in full, and a `<system-reminder>` the
-user typed mid-message is left untouched.
-
 Compaction is **not** a channel by itself — it's a mutation of the
-user-message channel. The strip-then-re-emit pair is what keeps the
-reminder channel coherent across a compaction.
+user-message channel that leaves the other two alone:
 
-Implementation: `internal/app/conv/compact.go` and
-`internal/core/message.go` (`BuildCompactionText`). The agent emits
-`OnCompact` events for observers.
+- the **system prompt** is reused from cache (never rebuilt),
+- the **messages** collapse into a single `Previous context:` summary message,
+- the **`<system-reminder>` blocks** are stripped from the summarization input
+  (`core.BuildCompactionText` peels the trailing reminder run off each user
+  message) and re-emitted fresh on the next user turn, so every reminder
+  provider shares one lifecycle: injected on the first user message, skipped
+  from the summary during compaction, re-injected after `PostCompact`.
+
+`BuildCompactionText`'s sibling `BuildConversationText` keeps reminders intact
+and is used for proactive-compaction *size estimation*, where the real prompt —
+reminders included — is what the estimate must track.
+
+For the full mechanism — the common pipeline, auto-compact vs. manual
+`/compact`, transcript boundary recording, and reminder freshness — see
+[`concepts/compaction.md`](compaction.md).
 
 ## See Also
 
@@ -190,5 +160,7 @@ Implementation: `internal/app/conv/compact.go` and
 - [`packages/core.md`](../packages/core.md) — `System`, `Section`, slot
   layout.
 - [`packages/reminder.md`](../packages/reminder.md) — runtime API.
+- [`concepts/compaction.md`](compaction.md) — the full compaction mechanism
+  (channels, auto vs. manual, transcript boundary).
 - [`packages/session.md`](../packages/session.md) — how compaction
   records flow into the transcript.

--- a/docs/packages/reminder.md
+++ b/docs/packages/reminder.md
@@ -50,7 +50,7 @@ func NewService() *Service
 func (s *Service) Register(p Provider)
 func (s *Service) Unregister(id string)
 func (s *Service) Enqueue(body string)
-func (s *Service) EnqueueAllProviders()
+func (s *Service) RefreshSystemReminders()
 // ... and a few drain/peek accessors for the harness
 
 // Standard provider IDs:
@@ -86,7 +86,7 @@ A handful of nits:
 
 - `Service` holds `providers []Provider` + a `pending []pendingEntry`
   queue. Mutex-protected.
-- `EnqueueAllProviders` is idempotent across repeated calls — it drops
+- `RefreshSystemReminders` is idempotent across repeated calls — it drops
   prior pending entries from the same provider before re-emitting, so
   `SessionStart` → `PostCompact` → `/skills` toggle in close succession
   produces one emission per provider rather than three.
@@ -100,12 +100,12 @@ A handful of nits:
   to the harness for the conversation builder.
 - Per-message: when the user submits, the harness calls
   `DrainPending()` and wraps the bodies into the outgoing user message.
-- Per-event: skill toggles / memory updates call `EnqueueAllProviders`
+- Per-event: skill toggles / memory updates call `RefreshSystemReminders`
   to refresh provider-emitted reminders.
 - On compaction: reminder blocks are **skipped, not summarized**.
   `core.BuildCompactionText` peels trailing `<system-reminder>…</system-reminder>`
   blocks from user content before the summarizer runs, then the harness calls
-  `DiscardPendingNotices` + `EnqueueAllProviders` so fresh provider state
+  `DiscardPendingNotices` + `RefreshSystemReminders` so fresh provider state
   reattaches to the next user turn. All providers (skills, memory-user,
   memory-project) and one-time notices share this lifecycle. On PostCompact
   the harness re-reads memory from disk before re-emitting, so an edited

--- a/docs/packages/reminder.md
+++ b/docs/packages/reminder.md
@@ -50,7 +50,7 @@ func NewService() *Service
 func (s *Service) Register(p Provider)
 func (s *Service) Unregister(id string)
 func (s *Service) Enqueue(body string)
-func (s *Service) RefreshSystemReminders()
+func (s *Service) RequeueSystemReminders()
 // ... and a few drain/peek accessors for the harness
 
 // Standard provider IDs:
@@ -86,7 +86,7 @@ A handful of nits:
 
 - `Service` holds `providers []Provider` + a `pending []pendingEntry`
   queue. Mutex-protected.
-- `RefreshSystemReminders` is idempotent across repeated calls — it drops
+- `RequeueSystemReminders` is idempotent across repeated calls — it drops
   prior pending entries from the same provider before re-emitting, so
   `SessionStart` → `PostCompact` → `/skills` toggle in close succession
   produces one emission per provider rather than three.
@@ -100,12 +100,12 @@ A handful of nits:
   to the harness for the conversation builder.
 - Per-message: when the user submits, the harness calls
   `DrainPending()` and wraps the bodies into the outgoing user message.
-- Per-event: skill toggles / memory updates call `RefreshSystemReminders`
+- Per-event: skill toggles / memory updates call `RequeueSystemReminders`
   to refresh provider-emitted reminders.
 - On compaction: reminder blocks are **skipped, not summarized**.
   `core.BuildCompactionText` peels trailing `<system-reminder>…</system-reminder>`
   blocks from user content before the summarizer runs, then the harness calls
-  `DiscardPendingNotices` + `RefreshSystemReminders` so fresh provider state
+  `DiscardPendingNotices` + `RequeueSystemReminders` so fresh provider state
   reattaches to the next user turn. All providers (skills, memory-user,
   memory-project) and one-time notices share this lifecycle. On PostCompact
   the harness re-reads memory from disk before re-emitting, so an edited

--- a/docs/packages/reminder.md
+++ b/docs/packages/reminder.md
@@ -107,8 +107,10 @@ A handful of nits:
   blocks from user content before the summarizer runs, then the harness calls
   `DiscardPendingNotices` + `EnqueueAllProviders` so fresh provider state
   reattaches to the next user turn. All providers (skills, memory-user,
-  memory-project) and one-time notices share this lifecycle. See
-  [`concepts/harness-channels.md`](../concepts/harness-channels.md#compaction).
+  memory-project) and one-time notices share this lifecycle. On PostCompact
+  the harness re-reads memory from disk before re-emitting, so an edited
+  memory file re-injects its latest content. See
+  [`concepts/compaction.md`](../concepts/compaction.md).
 
 ## Tests
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -84,6 +84,23 @@ func (s *Task) Send(content string, images []core.Image) {
 	ag.Inbox() <- core.Message{Role: core.RoleUser, Content: content, Images: images}
 }
 
+// Compact asks the running agent to compact in place using the precomputed
+// summary, replacing its conversation chain without tearing the agent down (so
+// the system prompt and tools are not rebuilt). The agent records the summary
+// and a compaction boundary and emits CompactEvent. Returns false when there is
+// no active agent to compact. Safe because the agent applies it at a phase
+// boundary on its own goroutine.
+func (s *Task) Compact(summary string) bool {
+	s.mu.RLock()
+	ag := s.agent
+	s.mu.RUnlock()
+	if ag == nil {
+		return false
+	}
+	ag.Inbox() <- core.Message{Signal: core.SigCompact, Content: summary}
+	return true
+}
+
 // interruptDrainTimeout caps how long InterruptTurn waits for the agent
 // goroutine to actually unwind its in-flight ThinkAct. Keeping this
 // tight avoids UI stalls; if the agent is still in a slow tool the

--- a/internal/app/conv/compact.go
+++ b/internal/app/conv/compact.go
@@ -91,7 +91,11 @@ func CompactConversation(ctx context.Context, c *llm.Client, msgs []core.Message
 }
 
 func RenderCompactStatus(width int, spinnerView string, state CompactState) string {
-	if !state.Active && state.LastResult == "" {
+	// Render only the in-progress spinner and error states. A successful
+	// compaction is communicated by the boundary line + the collapsed summary
+	// message, so the completed result box is suppressed (no redundant panel).
+	showError := state.LastResult != "" && state.LastError
+	if !state.Active && !showError {
 		return ""
 	}
 

--- a/internal/app/conv/compact.go
+++ b/internal/app/conv/compact.go
@@ -97,7 +97,7 @@ func RenderCompactStatus(width int, spinnerView string, state CompactState) stri
 
 	label := "SESSION SUMMARY"
 	title := "Conversation compacted"
-	subtitle := "Older context was folded into a shorter summary. You can continue normally."
+	subtitle := "" // completed state is terse — the detail line carries the count
 	detail := state.LastResult
 	accent := kit.CurrentTheme.Success
 	icon := "✓"

--- a/internal/app/conv/compact.go
+++ b/internal/app/conv/compact.go
@@ -36,6 +36,7 @@ type CompactState struct {
 	LastResult        string
 	LastError         bool
 	Phase             string
+	Count             int // messages being compacted, shown in the in-progress line
 	WarningSuppressed bool
 }
 
@@ -45,6 +46,7 @@ func (c *CompactState) Reset() {
 	c.LastResult = ""
 	c.LastError = false
 	c.Phase = ""
+	c.Count = 0
 	c.WarningSuppressed = false
 }
 
@@ -90,79 +92,29 @@ func CompactConversation(ctx context.Context, c *llm.Client, msgs []core.Message
 	return summary, count, nil
 }
 
-func RenderCompactStatus(width int, spinnerView string, state CompactState) string {
-	// Render only the in-progress spinner and error states. A successful
-	// compaction is communicated by the boundary line + the collapsed summary
-	// message, so the completed result box is suppressed (no redundant panel).
-	showError := state.LastResult != "" && state.LastError
-	if !state.Active && !showError {
+// RenderCompactStatus renders a single dim line while a manual /compact is in
+// flight (a spinner + how many messages are being compacted), and a one-line
+// error if it failed. A successful compaction shows nothing here — the boundary
+// line + the collapsed summary message communicate it. No box, no multi-line.
+func RenderCompactStatus(_ int, spinnerView string, state CompactState) string {
+	switch {
+	case state.Active:
+		msg := "Compacting conversation…"
+		if state.Count > 0 {
+			msg = fmt.Sprintf("Compacting %d messages…", state.Count)
+		}
+		return lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.TextDim).
+			PaddingLeft(1).
+			Render(spinnerView + " " + msg)
+	case state.LastResult != "" && state.LastError:
+		return lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.Error).
+			PaddingLeft(1).
+			Render("✗ " + state.LastResult)
+	default:
 		return ""
 	}
-
-	label := "SESSION SUMMARY"
-	title := "Conversation compacted"
-	subtitle := "" // completed state is terse — the detail line carries the count
-	detail := state.LastResult
-	accent := kit.CurrentTheme.Success
-	icon := "✓"
-
-	if state.Active {
-		if state.Phase != "" {
-			title = spinnerView + " " + state.Phase
-		} else {
-			title = spinnerView + " Compacting conversation"
-		}
-		subtitle = "Summarizing recent history into a shorter reusable summary."
-		if strings.TrimSpace(state.Focus) != "" {
-			detail = "Focus: " + state.Focus
-		} else {
-			detail = "Preparing a smaller conversation state for the next turns."
-		}
-		accent = kit.CurrentTheme.Primary
-		icon = ""
-	} else if state.LastError {
-		label = "COMPACT ERROR"
-		title = "Compact failed"
-		subtitle = "Conversation history was not replaced. You can retry once the issue is resolved."
-		accent = kit.CurrentTheme.Error
-		icon = "✗"
-	}
-
-	if icon != "" {
-		title = icon + " " + title
-	}
-
-	boxWidth := kit.CalculateBoxWidth(width)
-
-	labelStyle := lipgloss.NewStyle().
-		Foreground(kit.CurrentTheme.TextDim).
-		Bold(true)
-	headerStyle := lipgloss.NewStyle().
-		Foreground(accent).
-		Bold(true)
-	subtitleStyle := lipgloss.NewStyle().
-		Foreground(kit.CurrentTheme.Text)
-	bodyStyle := lipgloss.NewStyle().
-		Foreground(kit.CurrentTheme.TextDim)
-	boxStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(accent).
-		Background(kit.CurrentTheme.Background).
-		Padding(0, 1).
-		Width(boxWidth).
-		MarginLeft(1)
-
-	var lines []string
-	lines = append(lines, labelStyle.Render(label))
-	lines = append(lines, headerStyle.Render(title))
-	if strings.TrimSpace(subtitle) != "" {
-		lines = append(lines, subtitleStyle.Render(subtitle))
-	}
-	if strings.TrimSpace(detail) != "" {
-		lines = append(lines, bodyStyle.Render(detail))
-	}
-
-	return boxStyle.Render(strings.Join(lines, "\n"))
 }
 
 // --- Compact command ---

--- a/internal/app/conv/runtime.go
+++ b/internal/app/conv/runtime.go
@@ -26,7 +26,7 @@ type Runtime interface {
 	OnTurnEnd(result core.Result) tea.Cmd
 	OnAgentStop(err error) tea.Cmd
 	OnPermBridgeRequest(req *PermBridgeRequest) tea.Cmd
-	OnAutoCompact(info core.CompactInfo) tea.Cmd
+	OnCompacted(info core.CompactInfo) tea.Cmd
 	OnCompactResult(msg CompactResultMsg) tea.Cmd
 	OnTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd
 	HasRunningTasks() bool

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -61,7 +61,7 @@ func handleAgentEvent(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 		return rt.OnAgentStop(err)
 	case core.OnCompact:
 		info, _ := ev.CompactInfo()
-		return rt.OnAutoCompact(info)
+		return rt.OnCompacted(info)
 	default:
 		if extra := applyAgentEvent(rt, m, ev); extra != nil {
 			return tea.Batch(extra, rt.ContinueOutbox())
@@ -91,7 +91,7 @@ func handleAgentEventBatch(rt Runtime, m *Model, events []core.Event, closed boo
 			needsContinue = false
 		case core.OnCompact:
 			info, _ := ev.CompactInfo()
-			cmds = append(cmds, rt.OnAutoCompact(info))
+			cmds = append(cmds, rt.OnCompacted(info))
 			needsContinue = false
 		default:
 			if extra := applyAgentEvent(rt, m, ev); extra != nil {

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -147,7 +147,8 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 
 	switch msg.Role {
 	case core.RoleUser:
-		if msg.ToolResult != nil {
+		switch {
+		case msg.ToolResult != nil:
 			sb.WriteString(RenderToolResultInline(ToolResultData{
 				ToolName: msg.ToolName,
 				Content:  msg.ToolResult.Content,
@@ -155,7 +156,12 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 				IsError:  msg.ToolResult.IsError,
 				Expanded: msg.Expanded,
 			}, p.MDRenderer))
-		} else {
+		case core.IsCompactSummary(msg.Content):
+			// The post-compaction summary is injected as a user message (the
+			// model reads it, and it persists/seeds resume), but it's shown as a
+			// system notice — not a "❭" user turn — so the transcript stays clean.
+			sb.WriteString(RenderSystemMessage(msg.DisplayContent))
+		default:
 			sb.WriteString(RenderUserMessage(msg.Content, msg.DisplayContent, msg.Images, p.MDRenderer, p.Width))
 		}
 	case core.RoleNotice:

--- a/internal/app/hooks.go
+++ b/internal/app/hooks.go
@@ -64,7 +64,7 @@ func (m *model) executeStartupHooks(ctx context.Context) hook.HookOutcome {
 	// they ride on the first user message of this session. The system-prompt
 	// cache prefix stays untouched.
 	if m.services.Reminder != nil {
-		m.services.Reminder.RefreshSystemReminders()
+		m.services.Reminder.RequeueSystemReminders()
 	}
 	return m.services.Hook.Execute(ctx, hook.SessionStart, hook.HookInput{
 		Source: source,

--- a/internal/app/hooks.go
+++ b/internal/app/hooks.go
@@ -64,7 +64,7 @@ func (m *model) executeStartupHooks(ctx context.Context) hook.HookOutcome {
 	// they ride on the first user message of this session. The system-prompt
 	// cache prefix stays untouched.
 	if m.services.Reminder != nil {
-		m.services.Reminder.EnqueueAllProviders()
+		m.services.Reminder.RefreshSystemReminders()
 	}
 	return m.services.Hook.Execute(ctx, hook.SessionStart, hook.HookInput{
 		Source: source,

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -626,6 +626,7 @@ func (c *SlashCommandController) handleCompactCommand(_ context.Context, args st
 	c.env.Conversation.Compact.Active = true
 	c.env.Conversation.Compact.Focus = strings.TrimSpace(args)
 	c.env.Conversation.Compact.Phase = conv.PhaseSummarizing
+	c.env.Conversation.Compact.Count = len(c.env.Conversation.ConvertToProvider())
 	return "", tea.Batch(c.env.SpinnerTickCmd(), conv.CompactCmd(c.env.BuildCompactRequest(c.env.Conversation.Compact.Focus, "manual"))), nil
 }
 

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -53,7 +53,7 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	m.conv.Append(core.ChatMessage{
 		Role:           core.RoleUser,
 		Content:        core.FormatCompactSummary(info.Summary),
-		DisplayContent: fmt.Sprintf("✻ Conversation compacted — %d messages summarized (scroll up for history)", info.OriginalCount),
+		DisplayContent: fmt.Sprintf("≡ Conversation compacted — %d messages summarized (scroll up for history)", info.OriginalCount),
 	})
 
 	trigger := info.Trigger

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -53,6 +53,10 @@ func (m *model) OnAutoCompact(info core.CompactInfo) tea.Cmd {
 	// session-level reminders so they reattach to the next user turn and the
 	// LLM still has skills/memory/etc. context.
 	if m.services.Reminder != nil {
+		// Re-read memory from disk before re-emitting: a reminder provider
+		// renders from the cached instructions, so without this a memory file
+		// edited mid-session would re-inject stale content after compaction.
+		m.refreshMemoryContext(m.env.CWD, "post_compact")
 		// One-time notices (cancel notice, prior hook context) refer to
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.
@@ -98,6 +102,10 @@ func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 	// Manual /compact also drops conversation-history reminders. Re-enqueue
 	// providers so the next user turn carries fresh session-level context.
 	if m.services.Reminder != nil {
+		// Re-read memory from disk before re-emitting: a reminder provider
+		// renders from the cached instructions, so without this a memory file
+		// edited mid-session would re-inject stale content after compaction.
+		m.refreshMemoryContext(m.env.CWD, "post_compact")
 		// One-time notices (cancel notice, prior hook context) refer to
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -49,11 +49,25 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	m.conv.Clear()
 	m.env.ResetContextDisplay()
 	token := m.userInput.Provider.SetStatusMessage("compacted")
-	m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: core.FormatCompactSummary(info.Summary)})
+	// The full summary stays as the model's context (Content) and is persisted,
+	// but the transcript shows a terse one-liner instead of dumping the raw
+	// summary markdown. DisplayContent is render-only; Content is what the model
+	// and session store keep.
+	m.conv.Append(core.ChatMessage{
+		Role:           core.RoleUser,
+		Content:        core.FormatCompactSummary(info.Summary),
+		DisplayContent: fmt.Sprintf("Summary of %d earlier messages (kept as context).", info.OriginalCount),
+	})
 
 	trigger := info.Trigger
 	if trigger == "" {
 		trigger = "auto"
+	}
+	// Manual /compact shows the SESSION SUMMARY box; complete it here so its
+	// count matches the boundary line (both info.OriginalCount). Auto-compaction
+	// stays silent — just the boundary line.
+	if trigger == "manual" {
+		m.conv.Compact.Complete(fmt.Sprintf("Condensed %d earlier messages.", info.OriginalCount), false)
 	}
 	if m.services.Hook != nil {
 		m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: trigger})
@@ -95,8 +109,11 @@ func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 		m.conv.Compact.Complete(fmt.Sprintf("Compaction could not be completed: %v", msg.Error), true)
 		return tea.Batch(m.CommitMessages()...)
 	}
-	m.conv.Compact.Complete(fmt.Sprintf("Condensed %d earlier messages.", msg.OriginalCount), false)
 
+	// Don't complete the SESSION SUMMARY box here: the count is finalized in
+	// OnCompacted from the agent's authoritative message count, so the box and
+	// the boundary line never disagree. The spinner stays until the agent's
+	// CompactEvent arrives.
 	if m.services.Agent.Compact(msg.Summary) {
 		return tea.Batch(m.CommitMessages()...)
 	}

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -67,7 +67,7 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	if m.services.Reminder != nil {
 		m.refreshMemoryContext(m.env.CWD, "post_compact")
 		m.services.Reminder.DiscardPendingNotices()
-		m.services.Reminder.RefreshSystemReminders()
+		m.services.Reminder.RequeueSystemReminders()
 
 		// Manual /compact restores recently-accessed files as a one-time notice
 		// so they ride on the next user turn. Enqueued AFTER DiscardPendingNotices

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -61,7 +61,7 @@ func (m *model) OnAutoCompact(info core.CompactInfo) tea.Cmd {
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.
 		m.services.Reminder.DiscardPendingNotices()
-		m.services.Reminder.EnqueueAllProviders()
+		m.services.Reminder.RefreshSystemReminders()
 	}
 
 	scrollPart := tea.Sequence(append(scrollbackCmds, tea.Println(boundary), tea.ClearScreen)...)
@@ -110,7 +110,7 @@ func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 		// the now-summarized history; the model can't act on them
 		// meaningfully against the compacted prefix.
 		m.services.Reminder.DiscardPendingNotices()
-		m.services.Reminder.EnqueueAllProviders()
+		m.services.Reminder.RefreshSystemReminders()
 	}
 
 	scrollPart := tea.Sequence(append(scrollbackCmds, tea.Println(boundary), tea.ClearScreen)...)

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -35,7 +35,13 @@ func (m *model) BuildCompactRequest(focus, trigger string) conv.CompactRequest {
 	}
 }
 
-func (m *model) OnAutoCompact(info core.CompactInfo) tea.Cmd {
+// OnCompacted handles the CompactEvent emitted by the agent for BOTH
+// auto-compaction and manual /compact. By the time it runs the agent has
+// already replaced its in-memory chain with the summary and recorded the
+// compaction boundary — here we mirror that in the UI and refresh
+// session-level reminders. The agent is NOT torn down, so the system prompt
+// and tools are reused from cache (no rebuild).
+func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	scrollbackCmds := m.commitAllMessages()
 	boundaryStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	boundary := boundaryStyle.Render(fmt.Sprintf("✻ Conversation compacted — %d messages summarized (scroll up for history)", info.OriginalCount))
@@ -45,76 +51,60 @@ func (m *model) OnAutoCompact(info core.CompactInfo) tea.Cmd {
 	token := m.userInput.Provider.SetStatusMessage("compacted")
 	m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: core.FormatCompactSummary(info.Summary)})
 
-	if m.services.Hook != nil {
-		m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: "auto"})
+	trigger := info.Trigger
+	if trigger == "" {
+		trigger = "auto"
 	}
-	// Auto-compact summarizes the conversation history, dropping any
-	// system-reminder content that previously rode on user messages. Re-enqueue
-	// session-level reminders so they reattach to the next user turn and the
-	// LLM still has skills/memory/etc. context.
+	if m.services.Hook != nil {
+		m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: trigger})
+	}
+
+	// Compaction summarized away the system-reminder content that rode on the
+	// old user messages. Re-read memory from disk (a provider renders from the
+	// cached instructions, so an edited memory file would otherwise re-inject
+	// stale content), drop now-irrelevant one-time notices, and re-emit the
+	// providers so skills/memory reattach to the next user turn.
 	if m.services.Reminder != nil {
-		// Re-read memory from disk before re-emitting: a reminder provider
-		// renders from the cached instructions, so without this a memory file
-		// edited mid-session would re-inject stale content after compaction.
 		m.refreshMemoryContext(m.env.CWD, "post_compact")
-		// One-time notices (cancel notice, prior hook context) refer to
-		// the now-summarized history; the model can't act on them
-		// meaningfully against the compacted prefix.
 		m.services.Reminder.DiscardPendingNotices()
 		m.services.Reminder.RefreshSystemReminders()
+
+		// Manual /compact restores recently-accessed files as a one-time notice
+		// so they ride on the next user turn. Enqueued AFTER DiscardPendingNotices
+		// so it survives. Auto-compaction happens mid-task and skips this.
+		if trigger == "manual" && m.env.FileCache != nil {
+			if restored, _ := m.env.FileCache.RestoreRecent(); len(restored) > 0 {
+				m.services.Reminder.Enqueue(filecache.FormatRestoredFiles(restored))
+				m.conv.AddNotice(fmt.Sprintf("Restored %d recently accessed file(s) for context.", len(restored)))
+			}
+		}
 	}
 
 	scrollPart := tea.Sequence(append(scrollbackCmds, tea.Println(boundary), tea.ClearScreen)...)
 	return tea.Batch(scrollPart, m.ContinueOutbox(), kit.StatusTimer(3*time.Second, token))
 }
 
-// OnCompactResult handles manual /compact results.
-// Stops the agent so the next user message restarts it with compacted messages.
+// OnCompactResult applies a manual /compact result. It does not reset the UI
+// itself: it asks the running agent to compact in place (which records the
+// summary + boundary and emits CompactEvent), and that event drives
+// OnCompacted — the same path auto-compaction takes, with no agent rebuild.
+// Only when there is no active agent does it drive OnCompacted directly so the
+// next session start still seeds the summary.
 func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 	if msg.Error != nil {
 		m.conv.Compact.Complete(fmt.Sprintf("Compaction could not be completed: %v", msg.Error), true)
 		return tea.Batch(m.CommitMessages()...)
 	}
 	m.conv.Compact.Complete(fmt.Sprintf("Condensed %d earlier messages.", msg.OriginalCount), false)
-	scrollbackCmds := m.commitAllMessages()
-	boundaryStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	boundary := boundaryStyle.Render(fmt.Sprintf("✻ Conversation compacted — %d messages summarized (scroll up for history)", msg.OriginalCount))
 
-	m.conv.Clear()
-	m.env.ResetTokens()
-	token := m.userInput.Provider.SetStatusMessage("compacted")
-	m.StopAgentSession()
-
-	m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: core.FormatCompactSummary(msg.Summary)})
-
-	var restoredFiles []filecache.RestoredFile
-	if m.env.FileCache != nil {
-		restoredFiles, _ = m.env.FileCache.RestoreRecent()
-		if len(restoredFiles) > 0 {
-			restoredContext := filecache.FormatRestoredFiles(restoredFiles)
-			m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: restoredContext})
-			m.conv.AddNotice(fmt.Sprintf("Restored %d recently accessed file(s) for context.", len(restoredFiles)))
-		}
+	if m.services.Agent.Compact(msg.Summary) {
+		return tea.Batch(m.CommitMessages()...)
 	}
-	if m.services.Hook != nil {
-		m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: msg.Trigger})
-	}
-	// Manual /compact also drops conversation-history reminders. Re-enqueue
-	// providers so the next user turn carries fresh session-level context.
-	if m.services.Reminder != nil {
-		// Re-read memory from disk before re-emitting: a reminder provider
-		// renders from the cached instructions, so without this a memory file
-		// edited mid-session would re-inject stale content after compaction.
-		m.refreshMemoryContext(m.env.CWD, "post_compact")
-		// One-time notices (cancel notice, prior hook context) refer to
-		// the now-summarized history; the model can't act on them
-		// meaningfully against the compacted prefix.
-		m.services.Reminder.DiscardPendingNotices()
-		m.services.Reminder.RefreshSystemReminders()
-	}
-
-	scrollPart := tea.Sequence(append(scrollbackCmds, tea.Println(boundary), tea.ClearScreen)...)
-	return tea.Batch(scrollPart, tea.Batch(m.CommitMessages()...), kit.StatusTimer(3*time.Second, token))
+	return m.OnCompacted(core.CompactInfo{
+		Summary:       msg.Summary,
+		OriginalCount: msg.OriginalCount,
+		Trigger:       "manual",
+	})
 }
 
 func (m *model) OnTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd {

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/genai-io/gen-code/internal/app/conv"
 	"github.com/genai-io/gen-code/internal/app/kit"
@@ -43,20 +42,18 @@ func (m *model) BuildCompactRequest(focus, trigger string) conv.CompactRequest {
 // and tools are reused from cache (no rebuild).
 func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	scrollbackCmds := m.commitAllMessages()
-	boundaryStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	boundary := boundaryStyle.Render(fmt.Sprintf("✻ Conversation compacted — %d messages summarized (scroll up for history)", info.OriginalCount))
 
 	m.conv.Clear()
 	m.env.ResetContextDisplay()
 	token := m.userInput.Provider.SetStatusMessage("compacted")
-	// The full summary stays as the model's context (Content) and is persisted,
-	// but the transcript shows a terse one-liner instead of dumping the raw
-	// summary markdown. DisplayContent is render-only; Content is what the model
-	// and session store keep.
+	// The summary is injected as a user message — the model reads it (Content),
+	// and it persists + seeds resume — but the UI renders it as a single system
+	// notice (see RenderMessageAt: IsCompactSummary), so the transcript shows
+	// one clean line instead of the raw summary markdown or a "❭" user turn.
 	m.conv.Append(core.ChatMessage{
 		Role:           core.RoleUser,
 		Content:        core.FormatCompactSummary(info.Summary),
-		DisplayContent: fmt.Sprintf("Summary of %d earlier messages (kept as context).", info.OriginalCount),
+		DisplayContent: fmt.Sprintf("✻ Conversation compacted — %d messages summarized (scroll up for history)", info.OriginalCount),
 	})
 
 	trigger := info.Trigger
@@ -94,7 +91,7 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 		}
 	}
 
-	scrollPart := tea.Sequence(append(scrollbackCmds, tea.Println(boundary), tea.ClearScreen)...)
+	scrollPart := tea.Sequence(append(scrollbackCmds, tea.ClearScreen)...)
 	return tea.Batch(scrollPart, m.ContinueOutbox(), kit.StatusTimer(3*time.Second, token))
 }
 

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -126,7 +126,7 @@ func (m *model) ReloadPluginBackedState() error {
 	// Refresh skills/memory reminders so the LLM sees the updated skill set
 	// in the next user message instead of waiting for SessionStart/PostCompact.
 	if m.services.Reminder != nil {
-		m.services.Reminder.EnqueueAllProviders()
+		m.services.Reminder.RefreshSystemReminders()
 	}
 
 	return nil

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -126,7 +126,7 @@ func (m *model) ReloadPluginBackedState() error {
 	// Refresh skills/memory reminders so the LLM sees the updated skill set
 	// in the next user message instead of waiting for SessionStart/PostCompact.
 	if m.services.Reminder != nil {
-		m.services.Reminder.RefreshSystemReminders()
+		m.services.Reminder.RequeueSystemReminders()
 	}
 
 	return nil

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -88,7 +88,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// PostCompact. Without this nudge the LLM sees stale state until
 		// one of those fires.
 		if m.services.Reminder != nil {
-			m.services.Reminder.EnqueueAllProviders()
+			m.services.Reminder.RefreshSystemReminders()
 		}
 		return m, nil
 	case input.AgentToggleMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -88,7 +88,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// PostCompact. Without this nudge the LLM sees stale state until
 		// one of those fires.
 		if m.services.Reminder != nil {
-			m.services.Reminder.RefreshSystemReminders()
+			m.services.Reminder.RequeueSystemReminders()
 		}
 		return m, nil
 	case input.AgentToggleMsg:

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -31,6 +31,16 @@ func (m *model) handleSubmit() tea.Cmd {
 		return m.enqueueWhileStreaming(raw)
 	}
 
+	// A manual /compact computes its summary asynchronously, then applies it
+	// in place. Accepting a message in that window would race the compaction
+	// (the summary predates the new message, so an in-place replace could drop
+	// it). Hold submission until compaction finishes; the textarea keeps the
+	// text so the user just presses Enter again.
+	if m.conv.Compact.Active {
+		m.conv.AddNotice("Compaction in progress — please resubmit in a moment.")
+		return nil
+	}
+
 	log.QueueLog("handleSubmit: stream idle, normal submit %q", raw)
 	m.conv.Compact.ClearResult()
 	return m.dispatchSubmission(raw)

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -237,6 +237,11 @@ func (e Event) CompactInfo() (CompactInfo, bool) { ci, ok := e.Data.(CompactInfo
 type CompactInfo struct {
 	Summary       string
 	OriginalCount int
+	// BoundaryID is the ID of the synthetic summary message that replaces the
+	// pre-compaction chain. The session recorder writes it as the compaction
+	// boundary so transcript replay truncates history at the summary instead
+	// of resurrecting the summarized-away messages.
+	BoundaryID string
 }
 
 // InferenceContext is the PreInfer payload — what was about to be sent to the

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -242,6 +242,9 @@ type CompactInfo struct {
 	// compaction boundary so replay truncates history at the summary instead of
 	// resurrecting the summarized-away messages.
 	SummaryMessageID string
+	// Trigger is "auto" (proactive/reactive in-loop compaction) or "manual"
+	// (user /compact). Observers use it to vary post-compaction behavior.
+	Trigger string
 }
 
 // InferenceContext is the PreInfer payload — what was about to be sent to the

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -237,11 +237,11 @@ func (e Event) CompactInfo() (CompactInfo, bool) { ci, ok := e.Data.(CompactInfo
 type CompactInfo struct {
 	Summary       string
 	OriginalCount int
-	// BoundaryID is the ID of the synthetic summary message that replaces the
-	// pre-compaction chain. The session recorder writes it as the compaction
-	// boundary so transcript replay truncates history at the summary instead
-	// of resurrecting the summarized-away messages.
-	BoundaryID string
+	// SummaryMessageID is the ID of the synthetic summary message that replaces
+	// the pre-compaction chain. The session recorder writes it as the transcript
+	// compaction boundary so replay truncates history at the summary instead of
+	// resurrecting the summarized-away messages.
+	SummaryMessageID string
 }
 
 // InferenceContext is the PreInfer payload — what was about to be sent to the

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -238,35 +238,39 @@ const TruncatedResumePrompt = "Your response was truncated due to output token l
 // the chain without triggering a spurious inference on the lone summary.
 func (a *agent) waitForInput(ctx context.Context) error {
 	for {
+		// Block until a message arrives (idle state).
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case msg, ok := <-a.inbox:
-			if !ok || msg.Signal == SigStop {
-				return errStopped
+			startsTurn, err := a.ingestBatch(ctx, msg, ok)
+			if err != nil {
+				return err
 			}
-			startsTurn := a.ingest(ctx, msg)
-
-			// Drain remaining (non-blocking).
-		drain:
-			for {
-				select {
-				case msg, ok := <-a.inbox:
-					if !ok || msg.Signal == SigStop {
-						return errStopped
-					}
-					if a.ingest(ctx, msg) {
-						startsTurn = true
-					}
-				default:
-					break drain
-				}
-			}
-
 			if startsTurn {
 				return nil
 			}
-			// Only control signals arrived — stay idle.
-		case <-ctx.Done():
-			return ctx.Err()
+			// Only control signals arrived — keep waiting.
+		}
+	}
+}
+
+// ingestBatch processes the just-received message plus any others already
+// queued (non-blocking), and reports whether any of them starts a turn. A
+// closed inbox or SigStop yields errStopped.
+func (a *agent) ingestBatch(ctx context.Context, msg Message, ok bool) (startsTurn bool, err error) {
+	for {
+		if !ok || msg.Signal == SigStop {
+			return false, errStopped
+		}
+		if a.ingest(ctx, msg) {
+			startsTurn = true
+		}
+		select {
+		case msg, ok = <-a.inbox:
+			// another message was already queued — loop to process it
+		default:
+			return startsTurn, nil
 		}
 	}
 }

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -497,8 +497,16 @@ func (a *agent) compact(ctx context.Context) bool {
 		return false
 	}
 	originalCount := len(msgs)
-	a.SetMessages([]Message{UserMessage(FormatCompactSummary(summary), nil)})
-	a.emit(ctx, CompactEvent(a.id, CompactInfo{Summary: summary, OriginalCount: originalCount}))
+
+	// The summary becomes the sole message of the new chain. Give it a stable
+	// ID and record it as a normal message.appended so transcript replay can
+	// resolve the ID the next inference will reference; then emit the compaction
+	// boundary at that ID so replay truncates the summarized-away history.
+	summaryMsg := UserMessage(FormatCompactSummary(summary), nil)
+	summaryMsg.ID = NewMessageID()
+	a.SetMessages([]Message{summaryMsg})
+	a.emitAppend(summaryMsg)
+	a.emit(ctx, CompactEvent(a.id, CompactInfo{Summary: summary, OriginalCount: originalCount, BoundaryID: summaryMsg.ID}))
 	return true
 }
 

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -231,39 +231,61 @@ var errStopped = errors.New("stopped")
 // and the caller wants the model to continue in the next turn.
 const TruncatedResumePrompt = "Your response was truncated due to output token limits. Resume directly from where you left off. Do not repeat any content."
 
-// waitForInput blocks until at least one message arrives, then drains remaining.
+// waitForInput blocks until a real (turn-starting) message arrives, then drains
+// remaining. Control-only signals such as SigCompact are processed but do not
+// start a turn: if a wake-up delivered nothing but signals, we loop back to
+// blocking rather than returning, so e.g. a manual /compact while idle compacts
+// the chain without triggering a spurious inference on the lone summary.
 func (a *agent) waitForInput(ctx context.Context) error {
-	// Block until first message
-	select {
-	case msg, ok := <-a.inbox:
-		if !ok || msg.Signal == SigStop {
-			return errStopped
-		}
-		a.ingest(ctx, msg)
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	// Drain remaining (non-blocking)
 	for {
 		select {
 		case msg, ok := <-a.inbox:
 			if !ok || msg.Signal == SigStop {
 				return errStopped
 			}
-			a.ingest(ctx, msg)
-		default:
-			return nil
+			startsTurn := a.ingest(ctx, msg)
+
+			// Drain remaining (non-blocking).
+		drain:
+			for {
+				select {
+				case msg, ok := <-a.inbox:
+					if !ok || msg.Signal == SigStop {
+						return errStopped
+					}
+					if a.ingest(ctx, msg) {
+						startsTurn = true
+					}
+				default:
+					break drain
+				}
+			}
+
+			if startsTurn {
+				return nil
+			}
+			// Only control signals arrived — stay idle.
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }
 
-// ingest notifies hooks and appends a message (with text + images) to conversation.
-func (a *agent) ingest(ctx context.Context, msg Message) {
+// ingest processes one inbox message and reports whether it starts a turn
+// (i.e. a real message was appended to the conversation). SigCompact applies
+// an in-place compaction with the precomputed summary it carries; signals
+// never start a turn.
+func (a *agent) ingest(ctx context.Context, msg Message) bool {
+	if msg.Signal == SigCompact {
+		a.applyCompaction(ctx, msg.Content, len(a.snapshot()), "manual")
+		return false
+	}
 	a.emit(ctx, MessageEvent(msg))
 	if msg.Signal == "" {
 		a.append(msg)
+		return true
 	}
+	return false
 }
 
 // ThinkAct runs one full inference-action cycle until end_turn.
@@ -496,18 +518,29 @@ func (a *agent) compact(ctx context.Context) bool {
 	if err != nil || summary == "" {
 		return false
 	}
-	originalCount := len(msgs)
+	a.applyCompaction(ctx, summary, len(msgs), "auto")
+	return true
+}
 
-	// The summary becomes the sole message of the new chain. Give it a stable
-	// ID and record it as a normal message.appended so transcript replay can
-	// resolve the ID the next inference will reference; then emit the compaction
-	// boundary at that ID so replay truncates the summarized-away history.
+// applyCompaction replaces the conversation chain with a single summary
+// message in place. The summary becomes the sole message of the new chain;
+// it gets a stable ID and is recorded as a normal message.appended so
+// transcript replay can resolve the ID the next inference references, then a
+// CompactEvent is emitted carrying that ID as the boundary so replay truncates
+// the summarized-away history. Both auto-compaction (compact) and manual
+// /compact (SigCompact) funnel through here so they record identically and
+// neither rebuilds the agent.
+func (a *agent) applyCompaction(ctx context.Context, summary string, originalCount int, trigger string) {
 	summaryMsg := UserMessage(FormatCompactSummary(summary), nil)
 	summaryMsg.ID = NewMessageID()
 	a.SetMessages([]Message{summaryMsg})
 	a.emitAppend(summaryMsg)
-	a.emit(ctx, CompactEvent(a.id, CompactInfo{Summary: summary, OriginalCount: originalCount, SummaryMessageID: summaryMsg.ID}))
-	return true
+	a.emit(ctx, CompactEvent(a.id, CompactInfo{
+		Summary:          summary,
+		OriginalCount:    originalCount,
+		SummaryMessageID: summaryMsg.ID,
+		Trigger:          trigger,
+	}))
 }
 
 // isPromptTooLong checks if an error indicates the prompt exceeds the model's limit.
@@ -652,17 +685,20 @@ func (a *agent) emitFinal(event Event) {
 }
 
 // drainInbox non-blocking reads ONE pending inbox message.
-// Returns 1 if a message was consumed, 0 if none available.
-// Each message gets its own ThinkAct cycle so the TUI can pair
-// each user message with its response.
+// Returns 1 if a turn-starting message was consumed, 0 otherwise (nothing
+// pending, or a control-only signal such as SigCompact that was applied but
+// does not warrant a new ThinkAct). Each turn-starting message gets its own
+// ThinkAct cycle so the TUI can pair each user message with its response.
 func (a *agent) drainInbox(ctx context.Context) (int, error) {
 	select {
 	case msg, ok := <-a.inbox:
 		if !ok || msg.Signal == SigStop {
 			return 0, errStopped
 		}
-		a.ingest(ctx, msg)
-		return 1, nil
+		if a.ingest(ctx, msg) {
+			return 1, nil
+		}
+		return 0, nil
 	default:
 		return 0, nil
 	}

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -506,7 +506,7 @@ func (a *agent) compact(ctx context.Context) bool {
 	summaryMsg.ID = NewMessageID()
 	a.SetMessages([]Message{summaryMsg})
 	a.emitAppend(summaryMsg)
-	a.emit(ctx, CompactEvent(a.id, CompactInfo{Summary: summary, OriginalCount: originalCount, BoundaryID: summaryMsg.ID}))
+	a.emit(ctx, CompactEvent(a.id, CompactInfo{Summary: summary, OriginalCount: originalCount, SummaryMessageID: summaryMsg.ID}))
 	return true
 }
 

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -506,9 +506,20 @@ func isReadOnlyToolCall(name string) bool {
 // CompactMaxTokens is the max output tokens for compaction LLM calls.
 const CompactMaxTokens = 4096
 
+// CompactSummaryPrefix marks a user message as the post-compaction summary.
+// The UI uses it to render that message as a system notice rather than a normal
+// user turn, while the model and session store keep the full text.
+const CompactSummaryPrefix = "Previous context:\n"
+
 // FormatCompactSummary formats a compaction summary for injection as a user message.
 func FormatCompactSummary(summary string) string {
-	return "Previous context:\n" + summary
+	return CompactSummaryPrefix + summary
+}
+
+// IsCompactSummary reports whether content is a post-compaction summary message
+// (produced by FormatCompactSummary).
+func IsCompactSummary(content string) bool {
+	return strings.HasPrefix(content, CompactSummaryPrefix)
 }
 
 // compact calls CompactFunc and replaces messages with the summary.

--- a/internal/core/agent_impl_test.go
+++ b/internal/core/agent_impl_test.go
@@ -2,9 +2,83 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
+
+// Compaction must record the synthetic summary as a normal message.appended
+// (so replay can resolve the ID the next inference references) and emit a
+// CompactEvent whose BoundaryID equals that summary's ID (so replay truncates
+// the summarized-away history at the summary).
+func TestCompactRecordsSummaryAppendAndBoundary(t *testing.T) {
+	var captured []Event
+	ag := NewAgent(Config{
+		ID:     "test",
+		LLM:    newBlockingLLM(1),
+		System: NewSystem(),
+		Tools:  NewTools(),
+		CompactFunc: func(_ context.Context, _ []Message) (string, error) {
+			return "the summary", nil
+		},
+		OnEvent: func(e Event) { captured = append(captured, e) },
+	})
+	a := ag.(*agent)
+
+	// Drain the outbox so the blocking CompactEvent emit doesn't stall.
+	go func() {
+		for range ag.Outbox() {
+		}
+	}()
+
+	a.SetMessages([]Message{
+		UserMessage("hi", nil),
+		AssistantMessage("hello", "", nil),
+		UserMessage("tell me more", nil),
+	})
+
+	if !a.compact(context.Background()) {
+		t.Fatal("compact() returned false")
+	}
+
+	var summaryAppend *Message
+	var info *CompactInfo
+	for _, e := range captured {
+		switch e.Type {
+		case OnAppend:
+			if m, ok := e.Data.(Message); ok {
+				mm := m
+				summaryAppend = &mm
+			}
+		case OnCompact:
+			if ci, ok := e.CompactInfo(); ok {
+				c := ci
+				info = &c
+			}
+		}
+	}
+
+	if summaryAppend == nil {
+		t.Fatal("compact did not emit OnAppend for the summary message")
+	}
+	if summaryAppend.ID == "" {
+		t.Fatal("summary message must carry a stable ID")
+	}
+	if info == nil {
+		t.Fatal("compact did not emit OnCompact")
+	}
+	if info.BoundaryID != summaryAppend.ID {
+		t.Fatalf("boundary %q must equal summary ID %q", info.BoundaryID, summaryAppend.ID)
+	}
+
+	msgs := a.snapshot()
+	if len(msgs) != 1 || msgs[0].ID != summaryAppend.ID {
+		t.Fatalf("post-compact chain must be the single summary, got %d messages", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Content, "the summary") {
+		t.Fatalf("summary content missing from chain: %q", msgs[0].Content)
+	}
+}
 
 func TestEstimatePromptTokensUsesConversationGrowth(t *testing.T) {
 	got := estimatePromptTokens(1000, 2000, 3000)

--- a/internal/core/agent_impl_test.go
+++ b/internal/core/agent_impl_test.go
@@ -94,6 +94,63 @@ func TestEstimatePromptTokensNeverDropsBelowLastKnownPromptSize(t *testing.T) {
 	}
 }
 
+// A SigCompact applies an in-place compaction (replacing the chain with the
+// precomputed summary, recording the manual boundary) and must NOT start a
+// turn — otherwise the lone summary would trigger a spurious inference.
+func TestIngestSigCompactAppliesInPlaceWithoutStartingTurn(t *testing.T) {
+	var captured []Event
+	ag := NewAgent(Config{
+		ID:      "test",
+		LLM:     newBlockingLLM(1),
+		System:  NewSystem(),
+		Tools:   NewTools(),
+		OnEvent: func(e Event) { captured = append(captured, e) },
+	})
+	a := ag.(*agent)
+	go func() {
+		for range ag.Outbox() {
+		}
+	}()
+
+	a.SetMessages([]Message{
+		UserMessage("hi", nil),
+		AssistantMessage("hello", "", nil),
+		UserMessage("more", nil),
+	})
+
+	if a.ingest(context.Background(), Message{Signal: SigCompact, Content: "the summary"}) {
+		t.Fatal("SigCompact must not start a turn")
+	}
+
+	msgs := a.snapshot()
+	if len(msgs) != 1 || !strings.Contains(msgs[0].Content, "the summary") {
+		t.Fatalf("SigCompact should compact in place to the single summary, got %d messages", len(msgs))
+	}
+
+	var info *CompactInfo
+	for _, e := range captured {
+		if e.Type == OnCompact {
+			if ci, ok := e.CompactInfo(); ok {
+				c := ci
+				info = &c
+			}
+		}
+	}
+	if info == nil {
+		t.Fatal("SigCompact should emit a CompactEvent")
+	}
+	if info.Trigger != "manual" {
+		t.Fatalf("manual compaction trigger = %q, want manual", info.Trigger)
+	}
+	if info.SummaryMessageID == "" || info.SummaryMessageID != msgs[0].ID {
+		t.Fatalf("boundary %q must equal the summary message ID %q", info.SummaryMessageID, msgs[0].ID)
+	}
+
+	if !a.ingest(context.Background(), UserMessage("next", nil)) {
+		t.Fatal("a normal user message must start a turn")
+	}
+}
+
 // blockingLLM blocks Infer until the caller pushes a release signal. The
 // release channel is buffered so the test can enqueue signals without
 // racing the agent goroutine's read of the field.

--- a/internal/core/agent_impl_test.go
+++ b/internal/core/agent_impl_test.go
@@ -67,8 +67,8 @@ func TestCompactRecordsSummaryAppendAndBoundary(t *testing.T) {
 	if info == nil {
 		t.Fatal("compact did not emit OnCompact")
 	}
-	if info.BoundaryID != summaryAppend.ID {
-		t.Fatalf("boundary %q must equal summary ID %q", info.BoundaryID, summaryAppend.ID)
+	if info.SummaryMessageID != summaryAppend.ID {
+		t.Fatalf("SummaryMessageID %q must equal the appended summary ID %q", info.SummaryMessageID, summaryAppend.ID)
 	}
 
 	msgs := a.snapshot()

--- a/internal/core/agent_impl_test.go
+++ b/internal/core/agent_impl_test.go
@@ -9,7 +9,7 @@ import (
 
 // Compaction must record the synthetic summary as a normal message.appended
 // (so replay can resolve the ID the next inference references) and emit a
-// CompactEvent whose BoundaryID equals that summary's ID (so replay truncates
+// CompactEvent whose SummaryMessageID equals that summary's ID (so replay truncates
 // the summarized-away history at the summary).
 func TestCompactRecordsSummaryAppendAndBoundary(t *testing.T) {
 	var captured []Event

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -38,6 +38,10 @@ type Signal string
 
 const (
 	SigStop Signal = "stop"
+	// SigCompact asks the agent to compact in place using a precomputed
+	// summary carried in the message Content. Handled at a phase boundary on
+	// the agent's own goroutine, so it never races the conversation chain.
+	SigCompact Signal = "compact"
 )
 
 // Message is the canonical message type used across the codebase.

--- a/internal/inspector/replay.go
+++ b/internal/inspector/replay.go
@@ -132,7 +132,7 @@ func (b *replayBuilder) apply(rec transcript.Record) {
 		}
 	case transcript.SessionCompacted:
 		if rec.Session != nil {
-			b.boundaryID = rec.Session.BoundaryID
+			b.boundaryID = rec.Session.SummaryMessageID
 		}
 	case transcript.SystemSectionAdded:
 		if rec.System == nil {

--- a/internal/inspector/ui/assets/app.js
+++ b/internal/inspector/ui/assets/app.js
@@ -478,8 +478,7 @@ function inferenceDetailNodes(raw, replay) {
 
   if (replay.messages && replay.messages.length) {
     nodes.push(sectionHeader("Active message chain (" + replay.messages.length + ")"));
-    const lines = replay.messages.map((m) => "  " + m.role + "  " + m.id);
-    nodes.push(textBlock(lines.join("\n")));
+    nodes.push(messageChainList(replay.messages));
   }
 
   if (replay.integrity && replay.integrity.length) {
@@ -869,6 +868,55 @@ function toolsList(tools) {
     wrap.appendChild(item);
   }
   return wrap;
+}
+
+// messageChainList renders each active-chain message as a collapsible row:
+// the summary shows "role  id  — preview" and expanding it reveals the full
+// content blocks (text, tool_use, tool_result, …) via renderContentBlock.
+function messageChainList(messages) {
+  const wrap = document.createElement("div");
+  for (const m of messages) {
+    const item = document.createElement("details");
+    item.style.margin = "2px 0";
+    const summary = document.createElement("summary");
+    summary.style.cursor = "pointer";
+    summary.textContent = m.role + "  " + m.id + messagePreview(m);
+    item.appendChild(summary);
+
+    const body = document.createElement("div");
+    const blocks = m.content || [];
+    if (blocks.length) {
+      for (const b of blocks) {
+        body.appendChild(renderContentBlock(b));
+      }
+    } else {
+      const empty = document.createElement("pre");
+      empty.style.cssText = blockPreStyle();
+      empty.textContent = "(no content)";
+      body.appendChild(empty);
+    }
+    item.appendChild(body);
+    wrap.appendChild(item);
+  }
+  return wrap;
+}
+
+// messagePreview extracts a short one-line hint for the collapsed summary so a
+// row is identifiable without expanding it.
+function messagePreview(m) {
+  const blocks = m.content || [];
+  for (const b of blocks) {
+    if (b && b.type === "text" && b.text) {
+      const oneLine = b.text.replace(/\s+/g, " ").trim();
+      if (oneLine) return "  — " + (oneLine.length > 60 ? oneLine.slice(0, 60) + "…" : oneLine);
+    }
+  }
+  for (const b of blocks) {
+    if (b && b.type === "tool_use") return "  — " + (b.name || "tool_use");
+    if (b && b.type === "tool_result") return "  — tool_result";
+    if (b && b.type === "image") return "  — image";
+  }
+  return "";
 }
 
 // renderToolSchema produces a structured DOM for one tool schema:

--- a/internal/inspector/ui/assets/app.js
+++ b/internal/inspector/ui/assets/app.js
@@ -284,7 +284,7 @@ function ingestForChain(rec) {
     return;
   }
   if (rec.type === "session.compacted") {
-    state.compactBoundary = (rec.session && rec.session.boundaryId) || "";
+    state.compactBoundary = (rec.session && rec.session.summaryMessageId) || "";
     state.activeChain = computeActiveChain(state.messageParents, state.compactBoundary);
     state.activeLeaf = lastChainLeaf(state.activeChain);
     rehighlightMessageRows();

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -61,7 +61,7 @@ func (p providerFunc) Render() string { return p.render() }
 //   - providers: long-lived sources that re-emit on SessionStart and
 //     PostCompact (e.g. skills, memory).
 //   - pending: reminders queued for the next user message; each entry tracks
-//     which provider (if any) emitted it so EnqueueAllProviders can replace
+//     which provider (if any) emitted it so RefreshSystemReminders can replace
 //     stale provider entries instead of duplicating them. Entries with no
 //     provider are one-time notices (see Enqueue).
 //
@@ -122,7 +122,7 @@ func (s *Service) Unregister(id string) {
 // <system-reminder> wrapper; this method adds it.
 //
 // Empty bodies are dropped silently. Notices persist independently of
-// EnqueueAllProviders — the latter only touches provider-emitted entries.
+// RefreshSystemReminders — the latter only touches provider-emitted entries.
 func (s *Service) Enqueue(body string) {
 	body = strings.TrimSpace(body)
 	if body == "" {
@@ -174,19 +174,23 @@ func (s *Service) EnqueueOnce(body string) {
 	s.pending = append(s.pending, pendingEntry{wrapped: wrapped})
 }
 
-// EnqueueAllProviders renders every registered provider and queues the
-// non-empty bodies. Idempotent across repeated calls: any prior pending
-// entry from the same provider is dropped before re-emitting, so SessionStart
-// → PostCompact → /skills toggle in close succession produces a single
-// emission per provider rather than accumulating duplicates. One-time notices
-// queued via Enqueue are preserved.
+// RefreshSystemReminders re-renders the provider-sourced reminders only: it
+// renders every registered provider and queues the non-empty bodies. Despite
+// the name it does NOT touch one-time notices (Enqueue) — those are also
+// <system-reminder> blocks but are preserved here, since they describe a
+// past event rather than live session state.
+//
+// Idempotent across repeated calls: any prior pending entry from the same
+// provider is dropped before re-emitting, so SessionStart → PostCompact →
+// /skills toggle in close succession produces a single emission per provider
+// rather than accumulating duplicates.
 //
 // Each provider's body is wrapped with the provider ID as the `source`
 // attribute on the system-reminder tag (e.g. `<system-reminder
 // source="skills-directory">…`) so trace/audit can attribute who injected
 // what without parsing the body itself. Models treat unknown attributes
 // transparently — the model-visible meaning is unchanged.
-func (s *Service) EnqueueAllProviders() {
+func (s *Service) RefreshSystemReminders() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -61,7 +61,7 @@ func (p providerFunc) Render() string { return p.render() }
 //   - providers: long-lived sources that re-emit on SessionStart and
 //     PostCompact (e.g. skills, memory).
 //   - pending: reminders queued for the next user message; each entry tracks
-//     which provider (if any) emitted it so RefreshSystemReminders can replace
+//     which provider (if any) emitted it so RequeueSystemReminders can replace
 //     stale provider entries instead of duplicating them. Entries with no
 //     provider are one-time notices (see Enqueue).
 //
@@ -122,7 +122,7 @@ func (s *Service) Unregister(id string) {
 // <system-reminder> wrapper; this method adds it.
 //
 // Empty bodies are dropped silently. Notices persist independently of
-// RefreshSystemReminders — the latter only touches provider-emitted entries.
+// RequeueSystemReminders — the latter only touches provider-emitted entries.
 func (s *Service) Enqueue(body string) {
 	body = strings.TrimSpace(body)
 	if body == "" {
@@ -174,7 +174,7 @@ func (s *Service) EnqueueOnce(body string) {
 	s.pending = append(s.pending, pendingEntry{wrapped: wrapped})
 }
 
-// RefreshSystemReminders re-renders the provider-sourced reminders only: it
+// RequeueSystemReminders re-renders the provider-sourced reminders only: it
 // renders every registered provider and queues the non-empty bodies. Despite
 // the name it does NOT touch one-time notices (Enqueue) — those are also
 // <system-reminder> blocks but are preserved here, since they describe a
@@ -190,7 +190,7 @@ func (s *Service) EnqueueOnce(body string) {
 // source="skills-directory">…`) so trace/audit can attribute who injected
 // what without parsing the body itself. Models treat unknown attributes
 // transparently — the model-visible meaning is unchanged.
-func (s *Service) RefreshSystemReminders() {
+func (s *Service) RequeueSystemReminders() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -76,7 +76,7 @@ func TestServiceProviderRegistration(t *testing.T) {
 		return "- foo: do foo"
 	}))
 
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	if rendered != 1 {
 		t.Fatalf("provider Body should be called once, got %d", rendered)
 	}
@@ -92,7 +92,7 @@ func TestServiceProviderReplaceByID(t *testing.T) {
 	s.Register(NewProvider("skills", func() string { return "old" }))
 	s.Register(NewProvider("skills", func() string { return "new" }))
 
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	out := s.Drain()
 	if len(out) != 1 {
 		t.Fatalf("registering same ID twice should produce one reminder, got %d: %v", len(out), out)
@@ -107,7 +107,7 @@ func TestServiceProviderEmptyOutput(t *testing.T) {
 	s.Register(NewProvider("skills", func() string { return "" }))
 	s.Register(NewProvider("memory", func() string { return "stuff" }))
 
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	out := s.Drain()
 	if len(out) != 1 {
 		t.Fatalf("empty provider output should be skipped, got %d reminders: %v", len(out), out)
@@ -123,7 +123,7 @@ func TestServiceUnregister(t *testing.T) {
 	s.Register(NewProvider("b", func() string { return "beta" }))
 
 	s.Unregister("a")
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 
 	out := s.Drain()
 	if len(out) != 1 || !strings.Contains(out[0], "beta") {
@@ -172,7 +172,7 @@ func TestServiceFullSessionLifecycle(t *testing.T) {
 	s.Register(NewProvider("memory-user", func() string { return memoryBody }))
 
 	// SessionStart: harness enqueues all providers.
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 
 	// User submits "hello"; sendToAgent drains and attaches.
 	firstUserMsg := AttachToContent("hello", s.Drain())
@@ -196,7 +196,7 @@ func TestServiceFullSessionLifecycle(t *testing.T) {
 	}
 
 	// PostCompact: harness re-enqueues providers so the LLM can recover.
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	postCompactMsg := AttachToContent("after compact", s.Drain())
 	if !strings.Contains(postCompactMsg, skillsBody) {
 		t.Error("post-compact message should re-attach skills reminder")
@@ -214,24 +214,24 @@ func TestServiceProviderReflectsLatestState(t *testing.T) {
 	state := "v1"
 	s.Register(NewProvider("skills", func() string { return state }))
 
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	if got := s.Drain(); !strings.Contains(got[0], "v1") {
 		t.Fatalf("first emission should reflect v1, got %v", got)
 	}
 
 	state = "v2"
 
-	s.EnqueueAllProviders()
+	s.RefreshSystemReminders()
 	if got := s.Drain(); !strings.Contains(got[0], "v2") {
 		t.Errorf("second emission should reflect mutated state v2, got %v", got)
 	}
 }
 
-// TestServiceEnqueueAllProvidersIsIdempotent guards against the slow-growing
+// TestServiceRefreshSystemRemindersIsIdempotent guards against the slow-growing
 // duplicate-emission leak: SessionStart → PostCompact → /skills toggle in
 // close succession should produce one emission per provider, not three.
 // One-time notices (Enqueue) must survive a re-emission unmolested.
-func TestServiceEnqueueAllProvidersIsIdempotent(t *testing.T) {
+func TestServiceRefreshSystemRemindersIsIdempotent(t *testing.T) {
 	s := NewService()
 	s.Register(NewProvider("skills-directory", func() string { return "skills body" }))
 	s.Register(NewProvider("memory-user", func() string { return "user mem" }))
@@ -239,9 +239,9 @@ func TestServiceEnqueueAllProvidersIsIdempotent(t *testing.T) {
 	// Hook-context notice queued before the first emission.
 	s.Enqueue("hook context A")
 
-	s.EnqueueAllProviders() // first SessionStart
-	s.EnqueueAllProviders() // /skills toggle
-	s.EnqueueAllProviders() // PostCompact
+	s.RefreshSystemReminders() // first SessionStart
+	s.RefreshSystemReminders() // /skills toggle
+	s.RefreshSystemReminders() // PostCompact
 
 	out := s.Drain()
 	// 1 notice + 2 provider entries (one per provider) = 3 total.

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -76,7 +76,7 @@ func TestServiceProviderRegistration(t *testing.T) {
 		return "- foo: do foo"
 	}))
 
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	if rendered != 1 {
 		t.Fatalf("provider Body should be called once, got %d", rendered)
 	}
@@ -92,7 +92,7 @@ func TestServiceProviderReplaceByID(t *testing.T) {
 	s.Register(NewProvider("skills", func() string { return "old" }))
 	s.Register(NewProvider("skills", func() string { return "new" }))
 
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	out := s.Drain()
 	if len(out) != 1 {
 		t.Fatalf("registering same ID twice should produce one reminder, got %d: %v", len(out), out)
@@ -107,7 +107,7 @@ func TestServiceProviderEmptyOutput(t *testing.T) {
 	s.Register(NewProvider("skills", func() string { return "" }))
 	s.Register(NewProvider("memory", func() string { return "stuff" }))
 
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	out := s.Drain()
 	if len(out) != 1 {
 		t.Fatalf("empty provider output should be skipped, got %d reminders: %v", len(out), out)
@@ -123,7 +123,7 @@ func TestServiceUnregister(t *testing.T) {
 	s.Register(NewProvider("b", func() string { return "beta" }))
 
 	s.Unregister("a")
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 
 	out := s.Drain()
 	if len(out) != 1 || !strings.Contains(out[0], "beta") {
@@ -172,7 +172,7 @@ func TestServiceFullSessionLifecycle(t *testing.T) {
 	s.Register(NewProvider("memory-user", func() string { return memoryBody }))
 
 	// SessionStart: harness enqueues all providers.
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 
 	// User submits "hello"; sendToAgent drains and attaches.
 	firstUserMsg := AttachToContent("hello", s.Drain())
@@ -196,7 +196,7 @@ func TestServiceFullSessionLifecycle(t *testing.T) {
 	}
 
 	// PostCompact: harness re-enqueues providers so the LLM can recover.
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	postCompactMsg := AttachToContent("after compact", s.Drain())
 	if !strings.Contains(postCompactMsg, skillsBody) {
 		t.Error("post-compact message should re-attach skills reminder")
@@ -214,24 +214,24 @@ func TestServiceProviderReflectsLatestState(t *testing.T) {
 	state := "v1"
 	s.Register(NewProvider("skills", func() string { return state }))
 
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	if got := s.Drain(); !strings.Contains(got[0], "v1") {
 		t.Fatalf("first emission should reflect v1, got %v", got)
 	}
 
 	state = "v2"
 
-	s.RefreshSystemReminders()
+	s.RequeueSystemReminders()
 	if got := s.Drain(); !strings.Contains(got[0], "v2") {
 		t.Errorf("second emission should reflect mutated state v2, got %v", got)
 	}
 }
 
-// TestServiceRefreshSystemRemindersIsIdempotent guards against the slow-growing
+// TestServiceRequeueSystemRemindersIsIdempotent guards against the slow-growing
 // duplicate-emission leak: SessionStart → PostCompact → /skills toggle in
 // close succession should produce one emission per provider, not three.
 // One-time notices (Enqueue) must survive a re-emission unmolested.
-func TestServiceRefreshSystemRemindersIsIdempotent(t *testing.T) {
+func TestServiceRequeueSystemRemindersIsIdempotent(t *testing.T) {
 	s := NewService()
 	s.Register(NewProvider("skills-directory", func() string { return "skills body" }))
 	s.Register(NewProvider("memory-user", func() string { return "user mem" }))
@@ -239,9 +239,9 @@ func TestServiceRefreshSystemRemindersIsIdempotent(t *testing.T) {
 	// Hook-context notice queued before the first emission.
 	s.Enqueue("hook context A")
 
-	s.RefreshSystemReminders() // first SessionStart
-	s.RefreshSystemReminders() // /skills toggle
-	s.RefreshSystemReminders() // PostCompact
+	s.RequeueSystemReminders() // first SessionStart
+	s.RequeueSystemReminders() // /skills toggle
+	s.RequeueSystemReminders() // PostCompact
 
 	out := s.Drain()
 	// 1 notice + 2 provider entries (one per provider) = 3 total.

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -152,6 +152,27 @@ func (r *Recorder) OnAgentEvent(ev core.Event) {
 		r.onToolsChange(ev)
 	case core.OnAppend:
 		r.onAppend(ev)
+	case core.OnCompact:
+		r.onCompact(ev)
+	}
+}
+
+// onCompact persists the compaction boundary. The summary message itself is
+// recorded via the preceding message.appended (compaction emits OnAppend for
+// it first); this record marks that summary's ID as the point where replay
+// stops walking parents, so the summarized-away history is not resurrected.
+func (r *Recorder) onCompact(ev core.Event) {
+	info, ok := ev.CompactInfo()
+	if !ok || info.BoundaryID == "" {
+		return
+	}
+	err := r.fs.Compact(context.Background(), transcript.CompactCommand{
+		SessionID:  r.sessionID,
+		Time:       time.Now(),
+		BoundaryID: info.BoundaryID,
+	})
+	if err != nil {
+		log.Logger().Warn("recorder: compact boundary failed", zap.Error(err))
 	}
 }
 

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -166,11 +166,10 @@ func (r *Recorder) onCompact(ev core.Event) {
 	if !ok || info.SummaryMessageID == "" {
 		return
 	}
-	// The summary message's ID becomes the transcript compaction boundary.
 	err := r.fs.Compact(context.Background(), transcript.CompactCommand{
-		SessionID:  r.sessionID,
-		Time:       time.Now(),
-		BoundaryID: info.SummaryMessageID,
+		SessionID:        r.sessionID,
+		Time:             time.Now(),
+		SummaryMessageID: info.SummaryMessageID,
 	})
 	if err != nil {
 		log.Logger().Warn("recorder: compact boundary failed", zap.Error(err))

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -163,13 +163,14 @@ func (r *Recorder) OnAgentEvent(ev core.Event) {
 // stops walking parents, so the summarized-away history is not resurrected.
 func (r *Recorder) onCompact(ev core.Event) {
 	info, ok := ev.CompactInfo()
-	if !ok || info.BoundaryID == "" {
+	if !ok || info.SummaryMessageID == "" {
 		return
 	}
+	// The summary message's ID becomes the transcript compaction boundary.
 	err := r.fs.Compact(context.Background(), transcript.CompactCommand{
 		SessionID:  r.sessionID,
 		Time:       time.Now(),
-		BoundaryID: info.BoundaryID,
+		BoundaryID: info.SummaryMessageID,
 	})
 	if err != nil {
 		log.Logger().Warn("recorder: compact boundary failed", zap.Error(err))

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -207,6 +207,50 @@ func TestRecorderWritesToolsChangeEvents(t *testing.T) {
 	}
 }
 
+// Compaction must persist the summary as a message.appended and a
+// session.compacted boundary whose BoundaryID is that summary's ID, so replay
+// reconstructs the compacted chain instead of the summarized-away history.
+func TestRecorderWritesCompactionBoundary(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := transcript.NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := fs.Start(context.Background(), transcript.StartCommand{
+		SessionID: "sess-c", Cwd: "/tmp", Provider: "anthropic", Model: "claude-x", Time: time.Now(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	rec := NewRecorder(RecorderOptions{
+		FileStore: fs, SessionID: "sess-c", AgentID: "main",
+		Provider: "anthropic", Model: "claude-x", MaxTokens: 4096,
+	})
+
+	// A pre-compaction message, then the summary append + compaction boundary.
+	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Data: core.Message{ID: "m1", Role: core.RoleUser, Content: "hi"}})
+	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Data: core.Message{ID: "sum-1", Role: core.RoleUser, Content: "Previous context:\nsummary"}})
+	rec.OnAgentEvent(core.Event{Type: core.OnCompact, Data: core.CompactInfo{Summary: "summary", OriginalCount: 5, BoundaryID: "sum-1"}})
+
+	records := readAllRecords(t, dir, "sess-c")
+	var summaryAppended bool
+	var boundary string
+	for _, r := range records {
+		if r.Type == transcript.MessageAppended && r.Message != nil && r.Message.MessageID == "sum-1" {
+			summaryAppended = true
+		}
+		if r.Type == transcript.SessionCompacted && r.Session != nil {
+			boundary = r.Session.BoundaryID
+		}
+	}
+	if !summaryAppended {
+		t.Fatal("summary message.appended was not recorded")
+	}
+	if boundary != "sum-1" {
+		t.Fatalf("compaction boundary = %q, want sum-1", boundary)
+	}
+}
+
 // A nil-safe recorder (no FileStore) must accept events without panicking.
 func TestRecorderNilSafe(t *testing.T) {
 	var rec *Recorder

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -208,7 +208,7 @@ func TestRecorderWritesToolsChangeEvents(t *testing.T) {
 }
 
 // Compaction must persist the summary as a message.appended and a
-// session.compacted boundary whose BoundaryID is that summary's ID, so replay
+// session.compacted record whose SummaryMessageID is that summary's ID, so replay
 // reconstructs the compacted chain instead of the summarized-away history.
 func TestRecorderWritesCompactionBoundary(t *testing.T) {
 	dir := t.TempDir()
@@ -240,7 +240,7 @@ func TestRecorderWritesCompactionBoundary(t *testing.T) {
 			summaryAppended = true
 		}
 		if r.Type == transcript.SessionCompacted && r.Session != nil {
-			boundary = r.Session.BoundaryID
+			boundary = r.Session.SummaryMessageID
 		}
 	}
 	if !summaryAppended {

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -230,7 +230,7 @@ func TestRecorderWritesCompactionBoundary(t *testing.T) {
 	// A pre-compaction message, then the summary append + compaction boundary.
 	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Data: core.Message{ID: "m1", Role: core.RoleUser, Content: "hi"}})
 	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Data: core.Message{ID: "sum-1", Role: core.RoleUser, Content: "Previous context:\nsummary"}})
-	rec.OnAgentEvent(core.Event{Type: core.OnCompact, Data: core.CompactInfo{Summary: "summary", OriginalCount: 5, BoundaryID: "sum-1"}})
+	rec.OnAgentEvent(core.Event{Type: core.OnCompact, Data: core.CompactInfo{Summary: "summary", OriginalCount: 5, SummaryMessageID: "sum-1"}})
 
 	records := readAllRecords(t, dir, "sess-c")
 	var summaryAppended bool

--- a/internal/session/transcript/events_shape_test.go
+++ b/internal/session/transcript/events_shape_test.go
@@ -122,7 +122,7 @@ func TestEventsShape(t *testing.T) {
 
 	// compaction
 	mustOK(t, "Compact", store.Compact(ctx, CompactCommand{
-		SessionID: sid, Time: at(13), BoundaryID: "m2",
+		SessionID: sid, Time: at(13), SummaryMessageID: "m2",
 	}))
 
 	// Read raw lines.
@@ -258,14 +258,14 @@ func TestEventsShape(t *testing.T) {
 		}
 	}
 
-	// 6. session.compacted carries only the boundaryId, no constants.
+	// 6. session.compacted carries only the summaryMessageId, no constants.
 	cs := byType["session.compacted"]
 	if len(cs) != 1 {
 		t.Fatalf("session.compacted count = %d, want 1", len(cs))
 	}
 	csess := cs[0]["session"].(map[string]any)
-	if csess["boundaryId"] != "m2" {
-		t.Errorf("compact boundary = %v, want m2", csess["boundaryId"])
+	if csess["summaryMessageId"] != "m2" {
+		t.Errorf("compact summaryMessageId = %v, want m2", csess["summaryMessageId"])
 	}
 	for _, forbidden := range []string{"provider", "model", "maxTokens", "agentId"} {
 		if _, has := csess[forbidden]; has {

--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -387,7 +387,7 @@ func (s *FileStore) Compact(ctx context.Context, cmd CompactCommand) error {
 		SessionID: cmd.SessionID,
 		Time:      cmd.Time,
 		Type:      SessionCompacted,
-		Session:   &SessionRecord{BoundaryID: cmd.BoundaryID},
+		Session:   &SessionRecord{SummaryMessageID: cmd.SummaryMessageID},
 	}
 	if err := s.appendRecord(s.transcriptPath(cmd.SessionID), rec, true); err != nil {
 		return err

--- a/internal/session/transcript/fs_store_impl_test.go
+++ b/internal/session/transcript/fs_store_impl_test.go
@@ -118,9 +118,9 @@ func TestFileStoreCompactAndFork(t *testing.T) {
 		t.Fatalf("AppendMessage(m2): %v", err)
 	}
 	if err := store.Compact(context.Background(), CompactCommand{
-		SessionID:  "tx-1",
-		Time:       now.Add(3 * time.Second),
-		BoundaryID: "m1",
+		SessionID:        "tx-1",
+		Time:             now.Add(3 * time.Second),
+		SummaryMessageID: "m1",
 	}); err != nil {
 		t.Fatalf("Compact(): %v", err)
 	}
@@ -331,9 +331,9 @@ func TestFileStoreWritesExpectedEventShapes(t *testing.T) {
 		t.Fatalf("PatchState(): %v", err)
 	}
 	if err := store.Compact(context.Background(), CompactCommand{
-		SessionID:  "tx-shape",
-		Time:       now.Add(10 * time.Second),
-		BoundaryID: "m2",
+		SessionID:        "tx-shape",
+		Time:             now.Add(10 * time.Second),
+		SummaryMessageID: "m2",
 	}); err != nil {
 		t.Fatalf("Compact(): %v", err)
 	}
@@ -440,7 +440,7 @@ func TestFileStoreWritesExpectedEventShapes(t *testing.T) {
 
 	compact := records[10]
 	session = objectAt(t, compact, "session")
-	assertString(t, session, "boundaryId", "m2")
+	assertString(t, session, "summaryMessageId", "m2")
 	assertNoTopLevel(t, session, "provider", "model", "maxTokens", "agentId")
 }
 

--- a/internal/session/transcript/projector.go
+++ b/internal/session/transcript/projector.go
@@ -50,7 +50,7 @@ func Project(records []Record) (*Transcript, error) {
 			}
 		case SessionCompacted:
 			if r.Session != nil {
-				compactBoundary = r.Session.BoundaryID
+				compactBoundary = r.Session.SummaryMessageID
 			}
 			if t.ID == "" {
 				t.ID = r.SessionID

--- a/internal/session/transcript/projector_test.go
+++ b/internal/session/transcript/projector_test.go
@@ -110,7 +110,7 @@ func TestProjectCompactBoundaryTruncatesActiveChain(t *testing.T) {
 		{SessionID: "tx-1", Time: now.Add(time.Second), Type: MessageAppended, Message: &MessageRecord{MessageID: "m1", Role: "user"}},
 		{SessionID: "tx-1", Time: now.Add(2 * time.Second), Type: MessageAppended, ParentID: "m1", Message: &MessageRecord{MessageID: "m2", Role: "assistant"}},
 		{SessionID: "tx-1", Time: now.Add(3 * time.Second), Type: MessageAppended, ParentID: "m2", Message: &MessageRecord{MessageID: "m3", Role: "user"}},
-		{SessionID: "tx-1", Time: now.Add(4 * time.Second), Type: SessionCompacted, Session: &SessionRecord{BoundaryID: "m2"}},
+		{SessionID: "tx-1", Time: now.Add(4 * time.Second), Type: SessionCompacted, Session: &SessionRecord{SummaryMessageID: "m2"}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)

--- a/internal/session/transcript/records.go
+++ b/internal/session/transcript/records.go
@@ -109,12 +109,15 @@ type PatchOp struct {
 // (provider, model, maxTokens, agentId). Every following record inherits
 // them — they are not restamped per record.
 type SessionRecord struct {
-	Provider   string `json:"provider,omitempty"`
-	Model      string `json:"model,omitempty"`
-	MaxTokens  int    `json:"maxTokens,omitempty"`
-	AgentID    string `json:"agentId,omitempty"`
-	ParentID   string `json:"parentId,omitempty"`
-	BoundaryID string `json:"boundaryId,omitempty"`
+	Provider  string `json:"provider,omitempty"`
+	Model     string `json:"model,omitempty"`
+	MaxTokens int    `json:"maxTokens,omitempty"`
+	AgentID   string `json:"agentId,omitempty"`
+	ParentID  string `json:"parentId,omitempty"`
+	// SummaryMessageID, on a session.compacted record, is the ID of the summary
+	// message that replaced the pre-compaction chain. Replay uses it as the
+	// boundary to stop walking parents at.
+	SummaryMessageID string `json:"summaryMessageId,omitempty"`
 }
 
 // InferenceRecord carries the payload for inference.requested /

--- a/internal/session/transcript/store.go
+++ b/internal/session/transcript/store.go
@@ -41,9 +41,9 @@ type PatchStateCommand struct {
 }
 
 type CompactCommand struct {
-	SessionID  string
-	Time       time.Time
-	BoundaryID string
+	SessionID        string
+	Time             time.Time
+	SummaryMessageID string
 }
 
 type ForkCommand struct {


### PR DESCRIPTION
## Summary

Fixes compaction and unifies the auto and manual `/compact` paths.

- **Transcript fix.** Compaction never recorded the summary or a boundary, so replay rebuilt the old chain (`messageIds — N expected vs M replayed`). The agent now records the summary as `message.appended` + a `session.compacted` boundary; replay truncates there.

- **Manual `/compact` compacts in place.** It used to stop and rebuild the agent — re-emitting the whole system prompt + tools and busting the prompt cache. Now both paths compact the running agent via a shared `applyCompaction` (records summary + boundary, emits `CompactEvent`) driven by one handler. A `SigCompact` signal carries the summary; idle compaction no longer triggers a spurious inference, and submission is held while compacting so a typed message can't race the replace.

- **System prompt & reminders.** The system prompt is reused from cache (not rebuilt). On PostCompact, memory is re-read from disk before reminders re-emit, so an edited `GEN.md`/`CLAUDE.md` re-injects its latest content.

- **Naming / docs.** `BoundaryID` → `SummaryMessageID`; `EnqueueAllProviders` → `RequeueSystemReminders`. New `concepts/compaction.md` documents the mechanism with diagrams.

## Test plan

- [x] `go build ./...` and `go test ./...` green
- [x] records summary append + boundary; SigCompact compacts in place without starting a turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)