### PR TITLE
docs: L1 background-review design (per-turn self-learning)

### DIFF
--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -50,33 +50,81 @@ on its own and matches the production-proven hermes shape.
 | Memory | user turns since last review | every 10 turns | User-modeling drifts on conversational cadence, not work intensity. |
 | Skills | tool iterations within the turn | when this turn ≥ 10 tool iters | Skill capture should fire when the agent actually *did* work; tool-iter count is the cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
 
-Both config-overridable; `0` disables that arm. Combined when both fire on the
-same turn.
+- **Memory** fires on a **turn cadence** (default every 10 user turns) — it is
+  not tied to whether work happened. When it fires, the reviewer reads the
+  **recent conversation history** (the turn snapshot) and updates durable facts.
+- **Skills** fire on **work done this turn** (tool-iters ≥ K), not on a turn
+  cadence and not on "a skill was invoked". Whether a skill was invoked affects
+  *which* skill to update (see §3b), not *whether* to review — otherwise new
+  skills for tasks that had no skill yet would never be learned.
 
-The trigger is a **pure event consumer** subscribed to `core.Agent.Outbox()`,
-reading `TurnEvent` (which already carries `Result.Turns`, `Result.ToolUses`,
-`Result.StopReason`). No `internal/core` changes; counters live in the consumer
-and hydrate from history on session resume.
+Both config-overridable; `0` disables that arm. Combined when both fire on the
+same turn. The trigger is a **pure event consumer** subscribed to
+`core.Agent.Outbox()`, reading `TurnEvent` (`Result.Turns`/`ToolUses`/
+`StopReason`). No `internal/core` changes; counters live in the consumer and
+hydrate from history on session resume.
 
 ---
 
 ## 3. What L1 writes — directly
 
-- **Memory**: durable user/project facts → `.gen/memory/MEMORY.md` / `USER.md`.
-- **Skill**: how to do a class of task → `.gen/skills/agent-created/<name>/`
-  (create or patch an agent-created skill; never touch user-curated/pinned ones,
-  so the future L2 curator can manage them without surprises).
+The write tools (`memory_write` + `skill_manage`) belong **only to the L1
+reviewer fork** in this phase. The main agent never writes memory/skills — it
+only reads/invokes them (existing skills-directory injection + skill-view).
+Because only the reviewer writes, provenance is simply **by location**: every
+L1 write lands under agent-created paths, kept apart from user-authored skills,
+so the future L2 curator can manage them without touching the user's. (Letting
+the main agent write — Hermes-style provenance flags — can come later.)
 
-Three review prompts, picked by which triggers fired:
+### 3a. Memory flow
 
-- **memory-only**: user persona, preferences, expectations. "Nothing to save."
-  is a valid output.
-- **skill-only**: be active (most working sessions produce ≥1 update); preference
-  order = update a loaded skill → update an umbrella → add a support file →
-  create a new umbrella. Embeds an anti-pattern list (no environment-dependent
-  failures, no negative tool claims, no transient errors, no one-off task
-  narratives). "Nothing to save." is valid but not the default.
-- **combined**: both, when both triggers fire on the same turn.
+- Trigger: every N user turns (§2).
+- The reviewer reads the recent conversation history and extracts **durable
+  user/project facts** (who the user is, preferences, project conventions,
+  build/debug insights).
+- Writes via `memory_write` to `.gen/memory/MEMORY.md` (+ `USER.md` for the user
+  profile). Append/replace existing entries; "Nothing to save." is valid.
+- This is the corpus the existing reminder injection already loads — so a write
+  here shows up in the next session's `<memory>` reminder.
+
+### 3b. Skill flow — creation / update
+
+Trigger: this turn did real work (tool-iters ≥ K). The reviewer runs the skill
+review prompt against the turn snapshot and follows a **preference order**
+(broadest reuse first; create new only as a last resort):
+
+1. **Patch a skill that was loaded/used this turn.** If the agent consulted a
+   skill (a skill-view in the turn history) and it was wrong/outdated →
+   `skill_manage(patch, name, old, new)` to fix it. *(This is where "a skill was
+   invoked" matters — it picks the target.)*
+2. **Patch an existing umbrella.** List + view existing broad, class-level
+   skills; if one covers this learning, patch it (add a pitfall/step, broaden a
+   trigger).
+3. **Add a support file** to an umbrella: `skill_manage(write_file, name,
+   "references|templates|scripts/…", content)`, plus a pointer line in SKILL.md.
+4. **Create a new class-level umbrella** — only when nothing above fits.
+   `skill_manage(create, name, content)`. The name must be **class-level**
+   (e.g. `go-table-tests`), never session-specific (no PR numbers, error
+   strings, `fix-x-today`).
+
+"Umbrella" is a **convention, not a data-model marker** — the preference order
+above is what keeps the collection broad instead of sprouting one narrow skill
+per session. New skills are written to `.gen/skills/agent-created/<name>/`
+(a `SKILL.md` with frontmatter `name`/`description` + optional
+`references/`/`templates/`/`scripts/`), isolated from user-authored skills.
+
+`skill_manage` actions: `create`, `edit` (full rewrite — rare), `patch`,
+`write_file`, `remove_file`, `delete`. **`patch`** is targeted find-and-replace
+with a fuzzy-match chain (exact → line-trimmed → whitespace/indent/escape/
+unicode-normalized → block-anchor → context-similarity) and an **escape-drift
+guard** (rejects matches where transport-added `\'`/`\"` backslashes don't exist
+in the file, prompting a clean re-read). Requires a unique match unless
+`replace_all`.
+
+Three review prompts, picked by which triggers fired (memory-only / skill-only /
+combined). The skill prompt is **active** (most working sessions produce ≥1
+update) and embeds an anti-pattern list (no environment-dependent failures, no
+negative tool claims, no transient errors, no one-off task narratives).
 
 ---
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -97,9 +97,29 @@ user-authored files (`GEN.md`/`CLAUDE.md`/rules); it does **not** read this
 store today. A small change must add `~/.gen/projects/<project>/memory/MEMORY.md`
 as a **new, distinct memory source** (its own level, e.g. "auto"), kept separate
 from the user-authored `GEN.md`/`CLAUDE.md` — so agent-written memory and
-user-written instructions never mix. Load the `MEMORY.md` index (cap like Claude
-Code: first ~200 lines / 25KB); topic files load on demand. Without this read
-side, L1 writes would never be injected.
+user-written instructions never mix. Without this read side, L1 writes would
+never be injected.
+
+**Load timing — reuses the existing injection lifecycle:**
+
+- **Session start:** read the `MEMORY.md` index → cache → inject as a
+  `<system-reminder source="memory-auto">` block on the first user message.
+  Cap the index like Claude Code (first ~200 lines / 25KB); topic files are read
+  on demand by the agent's file tools, not injected.
+- **PostCompact:** re-read from disk (`refreshMemoryContext`) + re-emit
+  (`RequeueSystemReminders`) — the same path already built for `GEN.md`/`CLAUDE.md`
+  memory — so the latest memory survives compaction.
+- **cwd change:** re-read, because `<project>` (and thus the store) changes when
+  the working directory moves to a different repo.
+
+**Update timing:** the L1 fork writes post-turn, on the memory cadence (every N
+user turns, §2), gated on `StopEndTurn`.
+
+**Write→visibility lag (by design):** L1 writes out-of-band, while the running
+session's memory was injected at a load point. So a fresh write is **not**
+live-patched into the in-flight context — it becomes visible at the next load
+point: the next **PostCompact** (which re-reads from disk) or the next **session
+start**. Acceptable, since memory mainly serves future turns/sessions.
 
 ### 3b. Skill flow — creation / update
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -27,7 +27,8 @@ reviews after a turn and writes).
 | When | After a turn | During the session, on model judgment | After a turn |
 | Writes directly? | **Yes** (fork has memory + skill tools) | Yes (main agent's own tool calls) | **Yes** |
 | Trigger | turns (memory) + tool-iters (skill) | model judgment + explicit "remember this" | same two signals |
-| Storage | `~/.hermes/MEMORY.md` + `USER.md`, `~/.hermes/skills/<name>/` | `MEMORY.md` index (first 200 lines/25KB loaded) + topic files | `.gen/memory/` + `.gen/skills/agent-created/` |
+| Memory path | `~/.hermes/MEMORY.md` + `USER.md` — **global** (`$HERMES_HOME`, not per-project) | `~/.claude/projects/<repo>/memory/MEMORY.md` — **per-project**, `<repo>` = git-root path with `/`→`-`; index (first 200 lines/25KB) + topic files | `~/.gen/projects/<project>/memory/MEMORY.md` — **per-project**, like Claude Code |
+| Project isolation | none (one global store) | yes (keyed on git repo; worktrees share) | yes (keyed on git repo) |
 
 **gen-code already has the *injection* side** (from the reminder/compaction
 work): memory loads + re-injects as `<system-reminder>` blocks
@@ -80,12 +81,25 @@ the main agent write — Hermes-style provenance flags — can come later.)
 
 - Trigger: every N user turns (§2).
 - The reviewer reads the recent conversation history and extracts **durable
-  user/project facts** (who the user is, preferences, project conventions,
-  build/debug insights).
-- Writes via `memory_write` to `.gen/memory/MEMORY.md` (+ `USER.md` for the user
-  profile). Append/replace existing entries; "Nothing to save." is valid.
-- This is the corpus the existing reminder injection already loads — so a write
-  here shows up in the next session's `<memory>` reminder.
+  user/project facts** (preferences, project conventions, build/debug insights).
+- Writes via `memory_write` to a **user-level, project-partitioned** store:
+  `~/.gen/projects/<project>/memory/MEMORY.md` (+ topic files, Claude-Code-style:
+  a concise `MEMORY.md` index, detail files loaded on demand). `<project>` is
+  derived from the git repo so worktrees/subdirs of one repo share a store;
+  fall back to the project root outside a repo.
+- **Why user-level + project-partitioned, not in-repo**: it isolates memory per
+  project but keeps it **machine-local and out of the repo**, so there is no
+  commit/gitignore decision and no agent churn in git history. (This mirrors
+  Claude Code's auto-memory.) Append/replace entries; "Nothing to save." valid.
+
+**Injection integration (required).** `LoadMemoryFiles` currently reads only
+user-authored files (`GEN.md`/`CLAUDE.md`/rules); it does **not** read this
+store today. A small change must add `~/.gen/projects/<project>/memory/MEMORY.md`
+as a **new, distinct memory source** (its own level, e.g. "auto"), kept separate
+from the user-authored `GEN.md`/`CLAUDE.md` — so agent-written memory and
+user-written instructions never mix. Load the `MEMORY.md` index (cap like Claude
+Code: first ~200 lines / 25KB); topic files load on demand. Without this read
+side, L1 writes would never be injected.
 
 ### 3b. Skill flow — creation / update
 
@@ -161,7 +175,8 @@ Module map:
 | Wire-up | `internal/agent/session.go::Task.Start` (start), `stopLocked` (tear down) |
 | Fork | `core.NewAgent` directly, restricted `core.Tools` |
 | System prompt | pass the parent's `system.System` verbatim |
-| Writes | `memory_write` → `.gen/memory/`; `skill_manage` → `.gen/skills/agent-created/` |
+| Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → agent-created skills (location TBD, §7) |
+| Injection read | extend `LoadMemoryFiles` to read the memory store as a new "auto" source (§3a) |
 
 ---
 
@@ -186,9 +201,12 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 
 - **Phase 1 — L1 (this issue, #52).** Trigger + fork + direct memory/skill writes
   + the three review prompts.
-  - Prereqs: `skill_manage` tool with patch semantics; a first-class memory
-    writer (`.gen/memory/MEMORY.md` + `USER.md`). gen-code's injection side
-    already reads these once they exist.
+  - Prereqs:
+    - `skill_manage` tool with patch semantics.
+    - A first-class memory writer to `~/.gen/projects/<project>/memory/MEMORY.md`.
+    - **Injection read side**: extend `LoadMemoryFiles` to load that store as a
+      new, distinct "auto" source (§3a) — it does not today, so without this L1
+      writes are never injected.
 - **Phase 2 — L2 curator (separate issue).** Deferred (see §5).
 
 ### Concrete next steps (Phase 1)
@@ -196,7 +214,8 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 1. New package `internal/selflearn/l1`: `Reviewer` (counters + Outbox
    subscription + trigger), `forkAgent(parent, snapshot, mode)` (restricted
    `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
-2. `memory_write` + `skill_manage` tools and their stores under `.gen/`.
+2. `memory_write` (store at `~/.gen/projects/<project>/memory/`) + `skill_manage`
+   tools; extend `LoadMemoryFiles` to read the memory store.
 3. Review prompt templates (memory / skill / combined), rewritten for gen-code
    terminology.
 4. Wire-up in `Task.Start` / `stopLocked`; gate on `StopEndTurn`.
@@ -208,8 +227,13 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 
 ## 7. Open questions (L1)
 
-- **On-disk skill layout** — confirm `.gen/skills/agent-created/` (isolated from
-  user-curated skills).
+- **Skill store location.** Memory is project-partitioned at user level
+  (`~/.gen/projects/<project>/memory/`, settled). Skills are different — a skill
+  like `go-table-tests` is **reusable across projects**, so agent-created skills
+  may belong at user-global level (e.g. `~/.gen/skills/agent-created/`, as hermes
+  does with `~/.hermes/skills/`) rather than per-project or in-repo. Decide:
+  user-global vs project-partitioned vs in-repo, and keep them isolated from
+  user-authored skills regardless.
 - **Cache parity on non-Anthropic providers** — verify system-prompt inheritance
   helps (or at least doesn't hurt) across gen-code's providers.
 - **Usage telemetry** — whether to land the minimal usage log in this phase (for

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -147,28 +147,31 @@ per session.
 
 **Two levels (user + project), for both create and update.** gen-code already
 loads skills from two scopes — `ScopeUser` (`~/.gen/skills/`) and `ScopeProject`
-(`.gen/skills/`) — so no new loader source is needed (unlike memory). Agent
-writes go to an isolated `agent-created/` subdir at each scope:
+(`.gen/skills/`) — so no new loader source is needed (unlike memory). Skills
+live directly in those dirs (`~/.gen/skills/<name>/`, `./.gen/skills/<name>/`);
+**no separate `agent-created/` subdir.**
 
-- **User-level** (cross-project, reusable): `~/.gen/skills/agent-created/<name>/`
-- **Project-level** (this repo's code/conventions/tooling): `./.gen/skills/agent-created/<name>/`
+**Provenance is a frontmatter field, not a directory.** Add one field to
+`SKILL.md`, e.g. `origin: agent-created`; **absent = `user-created`** (the
+default). The `Skill` struct (`internal/skill/types.go`) currently has no
+metadata map, so this is a one-field addition (`Origin string`, Claude ignores
+unknown frontmatter). This mirrors hermes, which marks provenance with a flag,
+not a separate path. (A sidecar file is the alternative; a field is simpler for
+Phase 1.)
 
-A skill is a `SKILL.md` (frontmatter `name`/`description` + optional
-`references/`/`templates/`/`scripts/`).
-
-- **On create**, L1 picks the level: reusable/general → user; specific to this
-  project → project (the review prompt encodes the rule).
-- **On update**, patch the skill **at its existing scope** (don't relocate).
-- **Scope of L1 writes (Phase 1):** L1 only creates/patches **agent-created**
-  skills; it reads/consults user-authored skills (to avoid duplication) but does
-  **not** modify them — keeping user skills untouched. (Relaxing this to let L1
-  patch a just-used user skill, Hermes-style, is a later option.)
+- **On create**, L1 writes `origin: agent-created` and picks the level:
+  reusable/general → user (`~/.gen/skills/`); specific to this project →
+  project (`./.gen/skills/`). The review prompt encodes the rule.
+- **On update**, patch the skill **in place** (don't relocate or change scope).
+- **Scope of L1 writes (Phase 1):** L1 only creates/patches skills it owns
+  (`origin: agent-created`); it reads/consults `user-created` skills (to avoid
+  duplication) but does **not** modify them. The future L2 curator likewise only
+  manages `agent-created` skills, never the user's.
 
 **Why this differs from memory:** memory is personal/accumulated → machine-local,
 project-partitioned, not in the repo. Skills are reusable artifacts a team may
-want to share → they follow gen-code's existing user/project scopes; project-
-level lives in-repo `./.gen/skills/` (gitignore the `agent-created/` subdir if
-you don't want auto-generated skills committed).
+want to share → they live in gen-code's existing user/project scopes (project-
+level in-repo `./.gen/skills/`), distinguished only by the `origin` field.
 
 `skill_manage` actions: `create`, `edit` (full rewrite — rare), `patch`,
 `write_file`, `remove_file`, `delete`. **`patch`** is targeted find-and-replace
@@ -218,8 +221,9 @@ Module map:
 | Wire-up | `internal/agent/session.go::Task.Start` (start), `stopLocked` (tear down) |
 | Fork | `core.NewAgent` directly, restricted `core.Tools` |
 | System prompt | pass the parent's `system.System` verbatim |
-| Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → `~/.gen/skills/agent-created/` (user) or `./.gen/skills/agent-created/` (project) |
-| Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source (§3a). skills: no change — existing user/project scope loader picks up the `agent-created/` subdir. |
+| Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → `~/.gen/skills/<name>/` (user) or `./.gen/skills/<name>/` (project), with `origin: agent-created` |
+| Provenance | add `Origin` to the skill frontmatter struct (`internal/skill/types.go`); absent = `user-created` |
+| Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source (§3a). skills: no change — existing user/project scope loader already covers it. |
 
 ---
 
@@ -271,10 +275,12 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 ## 7. Open questions (L1)
 
 - **Let L1 patch user-authored skills?** Phase 1 default is no (L1 only writes
-  agent-created skills). Hermes allows patching a just-used user skill (its
-  preference #1); revisit if "fix the skill I just used" turns out important.
-- **gitignore `./.gen/skills/agent-created/`?** Default: commit (team-shared
-  project skills) or gitignore (keep auto-generated skills local) — team choice.
+  `origin: agent-created` skills). Hermes allows patching a just-used user skill
+  (its preference #1); revisit if "fix the skill I just used" turns out
+  important.
+- **Commit agent-created project skills?** They live in-repo at `./.gen/skills/`
+  mixed with user skills (distinguished by `origin`). Team choice whether to
+  commit auto-generated ones; can be filtered by the `origin` field if needed.
 - **Cache parity on non-Anthropic providers** — verify system-prompt inheritance
   helps (or at least doesn't hurt) across gen-code's providers.
 - **Usage telemetry** — whether to land the minimal usage log in this phase (for

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -146,27 +146,55 @@ live-patched into the in-flight context — it becomes visible at the next load
 point: the next **PostCompact** (which re-reads from disk) or the next **session
 start**. Acceptable, since memory mainly serves future turns/sessions.
 
-### 3b. Skill flow — creation / update
+### 3b. Skill flow — when to create vs update
 
-Trigger: this turn did real work (tool-iters ≥ K). The reviewer runs the skill
-review prompt against the turn snapshot and follows a **preference order**
-(broadest reuse first; create new only as a last resort):
+**Precondition (whether a skill review runs at all):** this turn did real work
+(tool-iters ≥ K, §2), the turn ended cleanly (`StopEndTurn`), and the skill arm
+is enabled. The trigger is about *work done* — not about whether a skill was
+invoked.
 
-1. **Patch a skill that was loaded/used this turn.** If the agent consulted a
-   skill (a skill-view in the turn history) and it was wrong/outdated →
-   `skill_manage(patch, name, old, new)` to fix it. *(This is where "a skill was
-   invoked" matters — it picks the target.)*
-2. **Patch an existing umbrella.** List + view existing broad, class-level
-   skills; if one covers this learning, patch it (add a pitfall/step, broaden a
-   trigger).
-3. **Add a support file** to an umbrella: `skill_manage(write_file, name,
-   "references|templates|scripts/…", content)`, plus a pointer line in SKILL.md.
-4. **Create a new class-level umbrella** — only when nothing above fits.
-   `skill_manage(create, name, content)`. The name must be **class-level**
-   (e.g. `go-table-tests`), never session-specific (no PR numbers, error
-   strings, `fix-x-today`).
+Once the review runs, the model chooses create / update / nothing by this
+decision flow (broadest reuse first; create is the last resort):
 
-"Umbrella" is a **convention, not a data-model marker** — the preference order
+```
+turn ends
+  │  tool-iters ≥ K ?                    ── no ──▶ no skill review
+  │  StopEndTurn & skill arm enabled ?   ── no ──▶ skip
+  ▼ yes
+skill review fork  (reads the turn snapshot)
+  │
+  ▼
+① a skill loaded/used this turn was wrong / outdated / incomplete ?
+  │  yes ──────────▶  UPDATE · patch that skill
+  ▼ no
+② an existing umbrella skill covers this learning ?
+  │  yes ──────────▶  UPDATE · patch the umbrella, or add a
+  │                            references/templates/scripts support file
+  ▼ no
+③ a NEW, generalizable class of task that no skill covers ?
+  │  yes ──────────▶  CREATE · new class-level umbrella (origin: agent-created)
+  ▼ no
+            Nothing to save   (smooth session, or only anti-patterns)
+```
+
+**UPDATE — when an applicable skill already exists (① or ②).** Preferred (keeps
+the collection broad, avoids near-duplicates). `skill_manage(patch, …)` to
+fix/extend an existing skill; `skill_manage(write_file, …)` to add a
+`references/templates/scripts` support file (plus a pointer line in `SKILL.md`).
+Patch the skill **in place**, at its existing scope.
+
+**CREATE — only when the learning is a genuinely new class of task no skill
+covers (③).** Last resort. `skill_manage(create, name, content)`; the name must
+be **class-level** (e.g. `go-table-tests`), never session-specific (no PR
+numbers, error strings, `fix-x-today`). Always written with
+`origin: agent-created`, at the level L1 chose (user vs project, below).
+
+**NOTHING TO SAVE — when** the session ran smoothly with no correction and no
+new technique, or the only candidate is an **anti-pattern**: environment-
+dependent failures, negative claims about tools, transient errors, one-off task
+narratives.
+
+"Umbrella" is a **convention, not a data-model marker** — the decision flow
 above is what keeps the collection broad instead of sprouting one narrow skill
 per session.
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -3,14 +3,56 @@
 Layer 1 of the self-learning loop in [#46](https://github.com/genai-io/gen-code/issues/46).
 This is [#52](https://github.com/genai-io/gen-code/issues/52).
 
-**Decision.** After every clean turn, an **out-of-band reviewer fork** writes
-to memory/skill stores **directly** — no proposal queue, no human gating. The
-fork is best-effort, capped at one in-flight per session, and never touches the
-main turn's prompt cache. Collection-level grooming (dedup, contradictions,
-unbounded growth) is the job of a later **L2 curator**, designed in its own
-issue (rationale in §8).
+**Contents.** [§0 Overview](#0-what-l1-is-and-the-problems-it-solves) · [§1 Compare](#1-three-systems-compared) · [§2 Architecture](#2-architecture) · [§3 Trigger](#3-trigger--two-arms) · [§4 Memory](#4-memory-flow) · [§5 Skill](#5-skill-flow) · [§6 Fork & UI](#6-fork-mechanics--invariants) · [§7 Filesystem](#7-filesystem-layout) · [§8 L1 vs L2](#8-l1-vs-l2--where-grooming-lives) · [§9 Phasing](#9-phasing--next-steps) · [§10 Open questions](#10-open-questions)
 
-**Contents.** [§1 Compare](#1-three-systems-compared) · [§2 Architecture](#2-architecture) · [§3 Trigger](#3-trigger--two-arms) · [§4 Memory](#4-memory-flow) · [§5 Skill](#5-skill-flow) · [§6 Fork & UI](#6-fork-mechanics--invariants) · [§7 Filesystem](#7-filesystem-layout) · [§8 L1 vs L2](#8-l1-vs-l2--where-grooming-lives) · [§9 Phasing](#9-phasing--next-steps) · [§10 Open questions](#10-open-questions)
+---
+
+## 0. What L1 is, and the problems it solves
+
+### What it is
+
+L1 is a **background reviewer** that runs after each clean turn in its own
+forked agent. It reads the just-completed conversation and writes directly
+to two stores:
+
+- **Auto-memory** — per-project durable facts (user preferences, project
+  conventions, recurring context). Stored at
+  `~/.gen/projects/<project>/memory/`; injected into the system prompt of
+  every future session.
+- **Skill library** — class-level techniques marked
+  `origin: agent-created`, living alongside user-authored skills in
+  `~/.gen/skills/` (user-wide) and `./.gen/skills/` (project). Loaded the
+  same way user skills already are.
+
+The reviewer is **best-effort, out-of-band, eviction-first**: it never
+blocks the user's turn; it retires stale entries before adding new ones;
+every action is gated by config (§5.5). At most one review is in flight per
+session; failures never affect the user reply.
+
+### Problems L1 solves
+
+| Symptom today (without L1) | What L1 changes |
+|---|---|
+| Every session starts at zero. User re-explains preferences, working style, and project conventions each time. | Reviewer captures durable user/project facts; future sessions start already knowing them. |
+| Skills get used but their mistakes never get fixed. Same mistake repeats across sessions. | Reviewer patches a skill the conversation just proved wrong, incomplete, or outdated (§5.1). |
+| Skills accumulate but never retire. Obsolete entries pile up and mislead later sessions. | Reviewer deletes a skill in the same pass that learned its replacement (§5.1). |
+| Non-trivial fixes, debug paths, and tool-usage patterns evaporate at session end. | Generalizable learnings captured as class-level skills; level (user vs project) chosen by reusability. |
+| `GEN.md` / `CLAUDE.md` only grows if the user hand-curates it. | A separate auto-memory store grows alongside, machine-local and project-partitioned (§4) — never mixed with the user-authored instructions. |
+
+### What L1 deliberately does not do
+
+- **No cross-collection grooming.** L1 sees one turn at a time.
+  Whole-library dedup, contradiction resolution, and usage-based
+  retirement is L2's job (§8) — deferred to a separate issue.
+- **No approval prompts.** L1 writes directly, gated by config rather
+  than by interrupts. Default is opt-in (off); permission defaults stay
+  conservative once on.
+- **No touch on user-authored content**, unless `allowUpdateUserCreated`
+  is explicitly enabled (§5.5). Even then, only `patch` —
+  create/delete on user-created skills are impossible at any setting.
+- **No live patching of the running session.** Writes become visible at
+  the next memory load (PostCompact or new session, §4.6). Live-patching
+  would invalidate the prefix cache.
 
 ---
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -59,10 +59,12 @@ on its own and matches the production-proven hermes shape.
   *which* skill to update (see §3b), not *whether* to review — otherwise new
   skills for tasks that had no skill yet would never be learned.
 
-Combined when both fire on the same turn. The trigger is a **pure event
-consumer** subscribed to `core.Agent.Outbox()`, reading `TurnEvent`
-(`Result.Turns`/`ToolUses`/`StopReason`). No `internal/core` changes; counters
-live in the consumer and hydrate from history on session resume.
+Combined when both fire on the same turn. The trigger **observes completed
+turns**: it is handed each turn `Result` (`Turns`/`ToolUses`/`StopReason`) as
+the turn finishes — the `Outbox` is single-consumer (already drained by the
+app), so the reviewer is fed rather than subscribing to it. No `internal/core`
+changes; counters live in the reviewer and hydrate from history on session
+resume.
 
 **Configuration.** The two arms are toggled and tuned independently via
 `settings.json` (a new `selfLearn` section, merged across user/project/local
@@ -309,7 +311,7 @@ Module map:
 
 | Concern | Module |
 |---|---|
-| Trigger + fork | new `internal/selflearn/l1` (subscribes to `core.Agent.Outbox()`, owns counters) |
+| Trigger + fork | new `internal/selflearn` (observes completed turns, owns counters) |
 | Wire-up | `internal/agent/session.go::Task.Start` (start), `stopLocked` (tear down) |
 | Fork | `core.NewAgent` directly, restricted `core.Tools` |
 | System prompt | pass the parent's `system.System` verbatim |
@@ -350,8 +352,8 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 
 ### Concrete next steps (Phase 1)
 
-1. New package `internal/selflearn/l1`: `Reviewer` (counters + Outbox
-   subscription + trigger), `forkAgent(parent, snapshot, mode)` (restricted
+1. New package `internal/selflearn`: `Reviewer` (counters + turn observation +
+   trigger), `forkAgent(parent, snapshot, mode)` (restricted
    `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
 2. `memory_write` (store at `~/.gen/projects/<project>/memory/`) + `skill_manage`
    tools; extend `LoadMemoryFiles` to read the memory store.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -143,9 +143,32 @@ review prompt against the turn snapshot and follows a **preference order**
 
 "Umbrella" is a **convention, not a data-model marker** — the preference order
 above is what keeps the collection broad instead of sprouting one narrow skill
-per session. New skills are written to `.gen/skills/agent-created/<name>/`
-(a `SKILL.md` with frontmatter `name`/`description` + optional
-`references/`/`templates/`/`scripts/`), isolated from user-authored skills.
+per session.
+
+**Two levels (user + project), for both create and update.** gen-code already
+loads skills from two scopes — `ScopeUser` (`~/.gen/skills/`) and `ScopeProject`
+(`.gen/skills/`) — so no new loader source is needed (unlike memory). Agent
+writes go to an isolated `agent-created/` subdir at each scope:
+
+- **User-level** (cross-project, reusable): `~/.gen/skills/agent-created/<name>/`
+- **Project-level** (this repo's code/conventions/tooling): `./.gen/skills/agent-created/<name>/`
+
+A skill is a `SKILL.md` (frontmatter `name`/`description` + optional
+`references/`/`templates/`/`scripts/`).
+
+- **On create**, L1 picks the level: reusable/general → user; specific to this
+  project → project (the review prompt encodes the rule).
+- **On update**, patch the skill **at its existing scope** (don't relocate).
+- **Scope of L1 writes (Phase 1):** L1 only creates/patches **agent-created**
+  skills; it reads/consults user-authored skills (to avoid duplication) but does
+  **not** modify them — keeping user skills untouched. (Relaxing this to let L1
+  patch a just-used user skill, Hermes-style, is a later option.)
+
+**Why this differs from memory:** memory is personal/accumulated → machine-local,
+project-partitioned, not in the repo. Skills are reusable artifacts a team may
+want to share → they follow gen-code's existing user/project scopes; project-
+level lives in-repo `./.gen/skills/` (gitignore the `agent-created/` subdir if
+you don't want auto-generated skills committed).
 
 `skill_manage` actions: `create`, `edit` (full rewrite — rare), `patch`,
 `write_file`, `remove_file`, `delete`. **`patch`** is targeted find-and-replace
@@ -195,8 +218,8 @@ Module map:
 | Wire-up | `internal/agent/session.go::Task.Start` (start), `stopLocked` (tear down) |
 | Fork | `core.NewAgent` directly, restricted `core.Tools` |
 | System prompt | pass the parent's `system.System` verbatim |
-| Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → agent-created skills (location TBD, §7) |
-| Injection read | extend `LoadMemoryFiles` to read the memory store as a new "auto" source (§3a) |
+| Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → `~/.gen/skills/agent-created/` (user) or `./.gen/skills/agent-created/` (project) |
+| Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source (§3a). skills: no change — existing user/project scope loader picks up the `agent-created/` subdir. |
 
 ---
 
@@ -247,13 +270,11 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 
 ## 7. Open questions (L1)
 
-- **Skill store location.** Memory is project-partitioned at user level
-  (`~/.gen/projects/<project>/memory/`, settled). Skills are different — a skill
-  like `go-table-tests` is **reusable across projects**, so agent-created skills
-  may belong at user-global level (e.g. `~/.gen/skills/agent-created/`, as hermes
-  does with `~/.hermes/skills/`) rather than per-project or in-repo. Decide:
-  user-global vs project-partitioned vs in-repo, and keep them isolated from
-  user-authored skills regardless.
+- **Let L1 patch user-authored skills?** Phase 1 default is no (L1 only writes
+  agent-created skills). Hermes allows patching a just-used user skill (its
+  preference #1); revisit if "fix the skill I just used" turns out important.
+- **gitignore `./.gen/skills/agent-created/`?** Default: commit (team-shared
+  project skills) or gitignore (keep auto-generated skills local) — team choice.
 - **Cache parity on non-Anthropic providers** — verify system-prompt inheritance
   helps (or at least doesn't hurt) across gen-code's providers.
 - **Usage telemetry** — whether to land the minimal usage log in this phase (for

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -1,74 +1,100 @@
 # L1 — Background Review (per-turn self-learning)
 
-Design for Layer 1 of the self-learning loop in
-[#46](https://github.com/genai-io/gen-code/issues/46). This is
-[#52](https://github.com/genai-io/gen-code/issues/52).
+Layer 1 of the self-learning loop in [#46](https://github.com/genai-io/gen-code/issues/46).
+This is [#52](https://github.com/genai-io/gen-code/issues/52).
 
-**Decision** (after comparing against the hermes-agent reference,
-`agent/background_review.py`): gen-code uses an **out-of-band** review that
-**writes memory/skills directly** per turn — useful on its own the moment it
-ships. A later, separate **L2 curator** keeps the collection healthy; its design
-is deferred to its own issue (a short rationale is in §5).
-
-This doc focuses on L1: comparison, trigger, what it writes, fork mechanics, and
-phasing.
+**Decision.** After every clean turn, an **out-of-band reviewer fork** writes
+to memory/skill stores **directly** — no proposal queue, no human gating. The
+fork is best-effort, capped at one in-flight per session, and never touches the
+main turn's prompt cache. Collection-level grooming (dedup, contradictions,
+unbounded growth) is the job of a later **L2 curator**, designed in its own
+issue (rationale in §8).
 
 ---
 
-## 1. How three systems do self-evolving memory (comparison)
+## 1. Three systems compared
 
-Two places the "write memory" decision can live: **in-band** (the main agent
-writes mid-session, on its own judgment) vs **out-of-band** (a separate agent
-reviews after a turn and writes).
-
-| Axis | Hermes (`background_review.py`) | Claude Code (auto memory) | gen-code (decided) |
+| Axis | Hermes (`background_review.py`) | Claude Code (auto memory) | gen-code L1 (this doc) |
 |---|---|---|---|
-| Write decision | **Out-of-band** review fork | **In-band** main agent | **Out-of-band** (aligned with Hermes) |
-| When | After a turn | During the session, on model judgment | After a turn |
-| Writes directly? | **Yes** (fork has memory + skill tools) | Yes (main agent's own tool calls) | **Yes** |
-| Trigger | turns (memory) + tool-iters (skill) | model judgment + explicit "remember this" | same two signals |
-| Memory path | `~/.hermes/MEMORY.md` + `USER.md` — **global** (`$HERMES_HOME`, not per-project) | `~/.claude/projects/<repo>/memory/MEMORY.md` — **per-project**, `<repo>` = git-root path with `/`→`-`; index (first 200 lines/25KB) + topic files | `~/.gen/projects/<project>/memory/MEMORY.md` — **per-project**, like Claude Code |
-| Project isolation | none (one global store) | yes (keyed on git repo; worktrees share) | yes (keyed on git repo) |
+| Where the write decision lives | **Out-of-band** fork | **In-band** main agent | **Out-of-band** (Hermes-aligned) |
+| When | After a clean turn | Mid-turn, on model judgment | After a clean turn |
+| Writes directly | yes (fork has memory + skill tools) | yes (main agent's own tool) | yes |
+| Trigger signals | turns (memory) + tool-iters (skill) | model judgment + explicit "remember this" | **turns + tool-iters** |
+| Memory scope | **global** `~/.hermes/MEMORY.md` + `USER.md` | **per-project** `~/.claude/projects/<repo>/memory/` (index + topic files) | **per-project** `~/.gen/projects/<project>/memory/` (Claude-Code-aligned) |
+| Skill scope | global, with provenance flags | global, with provenance | **user + project**, `origin: agent-created` field |
+| Cache parity | inherits cached system prompt verbatim (≈26% cost cut measured) | n/a (no fork) | inherits verbatim |
 
-**gen-code already has the *injection* side** (from the reminder/compaction
-work): memory loads + re-injects as `<system-reminder>` blocks
-(`memory-user`/`memory-project`), refreshed from disk on PostCompact. What's
-missing is the *write* side — `internal/reminder` injects but never persists.
-L1 adds the write side.
-
-**Why out-of-band + direct-write:** in-band (Claude Code) is cheapest but spends
-main-context tokens every session and only appends in the flow of work.
-Out-of-band keeps the main turn clean and lets a dedicated prompt review after
-the reply is delivered. Direct write (vs staging proposals) makes Phase 1 useful
-on its own and matches the production-proven hermes shape.
+**Why this mix.** Hermes' out-of-band shape is the production-proven one (best
+turn responsiveness, dedicated reviewer prompt, no main-context bloat); Claude
+Code's per-project memory layout is the right home for gen-code's multi-repo
+users (worktrees of one repo share a store; different repos don't leak into
+each other). gen-code already has the **read/injection side** (memory loads
++ `<system-reminder>` re-emit on PostCompact); L1 only adds the **write side**.
 
 ---
 
-## 2. Trigger — two signals
+## 2. Architecture
 
-| Review kind | Signal | Default | Rationale |
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant M as Main agent
+    participant R as Reviewer<br/>(internal/selflearn)
+    participant F as Fork<br/>(restricted)
+    participant S as Stores<br/>(memory · skills)
+
+    U->>M: prompt
+    M-->>U: reply (StopEndTurn)
+    M->>R: Observe(Result)
+    Note right of R: counters++<br/>any arm tripped?
+    R->>F: spawn fork<br/>(cached system prompt,<br/>turn snapshot,<br/>memory+skill tools only)
+    F->>S: read existing entries
+    F->>S: memory_write / skill_manage
+    F-->>R: actions summary
+    R-->>U: 💾 Self-improvement review: one-line summary
+```
+
+Key points the diagram encodes:
+
+- The reviewer is **fed** completed turns (single-consumer outbox is already
+  drained by the app); it doesn't subscribe.
+- The fork's read side reads current memory + lists existing skills so it can
+  pick **update over create** and **replace over append**.
+- The user-visible surface is a single line per fork — silent on "Nothing to
+  save."
+
+---
+
+## 3. Trigger — two arms
+
+```mermaid
+flowchart TD
+    A[turn ends] --> B{StopEndTurn?}
+    B -- no --> Z[skip]
+    B -- yes --> C[mem_counter++<br/>skill_counter += ToolUses]
+    C --> D{mem ≥ N or<br/>skill ≥ K?}
+    D -- no --> Z
+    D -- yes --> E{review in flight?}
+    E -- yes --> X[drop · don't reset counter]
+    E -- no --> G[mark in-flight,<br/>reset tripped arms,<br/>spawn fork]
+    G --> H[run review] --> I[clear in-flight]
+```
+
+| Arm | Signal | Default | Why this signal |
 |---|---|---|---|
-| Memory | user turns since last review | every 10 turns | User-modeling drifts on conversational cadence, not work intensity. |
-| Skills | tool iterations within the turn | when this turn ≥ 10 tool iters | Skill capture should fire when the agent actually *did* work; tool-iter count is the cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
+| Memory | user turns since last review | every **10** user turns | User-modelling drifts on conversational cadence, not work intensity. |
+| Skills | tool iterations **this turn** | when turn ≥ **10** tool-iters | Skill capture should fire when the agent actually *did* work; tool-iters is a cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
 
-- **Memory** fires on a **turn cadence** (default every 10 user turns) — it is
-  not tied to whether work happened. When it fires, the reviewer reads the
-  **recent conversation history** (the turn snapshot) and updates durable facts.
-- **Skills** fire on **work done this turn** (tool-iters ≥ K), not on a turn
-  cadence and not on "a skill was invoked". Whether a skill was invoked affects
-  *which* skill to update (see §3b), not *whether* to review — otherwise new
-  skills for tasks that had no skill yet would never be learned.
+Both arms count independently and may fire on the same turn (combined prompt).
+Counters live in the reviewer and **hydrate from history on session resume**
+(memory only — the skill counter is intra-turn).
 
-Combined when both fire on the same turn. The trigger **observes completed
-turns**: it is handed each turn `Result` (`Turns`/`ToolUses`/`StopReason`) as
-the turn finishes — the `Outbox` is single-consumer (already drained by the
-app), so the reviewer is fed rather than subscribing to it. No `internal/core`
-changes; counters live in the reviewer and hydrate from history on session
-resume.
+### 3.1 Configuration
 
-**Configuration.** The two arms are toggled and tuned independently via
-`settings.json` (a new `selfLearn` section, merged across user/project/local
-layers like other gen-code settings):
+The two arms are toggled and tuned independently via `settings.json` (a new
+`selfLearn` section, merged across user / project / local layers like other
+gen-code settings):
 
 ```json
 {
@@ -79,235 +105,151 @@ layers like other gen-code settings):
 }
 ```
 
-- `memory.enabled` / `skills.enabled` — enable each arm separately. You can run
-  memory-evolving without skill-evolving and vice versa.
-- `memory.everyTurns` — memory cadence (user turns); `skills.everyToolIters` —
-  skill threshold (tool iterations this turn).
-- **When both arms are off, no L1 reviewer goroutine is started** — zero
+- `memory.enabled` / `skills.enabled` — enable each arm separately. Running
+  memory-evolving without skill-evolving (or vice versa) is supported.
+- `memory.everyTurns` — memory cadence in user turns.
+- `skills.everyToolIters` — skill threshold in tool iterations this turn.
+- **When both arms are off, no reviewer goroutine is started** — zero
   overhead, no extra model calls, nothing written.
-- **Default: off (opt-in).** L1 forks an extra model call per cadence and writes
-  files automatically; ship it opt-in, then consider defaulting on once trusted
-  (Claude Code ships auto-memory on — we can match later). *(Default value is an
-  easily-changed decision.)*
-- Optional escape hatch: an env override (e.g. `GEN_DISABLE_SELF_LEARN=1`),
-  mirroring Claude Code's `CLAUDE_CODE_DISABLE_AUTO_MEMORY`.
+- **Default: off (opt-in).** L1 forks an extra model call per cadence and
+  writes files automatically; ship opt-in, default-on later once trusted
+  (Claude Code ships auto-memory on — we can match).
+- Optional escape hatch: env override `GEN_DISABLE_SELF_LEARN=1`, mirroring
+  Claude Code's `CLAUDE_CODE_DISABLE_AUTO_MEMORY`.
 
 ---
 
-## 3. What L1 writes — directly
+## 4. Memory flow
 
-The write tools (`memory_write` + `skill_manage`) belong **only to the L1
-reviewer fork** in this phase; the main agent reads/invokes skills and memory
-but never writes them. L1-written content is marked **agent-owned** — skills via
-the `origin: agent-created` frontmatter field (§3b), memory by living in its own
-dedicated store (§3a) — so the future L2 curator manages only agent-owned
-content and never the user's. (Letting the main agent write skills too can come
-later.)
-
-### 3a. Memory flow — when to add vs replace
-
-**Precondition (whether a memory review runs):** the memory cadence is due
-(every N user turns, §2), the memory arm is enabled, and the turn ended cleanly
-(`StopEndTurn`). Unlike skills, this is a **turn cadence** — independent of how
-much work the turn did.
-
-**Inputs to the fork:** the conversation snapshot (the recent turns) + the
-memory-review prompt; the fork also **reads the current memory store** so it can
-refresh/dedupe rather than blindly append.
-
-```
-memory cadence due  (memory arm enabled)
-  │  StopEndTurn ?   ── no ──▶ skip (cancelled / interrupted)
-  ▼ yes
-memory review fork  (inherits system prompt; reads conversation snapshot +
-                     current MEMORY.md)
-  │
-  ▼
-a durable fact worth keeping?  (user preference, project convention,
-  │                             build/debug insight — NOT one-off task state)
-  │  no ──▶ Nothing to save
-  ▼ yes
-already an entry about this?
-  │  yes ──────────▶  memory_write(replace …)   refresh / correct it
-  ▼ no
-  └────────────────▶  memory_write(add …)       append new entry
-                          → ~/.gen/projects/<project>/memory/MEMORY.md
+```mermaid
+flowchart TD
+    A[memory cadence due<br/>+ StopEndTurn + arm enabled] --> B[fork reads<br/>snapshot + MEMORY.md]
+    B --> C{durable fact<br/>worth keeping?}
+    C -- no --> Z[Nothing to save]
+    C -- yes --> D{existing entry<br/>covers it?}
+    D -- yes --> R[memory_write replace]
+    D -- no --> N[memory_write add]
+    R --> P[~/.gen/projects/&lt;project&gt;/memory/]
+    N --> P
 ```
 
-`memory_write` actions: `add`, `replace`, `remove`, operating on the memory
-store (the `MEMORY.md` index; long detail may spill into topic files like
-`debugging.md`, loaded on demand). "Nothing to save." is valid.
+**Tool actions:** `add` / `replace` / `remove`. "Nothing to save." is a valid
+outcome.
 
 **Anti-patterns (don't save):** one-off task state, transient errors,
-"what we did this session" narratives — those are not durable across sessions.
+"what-we-did-this-session" narratives — none are durable across sessions.
 
-**Store:** `~/.gen/projects/<project>/memory/MEMORY.md` (+ topic files,
-Claude-Code-style: concise index, details on demand). `<project>` is the **git
-repo root path, separators replaced** (the same encoding Claude Code uses, e.g.
-`-Users-me-work-gen-code`), so worktrees/subdirs of one repo share a store; fall
-back to the project root outside a repo.
+**Store layout.** `~/.gen/projects/<project>/memory/MEMORY.md` is the index;
+long detail spills into topic files (`debugging.md`, …) loaded on demand.
+`<project>` is the git-repo root path with `/` → `-` (Claude Code's encoding,
+e.g. `-Users-me-work-gen-code`), so worktrees of one repo share a store. Fall
+back to cwd outside a repo. User-level + project-partitioned is
+**machine-local, out of the repo** — no commit/gitignore decision, no agent
+churn in git history.
 
-**Why user-level + project-partitioned, not in-repo:** isolates memory per
-project but keeps it **machine-local and out of the repo** — no commit/gitignore
-decision, no agent churn in git history. (Mirrors Claude Code's auto-memory.)
+**Injection lifecycle (reuses existing infrastructure).**
 
-**Injection integration (required).** `LoadMemoryFiles` currently reads only
-user-authored files (`GEN.md`/`CLAUDE.md`/rules); it does **not** read this
-store today. A small change must add `~/.gen/projects/<project>/memory/MEMORY.md`
-as a **new, distinct memory source** (its own level, e.g. "auto"), kept separate
-from the user-authored `GEN.md`/`CLAUDE.md` — so agent-written memory and
-user-written instructions never mix. Without this read side, L1 writes would
+| When | What happens |
+|---|---|
+| Session start | Read `MEMORY.md` index (cap ~200 lines / 25 KB) → inject as `<system-reminder source="memory-auto">` on first user message. Topic files are read on demand by file tools, not injected. |
+| PostCompact | Re-read from disk + re-emit reminders (same path as `GEN.md` / `CLAUDE.md`). |
+| cwd change | Re-read, because `<project>` changes. |
+
+This requires one small read-side change: extend `LoadMemoryFiles` with a new,
+**distinct "auto" source** so agent-written memory and user-authored
+`GEN.md` / `CLAUDE.md` never mix. Without this read side, L1 writes would
 never be injected.
 
-**Load timing — reuses the existing injection lifecycle:**
-
-- **Session start:** read the `MEMORY.md` index → cache → inject as a
-  `<system-reminder source="memory-auto">` block on the first user message.
-  Cap the index like Claude Code (first ~200 lines / 25KB); topic files are read
-  on demand by the agent's file tools, not injected.
-- **PostCompact:** re-read from disk (`refreshMemoryContext`) + re-emit
-  (`RequeueSystemReminders`) — the same path already built for `GEN.md`/`CLAUDE.md`
-  memory — so the latest memory survives compaction.
-- **cwd change:** re-read, because `<project>` (and thus the store) changes when
-  the working directory moves to a different repo.
-
-**Update timing:** the L1 fork writes post-turn, on the memory cadence (every N
-user turns, §2), gated on `StopEndTurn`.
-
-**Write→visibility lag (by design):** L1 writes out-of-band, while the running
-session's memory was injected at a load point. So a fresh write is **not**
-live-patched into the in-flight context — it becomes visible at the next load
-point: the next **PostCompact** (which re-reads from disk) or the next **session
-start**. Acceptable, since memory mainly serves future turns/sessions.
-
-### 3b. Skill flow — when to create vs update
-
-> **Umbrella** = a broad, **class-level** skill (e.g. `go-testing`,
-> `code-review`) that accumulates many specific learnings over time — as opposed
-> to a **narrow, session-specific** skill (`fix-flaky-test-pr-1234`). It is a
-> naming convention, not a stored field — the flow prefers extending an umbrella
-> over spawning narrow skills, so the collection stays "broad and few".
-
-**Precondition (whether a skill review runs at all):** this turn did real work
-(tool-iters ≥ K, §2), the turn ended cleanly (`StopEndTurn`), and the skill arm
-is enabled. The trigger is about *work done* — not about whether a skill was
-invoked.
-
-Once the review runs, the model chooses create / update / nothing by this
-decision flow (broadest reuse first; create is the last resort):
-
-```
-turn ends
-  │  tool-iters ≥ K ?                    ── no ──▶ no skill review
-  │  StopEndTurn & skill arm enabled ?   ── no ──▶ skip
-  ▼ yes
-skill review fork  (reads the turn snapshot)
-  │
-  ▼
-① a skill loaded/used this turn was wrong / outdated / incomplete ?
-  │  yes ──────────▶  UPDATE · patch that skill
-  ▼ no
-② an existing umbrella skill covers this learning ?
-  │  yes ──────────▶  UPDATE · patch the umbrella, or add a
-  │                            references/templates/scripts support file
-  ▼ no
-③ a NEW, generalizable class of task that no skill covers ?
-  │  yes ──────────▶  CREATE · new class-level umbrella (origin: agent-created)
-  ▼ no
-            Nothing to save   (smooth session, or only anti-patterns)
-```
-
-**UPDATE — when an applicable skill already exists (① or ②).** Preferred (keeps
-the collection broad, avoids near-duplicates). `skill_manage(patch, …)` to
-fix/extend an existing skill; `skill_manage(write_file, …)` to add a
-`references/templates/scripts` support file (plus a pointer line in `SKILL.md`).
-Patch the skill **in place**, at its existing scope.
-
-**CREATE — only when the learning is a genuinely new class of task no skill
-covers (③).** Last resort. `skill_manage(create, name, content)` with
-`origin: agent-created`; the name must be **class-level** (e.g. `go-table-tests`),
-never session-specific (no PR numbers, error strings, `fix-x-today`). L1 picks
-the level: reusable/general → user (`~/.gen/skills/`), project-specific →
-project (`./.gen/skills/`).
-
-**NOTHING TO SAVE — when** the session ran smoothly with no correction and no
-new technique, or the only candidate is an **anti-pattern**: environment-
-dependent failures, negative claims about tools, transient errors, one-off task
-narratives.
-
-**Two levels (user + project), for both create and update.** gen-code already
-loads skills from two scopes — `ScopeUser` (`~/.gen/skills/`) and `ScopeProject`
-(`.gen/skills/`) — so no new loader source is needed (unlike memory). Skills
-live directly in those dirs (`~/.gen/skills/<name>/`, `./.gen/skills/<name>/`);
-**no separate `agent-created/` subdir.**
-
-**Provenance is a frontmatter field, not a directory.** Add one field to
-`SKILL.md`, e.g. `origin: agent-created`; **absent = `user-created`** (the
-default). The `Skill` struct (`internal/skill/types.go`) currently has no
-metadata map, so this is a one-field addition (`Origin string`, Claude ignores
-unknown frontmatter). This mirrors hermes, which marks provenance with a flag,
-not a separate path. (A sidecar file is the alternative; a field is simpler for
-Phase 1.)
-
-**Scope of L1 writes (Phase 1):** L1 only creates/patches skills it owns
-(`origin: agent-created`); it reads `user-created` skills (to avoid duplication)
-but never modifies them. The future L2 curator likewise touches only
-`agent-created` skills.
-
-**Why this differs from memory:** memory is personal/accumulated → machine-local,
-project-partitioned, not in the repo. Skills are reusable artifacts a team may
-want to share → they live in gen-code's existing user/project scopes (project-
-level in-repo `./.gen/skills/`), distinguished only by the `origin` field.
-
-`skill_manage` actions: `create`, `edit` (full rewrite — rare), `patch`,
-`write_file`, `remove_file`, `delete`. **`patch`** is targeted find-and-replace
-with a fuzzy-match chain (exact → line-trimmed → whitespace/indent/escape/
-unicode-normalized → block-anchor → context-similarity) and an **escape-drift
-guard** (rejects matches where transport-added `\'`/`\"` backslashes don't exist
-in the file, prompting a clean re-read). Requires a unique match unless
-`replace_all`.
-
-Three review prompts, picked by which triggers fired (memory-only / skill-only /
-combined). The skill prompt is **active** (most working sessions produce ≥1
-update) and embeds the anti-pattern list from NOTHING TO SAVE above.
+**Write→visibility lag (by design).** L1 writes out-of-band while the running
+session's memory was injected at a load point, so a fresh write becomes
+visible at the next load point (next PostCompact / next session) — not
+live-patched. Acceptable: memory primarily serves future turns.
 
 ---
 
-## 4. Fork mechanics + invariants
+## 5. Skill flow
 
-Fresh `core.Agent` (`core.NewAgent`) run with `ThinkAct` in a goroutine — **not**
-`subagent.Executor` (which is built for named, user-facing subagents with
-registry/hooks/session-persistence a silent reviewer must not carry).
+> **Umbrella** = a broad, **class-level** skill (e.g. `go-testing`,
+> `code-review`) that accumulates many learnings over time, as opposed to a
+> **narrow, session-specific** skill (`fix-flaky-test-pr-1234`). It is a
+> naming convention, not a stored field — the flow prefers extending an
+> umbrella over spawning narrow skills so the library stays "broad and few".
 
-**Construction & seeding:** the fork inherits the parent's `system.System`
-verbatim, is seeded with the parent's **message snapshot** (`SetMessages`) plus
-an injected user message carrying the review prompt, then runs `ThinkAct` under
-a **tight cap** — `MaxTurns ≈ 16` and a context deadline (≈5 min); drop the
-result if it exceeds either.
+```mermaid
+flowchart TD
+    A[turn ≥ K tool-iters<br/>+ StopEndTurn + arm enabled] --> B[fork reads turn snapshot]
+    B --> C{loaded skill<br/>was wrong / outdated?}
+    C -- yes --> U1[UPDATE · patch that skill]
+    C -- no --> D{existing umbrella<br/>covers this?}
+    D -- yes --> U2[UPDATE · patch umbrella<br/>+/- references/templates/scripts]
+    D -- no --> E{new class of task<br/>no skill covers?}
+    E -- yes --> N[CREATE · class-level umbrella<br/>origin: agent-created]
+    E -- no --> Z[Nothing to save]
+```
 
-Invariants (each one cost hermes a production bug):
+**UPDATE preferred.** Keeps the library broad and avoids near-duplicates.
+`skill_manage(patch, …)` to fix/extend; `skill_manage(write_file, …)` to add
+a `references/`, `templates/`, or `scripts/` support file (plus a pointer
+line in `SKILL.md`). Patch in place, at the existing scope.
 
-1. **Run AFTER the user reply is delivered.** Gate on `Result.StopReason ==
-   StopEndTurn` (skip cancelled/interrupted/max-turns).
+**CREATE as last resort.** Names must be **class-level** (`go-table-tests`,
+not `fix-pr-1234`). L1 picks the level: reusable/general → user
+(`~/.gen/skills/`), project-specific → project (`./.gen/skills/`).
+
+**Provenance is a frontmatter field, not a directory.** Add
+`origin: agent-created` to `SKILL.md`; absent ⇒ `user-created`. The `Skill`
+struct grows one field (`Origin string`). Skills live directly in gen-code's
+existing two scopes — no `agent-created/` subdir, no loader change.
+
+**Scope of L1 writes (Phase 1).** L1 only creates/patches
+`origin: agent-created` skills. It **reads** user-created skills (to avoid
+duplication) but never modifies them. The future L2 likewise touches only
+agent-owned content.
+
+**`skill_manage` actions.** `create`, `edit` (full rewrite — rare), `patch`,
+`write_file`, `remove_file`, `delete`. **`patch`** is targeted
+find-and-replace with a fuzzy-match chain (exact → line-trimmed → whitespace/
+indent/escape/unicode-normalized → block-anchor → context-similarity) and an
+**escape-drift guard** (rejects matches where transport-added `\'` / `\"`
+backslashes don't exist in the file).
+
+**Three review prompts**, picked by which arms fired (memory / skill /
+combined). The skill prompt is **active** (most working sessions produce ≥1
+update) and embeds the anti-pattern list.
+
+---
+
+## 6. Fork mechanics — invariants
+
+Fresh `core.Agent` (`core.NewAgent`) in a goroutine, **not**
+`subagent.Executor` (which carries registry / hooks / session-persistence a
+silent reviewer must not). The fork inherits the parent's `system.System`
+verbatim, is seeded with `SetMessages(snapshot)` + a user message carrying
+the review prompt, then runs `ThinkAct` under `MaxTurns ≈ 16` and a context
+deadline (≈ 5 min).
+
+Eight invariants, each one cost Hermes a production bug:
+
+1. **Run AFTER the user reply is delivered.** Gate on
+   `Result.StopReason == StopEndTurn` (skip cancelled / interrupted / max-turns).
 2. **Inherit the parent's cached system prompt byte-for-byte** for prefix-cache
-   parity (Anthropic/OpenRouter). Hermes measured ~26% cost reduction.
-3. **Toolset whitelist at dispatch.** Fork's `tools[]` matches the parent
-   (cache-key parity) but a static permission func allows only the **memory +
-   skill toolsets** — both **read and write**: it must read current memory and
-   list/view existing skills (to dedupe and choose add-vs-replace / patch-vs-
-   create), and write via `memory_write` / `skill_manage`. Everything else
-   denied.
-4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge` (would
-   deadlock the TUI); auto-deny any approval.
-5. **Best-effort.** Wrap in recover; review failure never affects the user turn.
+   parity (≈26% cost cut on Sonnet 4.5 per Hermes).
+3. **Toolset whitelist at dispatch.** `tools[]` matches the parent (cache-key
+   parity); a static permission func allows only the **memory + skill
+   toolsets** (read *and* write — needs read for dedupe). All else denied.
+4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge`
+   (would deadlock the TUI). Approvals auto-deny.
+5. **Best-effort.** Wrap in `recover`; review failure never affects the user
+   turn.
 6. **No session-scoped side effects** (no hooks, no session persistence).
-7. **Suppress fork status.** Only a one-line `💾 Self-improvement review:
-   <summary>` surfaces on the main outbox (`MessageEvent`, `From: "l1-review"`).
-   Silent on "nothing to save".
-8. **≤1 in-flight fork per session.** Drop new triggers while one runs (log, no
-   queue).
+7. **Suppress fork status.** Only one line surfaces on the main outbox:
+   `💾 Self-improvement review: <summary>` (`MessageEvent`,
+   `From: "l1-review"`). Silent on "Nothing to save."
+8. **≤1 in-flight fork per session.** Drop new triggers while one runs (log,
+   no queue). Counters are **not** reset on drop — the threshold stays
+   tripped and re-fires next clean turn.
 
-Module map:
+### Module map
 
 | Concern | Module |
 |---|---|
@@ -316,88 +258,112 @@ Module map:
 | Fork | `core.NewAgent` directly, restricted `core.Tools` |
 | System prompt | pass the parent's `system.System` verbatim |
 | Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → `~/.gen/skills/<name>/` (user) or `./.gen/skills/<name>/` (project), with `origin: agent-created` |
-| Provenance | add `Origin` to the skill frontmatter struct (`internal/skill/types.go`); absent = `user-created` |
-| Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source (§3a). skills: no change — existing user/project scope loader already covers it. |
+| Provenance | add `Origin` to skill frontmatter struct (`internal/skill/types.go`); absent ⇒ `user-created` |
+| Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source. Skills: no change (existing user/project loader covers it). |
 
 ---
 
-## 5. Why a later L2 curator (rationale only — design deferred)
+## 7. Filesystem layout
 
-L1 writes with a **local** view (one turn) and **frequently**. Over many turns
-the collection drifts in ways no single L1 write can fix: duplicate/overlapping
-entries, contradictions and stale facts, unbounded `MEMORY.md` growth past the
-injection budget. A separate, idle-triggered **L2 curator** evaluates the whole
-collection and dedups/prunes/consolidates/archives — the same role hermes'
-`agent/curator.py` plays. Its evaluation basis (usage telemetry + collection
-intrinsics) and trigger policy are out of scope here and tracked in a separate
-L2 issue.
+```
+# Skills (existing scopes, distinguished by origin)
+~/.gen/skills/<name>/
+├── SKILL.md            origin: agent-created | user-created
+├── references/         session-specific detail, condensed knowledge banks
+├── templates/          starter files meant to be copied
+└── scripts/            re-runnable actions (verification, fixtures)
 
-One L1-side implication worth noting now: L2's strongest signal will be **usage**
-(which skill was used, when), which gen-code doesn't record today. A light usage
-log can be added with L1 or just before L2 — flagged so it isn't forgotten.
+./.gen/skills/<name>/   project-level (same layout)
+
+# Memory (new "auto" source, machine-local, per-project)
+~/.gen/projects/<encoded-cwd>/memory/
+├── MEMORY.md           index, ≤200 lines / 25 KB injected
+├── debugging.md        topic file, read on demand
+└── ...
+```
 
 ---
 
-## 6. Phasing + prerequisites
+## 8. Why a later L2 curator (deferred)
 
-- **Phase 1 — L1 (this issue, #52).** Trigger + fork + direct memory/skill writes
-  + the three review prompts.
-  - Prereqs:
-    - `skill_manage` tool with patch semantics.
-    - A first-class memory writer to `~/.gen/projects/<project>/memory/MEMORY.md`.
-    - **Injection read side**: extend `LoadMemoryFiles` to load that store as a
-      new, distinct "auto" source (§3a) — it does not today, so without this L1
-      writes are never injected.
-- **Phase 2 — L2 curator (separate issue).** Deferred (see §5).
+L1 writes with a **local** view (one turn) and **frequently**. Across many
+turns the collection drifts in ways no single L1 write can fix:
+duplicate/overlapping entries, contradictions, stale facts, unbounded
+`MEMORY.md` growth past the injection budget. A separate, idle-triggered
+**L2 curator** evaluates the whole collection and dedups / prunes /
+consolidates / archives — the role Hermes' `agent/curator.py` plays. Its
+evaluation basis (usage telemetry + collection intrinsics) and trigger policy
+are out of scope here and tracked in a separate L2 issue.
 
-### Concrete next steps (Phase 1)
+One L1-side implication worth flagging now: L2's strongest signal will be
+**usage** (which skill was used when), which gen-code doesn't record today.
+A light usage log can land with L1 or just before L2 — flagged so it isn't
+forgotten.
 
-1. New package `internal/selflearn`: `Reviewer` (counters + turn observation +
-   trigger), `forkAgent(parent, snapshot, mode)` (restricted
-   `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
-2. `memory_write` (store at `~/.gen/projects/<project>/memory/`) + `skill_manage`
-   tools; extend `LoadMemoryFiles` to read the memory store.
-3. Review prompt templates (memory / skill / combined), rewritten for gen-code
+---
+
+## 9. Phasing + next steps
+
+**Phase 1 (this issue, #52)** — Trigger + fork + direct memory/skill writes
++ three review prompts.
+
+Prereqs:
+- `skill_manage` tool with patch semantics.
+- A first-class memory writer to `~/.gen/projects/<project>/memory/`.
+- **Injection read side**: extend `LoadMemoryFiles` to load that store as a
+  new, distinct "auto" source (§4) — without this, L1 writes are never injected.
+
+Concrete steps:
+1. New package `internal/selflearn`: `Reviewer` (counters + observation +
+   trigger), `forkAgent(parent, snapshot, mode)` (restricted `core.Agent`,
+   runs `ThinkAct`, surfaces one-line summary).
+2. `memory_write` + `skill_manage` tools; extend `LoadMemoryFiles` for the
+   "auto" source.
+3. Review prompt templates (memory / skill / combined) rewritten for gen-code
    terminology.
-4. Add the `selfLearn` settings section (`internal/setting`); wire-up in
-   `Task.Start` / `stopLocked` — start the reviewer only when ≥1 arm is enabled,
-   pass the enabled arms + intervals to it; gate reviews on `StopEndTurn`.
+4. Add the `selfLearn` settings section (§3.1); wire-up in `Task.Start` /
+   `stopLocked` — start the reviewer only when ≥1 arm is enabled, pass enabled
+   arms + intervals; gate reviews on `StopEndTurn`.
 5. Concurrency cap ≤1; drop-and-log on overlap.
 6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
    concurrency cap, restricted-toolset enforcement.
 
+**Phase 2 — L2 curator** (separate issue). Deferred; see §8.
+
 ---
 
-## 7. Open questions (L1)
+## 10. Open questions
 
-- **Let L1 patch user-authored skills?** Phase 1 default is no (L1 only writes
-  `origin: agent-created` skills). Hermes allows patching a just-used user skill
-  (its preference #1); revisit if "fix the skill I just used" turns out
-  important.
-- **Commit agent-created project skills?** They live in-repo at `./.gen/skills/`
-  mixed with user skills (distinguished by `origin`). Team choice whether to
-  commit auto-generated ones; can be filtered by the `origin` field if needed.
-- **Cache parity on non-Anthropic providers** — verify system-prompt inheritance
-  helps (or at least doesn't hurt) across gen-code's providers.
-- **Usage telemetry** — whether to land the minimal usage log in this phase (for
-  the future L2) or defer it entirely.
+- **User-level auto-memory?** Hermes has `USER.md` (global) alongside
+  `MEMORY.md`; Claude Code has user-level `~/.claude/CLAUDE.md` alongside
+  project `CLAUDE.md`. gen-code L1 currently writes only to project-partitioned
+  memory, so cross-project user persona ("I prefer terse output") would be
+  re-learned per repo. Options: (a) accept and let the user curate
+  `~/.gen/GEN.md` by hand; (b) extend L1 to choose user vs project level,
+  mirroring how skills already do. Recommend (b) once Phase 1 is stable.
+- **Let L1 patch user-authored skills?** Phase 1 default is no. Hermes allows
+  patching a just-used user skill (its preference #1); revisit if "fix the
+  skill I just used" turns out important.
+- **Commit agent-created project skills?** They live in-repo at
+  `./.gen/skills/` mixed with user skills (distinguished by `origin`). Team
+  choice whether to commit auto-generated ones; can be filtered by `origin`.
+- **Cache parity on non-Anthropic providers** — verify system-prompt
+  inheritance helps (or at least doesn't hurt) across gen-code's providers.
+- **Usage telemetry** — whether to land the minimal usage log in this phase
+  (for the future L2) or defer it entirely.
 
 ---
 
 ## References
 
-- hermes-agent L1: `agent/background_review.py` (fork, prompts, direct writes);
-  triggers in `agent/conversation_loop.py` (memory ~`:387–394`, skill
-  ~`:4046–4051`, guard `:4062`). L2 (for context): `agent/curator.py`
-  (idle-triggered maintenance).
-- Claude Code memory model: <https://code.claude.com/docs/en/memory> (in-band
-  contrast).
-- gen-code turn loop & outbox: `internal/core/agent_impl.go` (`Run`, `TurnEvent`,
-  `ThinkAct`).
-- gen-code injection side (built): `internal/reminder` providers, PostCompact
-  re-emit.
+- Hermes L1: `agent/background_review.py` (fork, prompts, direct writes);
+  triggers in `agent/conversation_loop.py` (memory `:387–394`, skill
+  `:4046–4051`, guard `:4062`). L2 (for context): `agent/curator.py`.
+- Claude Code memory model: <https://code.claude.com/docs/en/memory>.
+- gen-code turn loop & outbox: `internal/core/agent_impl.go`.
+- gen-code injection side (built): `internal/reminder` providers, PostCompact re-emit.
 - Session wire-up: `internal/agent/session.go` (`Task.Start`).
-- Permission model: `internal/agent/permission.go` (`PermissionBridge` — avoid),
-  `internal/tool/perm` (static funcs L1 uses).
+- Permission model: `internal/agent/permission.go` (`PermissionBridge` —
+  avoid), `internal/tool/perm` (static funcs L1 uses).
 - Parent issue: <https://github.com/genai-io/gen-code/issues/46>;
-  L1: <https://github.com/genai-io/gen-code/issues/52>
+  L1: <https://github.com/genai-io/gen-code/issues/52>.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -59,11 +59,36 @@ on its own and matches the production-proven hermes shape.
   *which* skill to update (see §3b), not *whether* to review — otherwise new
   skills for tasks that had no skill yet would never be learned.
 
-Both config-overridable; `0` disables that arm. Combined when both fire on the
-same turn. The trigger is a **pure event consumer** subscribed to
-`core.Agent.Outbox()`, reading `TurnEvent` (`Result.Turns`/`ToolUses`/
-`StopReason`). No `internal/core` changes; counters live in the consumer and
-hydrate from history on session resume.
+Combined when both fire on the same turn. The trigger is a **pure event
+consumer** subscribed to `core.Agent.Outbox()`, reading `TurnEvent`
+(`Result.Turns`/`ToolUses`/`StopReason`). No `internal/core` changes; counters
+live in the consumer and hydrate from history on session resume.
+
+**Configuration.** The two arms are toggled and tuned independently via
+`settings.json` (a new `selfLearn` section, merged across user/project/local
+layers like other gen-code settings):
+
+```json
+{
+  "selfLearn": {
+    "memory": { "enabled": false, "everyTurns": 10 },
+    "skills": { "enabled": false, "everyToolIters": 10 }
+  }
+}
+```
+
+- `memory.enabled` / `skills.enabled` — enable each arm separately. You can run
+  memory-evolving without skill-evolving and vice versa.
+- `memory.everyTurns` — memory cadence (user turns); `skills.everyToolIters` —
+  skill threshold (tool iterations this turn).
+- **When both arms are off, no L1 reviewer goroutine is started** — zero
+  overhead, no extra model calls, nothing written.
+- **Default: off (opt-in).** L1 forks an extra model call per cadence and writes
+  files automatically; ship it opt-in, then consider defaulting on once trusted
+  (Claude Code ships auto-memory on — we can match later). *(Default value is an
+  easily-changed decision.)*
+- Optional escape hatch: an env override (e.g. `GEN_DISABLE_SELF_LEARN=1`),
+  mirroring Claude Code's `CLAUDE_CODE_DISABLE_AUTO_MEMORY`.
 
 ---
 
@@ -265,7 +290,9 @@ log can be added with L1 or just before L2 — flagged so it isn't forgotten.
    tools; extend `LoadMemoryFiles` to read the memory store.
 3. Review prompt templates (memory / skill / combined), rewritten for gen-code
    terminology.
-4. Wire-up in `Task.Start` / `stopLocked`; gate on `StopEndTurn`.
+4. Add the `selfLearn` settings section (`internal/setting`); wire-up in
+   `Task.Start` / `stopLocked` — start the reviewer only when ≥1 arm is enabled,
+   pass the enabled arms + intervals to it; gate reviews on `StopEndTurn`.
 5. Concurrency cap ≤1; drop-and-log on overlap.
 6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
    concurrency cap, restricted-toolset enforcement.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -182,9 +182,9 @@ start**. Acceptable, since memory mainly serves future turns/sessions.
 
 > **Umbrella** = a broad, **class-level** skill (e.g. `go-testing`,
 > `code-review`) that accumulates many specific learnings over time — as opposed
-> to a **narrow, session-specific** skill (`fix-flaky-test-pr-1234`). The whole
-> flow prefers extending an umbrella over spawning narrow skills, so the
-> collection stays "broad and few", not "narrow and many".
+> to a **narrow, session-specific** skill (`fix-flaky-test-pr-1234`). It is a
+> naming convention, not a stored field — the flow prefers extending an umbrella
+> over spawning narrow skills, so the collection stays "broad and few".
 
 **Precondition (whether a skill review runs at all):** this turn did real work
 (tool-iters ≥ K, §2), the turn ended cleanly (`StopEndTurn`), and the skill arm
@@ -222,19 +222,16 @@ fix/extend an existing skill; `skill_manage(write_file, …)` to add a
 Patch the skill **in place**, at its existing scope.
 
 **CREATE — only when the learning is a genuinely new class of task no skill
-covers (③).** Last resort. `skill_manage(create, name, content)`; the name must
-be **class-level** (e.g. `go-table-tests`), never session-specific (no PR
-numbers, error strings, `fix-x-today`). Always written with
-`origin: agent-created`, at the level L1 chose (user vs project, below).
+covers (③).** Last resort. `skill_manage(create, name, content)` with
+`origin: agent-created`; the name must be **class-level** (e.g. `go-table-tests`),
+never session-specific (no PR numbers, error strings, `fix-x-today`). L1 picks
+the level: reusable/general → user (`~/.gen/skills/`), project-specific →
+project (`./.gen/skills/`).
 
 **NOTHING TO SAVE — when** the session ran smoothly with no correction and no
 new technique, or the only candidate is an **anti-pattern**: environment-
 dependent failures, negative claims about tools, transient errors, one-off task
 narratives.
-
-"Umbrella" is a **convention, not a data-model marker** — the decision flow
-above is what keeps the collection broad instead of sprouting one narrow skill
-per session.
 
 **Two levels (user + project), for both create and update.** gen-code already
 loads skills from two scopes — `ScopeUser` (`~/.gen/skills/`) and `ScopeProject`
@@ -250,14 +247,10 @@ unknown frontmatter). This mirrors hermes, which marks provenance with a flag,
 not a separate path. (A sidecar file is the alternative; a field is simpler for
 Phase 1.)
 
-- **On create**, L1 writes `origin: agent-created` and picks the level:
-  reusable/general → user (`~/.gen/skills/`); specific to this project →
-  project (`./.gen/skills/`). The review prompt encodes the rule.
-- **On update**, patch the skill **in place** (don't relocate or change scope).
-- **Scope of L1 writes (Phase 1):** L1 only creates/patches skills it owns
-  (`origin: agent-created`); it reads/consults `user-created` skills (to avoid
-  duplication) but does **not** modify them. The future L2 curator likewise only
-  manages `agent-created` skills, never the user's.
+**Scope of L1 writes (Phase 1):** L1 only creates/patches skills it owns
+(`origin: agent-created`); it reads `user-created` skills (to avoid duplication)
+but never modifies them. The future L2 curator likewise touches only
+`agent-created` skills.
 
 **Why this differs from memory:** memory is personal/accumulated → machine-local,
 project-partitioned, not in the repo. Skills are reusable artifacts a team may
@@ -274,8 +267,7 @@ in the file, prompting a clean re-read). Requires a unique match unless
 
 Three review prompts, picked by which triggers fired (memory-only / skill-only /
 combined). The skill prompt is **active** (most working sessions produce ≥1
-update) and embeds an anti-pattern list (no environment-dependent failures, no
-negative tool claims, no transient errors, no one-off task narratives).
+update) and embeds the anti-pattern list from NOTHING TO SAVE above.
 
 ---
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -1,0 +1,270 @@
+# Self-learning loop — design (L1 reflect, L2 curate)
+
+Design for the self-learning loop proposed in
+[#46](https://github.com/genai-io/gen-code/issues/46). [#52](https://github.com/genai-io/gen-code/issues/52)
+is Layer 1 (L1).
+
+**Decision after design discussion:** gen-code uses an **out-of-band** write
+model split into two stages — L1 *reflects and stages*, L2 *curates and
+commits*. L1 never writes memory/skills directly.
+
+This doc covers: how three systems approach self-evolving memory (horizontal
+comparison), the two-stage loop, what L1 reflects on, where reflections are
+stored, the trigger, the fork mechanics + invariants, and phasing.
+
+---
+
+## 1. How three systems do self-evolving memory (horizontal comparison)
+
+There are two fundamentally different places the "write memory" decision can
+live:
+
+- **In-band** — the *main* agent writes memory itself, mid-session, using its
+  file tools, on its own judgment.
+- **Out-of-band** — after a turn, a *separate* agent reviews the turn and
+  writes.
+
+| Axis | Hermes (`background_review.py`) | Claude Code (auto memory) | gen-code (decided) |
+|---|---|---|---|
+| Where the write decision lives | **Out-of-band**: forked review agent | **In-band**: the main agent | **Out-of-band**, two-stage |
+| When | After a turn (forked goroutine/thread) | During the session, whenever the model judges it worthwhile | After a turn (L1 fork) → periodically (L2 curator) |
+| Trigger | Cadence: user-turns (memory) + tool-iters (skills) | Model judgment + explicit "remember this" | Cadence (same two signals) for L1; threshold for L2 |
+| Who decides what to keep | A review prompt in the fork | The main agent with full live context | L1 fork proposes; **L2 decides what actually commits** |
+| Writes directly to memory/skills? | **Yes** (fork has the write tools) | Yes (main agent's own tool calls) | **No at L1** — L1 stages; L2 commits |
+| Extra model calls | Yes (one per review) | No (it's the main agent) | Yes (L1 fork + L2 curator) |
+| Storage | `MEMORY.md` + `USER.md` | `MEMORY.md` (index, first 200 lines/25KB loaded each session) + topic files (on demand) | injection already built (`GEN.md`/`CLAUDE.md` via reminder providers); + `.gen/reflections/` (L1 staging) and `.gen/memory/` (L2 output) |
+
+**What gen-code already has** (built in the reminder/compaction work): the
+*injection* side. Memory is loaded and re-injected as `<system-reminder>`
+blocks (`memory-user`/`memory-project`), refreshed from disk on PostCompact.
+What is missing is the *write/reflect* side — `internal/reminder` injects but
+never persists.
+
+**Why out-of-band + staged for gen-code** (first-principles, not "copy
+Hermes"):
+
+- In-band (Claude Code style) is cheapest and the decider has full context, but
+  it spends main-context tokens on a memory tool + MEMORY.md index every
+  session and relies on the model proactively self-writing. It also can only
+  *append* in the flow of work — it has no natural moment to step back and ask
+  "is the existing memory redundant / too big / stale?"
+- Out-of-band keeps the main turn clean and lets a dedicated prompt do a
+  thorough review. The cost (an extra model call) is acceptable because it runs
+  after the reply is delivered.
+- **Splitting reflect (L1) from commit (L2)** is the key refinement over
+  Hermes' direct-write fork. A single turn is a *local* view; durable
+  memory/skill edits should be made with a *global* view (the current memory in
+  full + multiple reflections). One observation may be noise; a pattern across
+  reflections is signal. Staging also keeps L1 low-risk: it only appends to a
+  journal and never corrupts the live memory, giving a clean audit trail. This
+  maps onto #46's existing L1/L2 layering.
+
+---
+
+## 2. The two-stage loop
+
+```
+┌──────── main agent.Run loop ────────┐
+│ ThinkAct → Result → emit TurnEvent  │   user gets the reply here
+└───────────────┬─────────────────────┘
+                │ TurnEvent on Outbox
+                ▼
+        L1 Reviewer (event consumer)
+        ├── counters (turns_since_memory, iters_since_skill)
+        ├── trigger check (Result.ToolUses, StopReason)
+        └── on fire → fork a fresh core.Agent
+                          │  reflect on the turn snapshot
+                          ▼
+              append ONE structured reflection record
+              to .gen/reflections/         ← stages, does NOT touch memory/skills
+
+        ... (later, on threshold / schedule) ...
+
+        L2 Curator
+        ├── reads accumulated reflections + current memory + current skills
+        ├── consolidates / dedupes / prunes / resolves contradictions
+        └── commits memory_write + skill_manage   ← the only writer of real memory/skills
+```
+
+- **L1 — reflect + stage** (this issue, #52). Per-turn, out-of-band fork.
+  Reflects on the just-finished turn and appends one reflection record. Never
+  writes memory/skills. Never blocks the user reply. Never busts the main
+  conversation's prefix cache.
+- **L2 — curate + commit** (next, separate issue). Periodic. Reads the staged
+  reflections together with the *current* memory/skill state and commits the
+  actual updates, with the global context needed to consolidate rather than
+  blindly append.
+
+---
+
+## 3. What L1 reflects on (targets)
+
+Three categories — not just skills/memory:
+
+1. **Memory candidates** — durable user/project facts: who the user is,
+   preferences, project conventions, build/debug insights.
+2. **Skill candidates** — "how to do this class of task": a procedure/workflow
+   update to an existing skill, or a new skill.
+3. **Self-assessment + memory/skill health (meta)** — the agent's
+   correctness / efficiency / effectiveness this turn (did it do well? wasted
+   steps? mistakes worth a durable lesson?), **and** observations about the
+   *existing* memory/skills (stale? redundant? `MEMORY.md` getting too big?).
+
+Category 3 is what makes this a *reflection* loop and not just an append loop:
+without it, L2 could only grow memory, never evaluate or prune it. It is the
+concrete form of "reflect on the current memory scale + the agent's
+correctness/efficiency/effectiveness."
+
+---
+
+## 4. Reflection record (L1 staging output)
+
+- **Location:** `.gen/reflections/` (append-only; one record per L1 fire).
+  Distinct from `.gen/memory/` (L2 output) and from user-curated skills.
+- **Format:** one file per record (e.g. `<timestamp>-<turn>.md`) with YAML
+  frontmatter + markdown body, so it is both machine-readable (L2) and
+  human-auditable.
+- **Suggested fields:**
+  - `turn_id`, `session_id`, `time`, `trigger` (memory | skill | combined)
+  - `memory_candidates`: proposed durable facts (each with a short rationale)
+  - `skill_candidates`: proposed skill updates/new skills (target skill, change)
+  - `self_assessment`: correctness / efficiency / effectiveness notes
+  - `memory_health`: observations on existing memory/skills (stale, redundant,
+    oversized) — input for L2 pruning
+- L2 consumes and may delete/compact processed records (open question on
+  retention).
+
+---
+
+## 5. Trigger — two signals (unchanged)
+
+L1 fires on two independent signals rather than one counter:
+
+| Review kind | Signal | Default | Rationale |
+|---|---|---|---|
+| Memory | user turns since last review | every 10 turns | User-modeling drifts on conversational cadence, not work intensity. |
+| Skills | tool iterations within the turn | when this turn ≥ 10 tool iters | Skill capture should fire when the agent actually *did* work; tool-iter count is the cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
+
+Both intervals are config-overridable; `0` disables that arm. Combined when
+both fire on the same turn.
+
+The trigger is a **pure event consumer** subscribed to `core.Agent.Outbox()`,
+reading `TurnEvent` (which already carries `Result.Turns`, `Result.ToolUses`,
+`Result.StopReason`). No `internal/core` changes needed; counters live in the
+consumer.
+
+---
+
+## 6. Fork mechanics + invariants
+
+The fork is a freshly-constructed `core.Agent` (`core.NewAgent`), **not**
+`subagent.Executor` (which is built for named, user-facing subagents with
+registry/hooks/session-persistence that a silent reviewer must not carry).
+
+Key change from the original draft: the L1 fork's only write tool is a
+**`reflection_write`** that appends to `.gen/reflections/`. It does **not** get
+`memory_write` / `skill_manage` — those belong to L2.
+
+Invariants (each one cost Hermes a production bug; we copy them):
+
+1. **Run AFTER the user reply is delivered.** Never compete with the main turn.
+2. **Inherit the parent's cached system prompt byte-for-byte** for prefix-cache
+   parity (Anthropic / OpenRouter). Hermes measured ~26% cost reduction.
+3. **Tool whitelist at dispatch time.** Fork's `tools[]` matches the parent (so
+   the cache key matches) but a static permission func denies everything except
+   `reflection_write`.
+4. **Auto-deny approval prompts** on the worker — use `tool.WithPermission`
+   (static), never `agent.PermissionBridge` (would deadlock against the TUI).
+5. **Best-effort only.** Wrap the spawn in recover; review failure must never
+   affect the user's session.
+6. **No session-scoped side effects** from the fork (no hooks, no session
+   persistence, no external memory plugins).
+7. **Suppress all status output.** Only a one-line summary surfaces:
+   `💾 Self-improvement review: <summary>` on the main outbox
+   (`MessageEvent`, `From: "l1-review"`). Silent on "nothing to record."
+8. **Hydrate counters from history on resume**, so cadence isn't reset by a
+   process restart.
+
+Module map:
+
+| Concern | Module |
+|---|---|
+| L1 trigger + fork | new `internal/selflearn/l1` (subscribes to `core.Agent.Outbox()`, owns counters, spawns forks) |
+| Wire-up | `internal/agent/session.go::Task.Start` (start consumer), `stopLocked` (tear down) |
+| Fork construction | `core.NewAgent` directly, restricted `core.Tools` |
+| System prompt inheritance | pass the parent's `system.System` instance verbatim |
+| Reflection write tool | new `reflection_write` → `.gen/reflections/` |
+| L2 curator (next phase) | new `internal/selflearn/l2`; `memory_write` + `skill_manage` |
+
+---
+
+## 7. Phasing
+
+- **Phase 1 — L1 reflect + stage (this issue, #52).** Trigger + fork +
+  `reflection_write` + reflection-record schema. Output: records in
+  `.gen/reflections/`. No live memory/skill writes yet.
+  - Prereq: a minimal reflection store (`.gen/reflections/` writer). This is
+    much lighter than the old prereqs because L1 no longer needs `memory_write`
+    or `skill_manage`.
+- **Phase 2 — L2 curate + commit (next, new issue).** Reads accumulated
+  reflections + current memory/skills; consolidates/prunes; commits via
+  `memory_write` + `skill_manage`.
+  - Prereqs (moved here from L1): `skill_manage` tool with patch semantics; a
+    first-class memory writer (`.gen/memory/MEMORY.md` + `USER.md`). gen-code's
+    injection side already reads these once they exist.
+
+This revises #52's original acceptance criteria, which had the L1 fork calling
+`memory_write` + `skill_manage` directly. Under the staged model, #52 = "reflect
++ stage"; the real writes move to the L2 issue.
+
+### Concrete next steps (Phase 1)
+
+1. New package `internal/selflearn/l1`: `Reviewer` (counters + Outbox
+   subscription + trigger), `forkAgent(parent, snapshot, mode)` (restricted
+   `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
+2. `reflection_write` tool + `.gen/reflections/` writer with the record schema
+   from §4.
+3. Reflection prompt templates (memory / skill / combined), rewritten for
+   gen-code terminology. Each must emit a structured reflection record, and
+   "nothing to record" is a valid output.
+4. Wire-up in `Task.Start` / `stopLocked`; gate on `Result.StopReason ==
+   StopEndTurn` (skip cancelled/interrupted/max-turns).
+5. Concurrency cap: ≤1 in-flight fork per session; drop new triggers while a
+   prior fork runs (log a warning, no queueing).
+6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
+   concurrency cap, reflection-record shape.
+
+---
+
+## 8. Open questions
+
+- **Reflection-record retention.** Does L2 delete processed records, or
+  compact them into a processed-archive? Avoid unbounded `.gen/reflections/`.
+- **L2 trigger.** Cadence (every N reflections), schedule, or on-demand
+  (`/curate`)? Out of scope for #52 but needs an answer before Phase 2.
+- **On-disk skill layout.** `.gen/skills/agent-created/` vs mixed with user
+  skills (so L2 lifecycle ops don't surprise the user).
+- **Cache parity on non-Anthropic providers.** Verify system-prompt
+  inheritance helps (or at least doesn't hurt) across gen-code's providers.
+- **Memory-health signal quality.** How reliably can a single-turn fork judge
+  "existing memory is redundant/stale" without loading the full memory? May
+  need to give the L1 fork read access to `MEMORY.md` (read-only) for category-3
+  reflection.
+
+---
+
+## References
+
+- Hermes-agent L1 reference: `agent/background_review.py`; triggers in
+  `agent/conversation_loop.py:432` (memory) and `:4191` (skills).
+- Claude Code memory model: <https://code.claude.com/docs/en/memory>
+  (CLAUDE.md vs auto memory; in-band agent-written memory).
+- gen-code turn loop & outbox: `internal/core/agent_impl.go` (`Run`,
+  `TurnEvent` emission, `ThinkAct`).
+- gen-code injection side (already built): `internal/reminder` providers
+  (`memory-user`/`memory-project`), PostCompact re-emit.
+- Session wire-up point: `internal/agent/session.go` (`Task.Start`).
+- Permission model: `internal/agent/permission.go` (`PermissionBridge` — what
+  L1 must avoid), `internal/tool/perm` (static permission funcs L1 uses).
+- Parent issue: <https://github.com/genai-io/gen-code/issues/46>;
+  L1: <https://github.com/genai-io/gen-code/issues/52>

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -95,27 +95,59 @@ layers like other gen-code settings):
 ## 3. What L1 writes — directly
 
 The write tools (`memory_write` + `skill_manage`) belong **only to the L1
-reviewer fork** in this phase. The main agent never writes memory/skills — it
-only reads/invokes them (existing skills-directory injection + skill-view).
-Because only the reviewer writes, provenance is simply **by location**: every
-L1 write lands under agent-created paths, kept apart from user-authored skills,
-so the future L2 curator can manage them without touching the user's. (Letting
-the main agent write — Hermes-style provenance flags — can come later.)
+reviewer fork** in this phase; the main agent reads/invokes skills and memory
+but never writes them. L1-written content is marked **agent-owned** — skills via
+the `origin: agent-created` frontmatter field (§3b), memory by living in its own
+dedicated store (§3a) — so the future L2 curator manages only agent-owned
+content and never the user's. (Letting the main agent write skills too can come
+later.)
 
-### 3a. Memory flow
+### 3a. Memory flow — when to add vs replace
 
-- Trigger: every N user turns (§2).
-- The reviewer reads the recent conversation history and extracts **durable
-  user/project facts** (preferences, project conventions, build/debug insights).
-- Writes via `memory_write` to a **user-level, project-partitioned** store:
-  `~/.gen/projects/<project>/memory/MEMORY.md` (+ topic files, Claude-Code-style:
-  a concise `MEMORY.md` index, detail files loaded on demand). `<project>` is
-  derived from the git repo so worktrees/subdirs of one repo share a store;
-  fall back to the project root outside a repo.
-- **Why user-level + project-partitioned, not in-repo**: it isolates memory per
-  project but keeps it **machine-local and out of the repo**, so there is no
-  commit/gitignore decision and no agent churn in git history. (This mirrors
-  Claude Code's auto-memory.) Append/replace entries; "Nothing to save." valid.
+**Precondition (whether a memory review runs):** the memory cadence is due
+(every N user turns, §2), the memory arm is enabled, and the turn ended cleanly
+(`StopEndTurn`). Unlike skills, this is a **turn cadence** — independent of how
+much work the turn did.
+
+**Inputs to the fork:** the conversation snapshot (the recent turns) + the
+memory-review prompt; the fork also **reads the current memory store** so it can
+refresh/dedupe rather than blindly append.
+
+```
+memory cadence due  (memory arm enabled)
+  │  StopEndTurn ?   ── no ──▶ skip (cancelled / interrupted)
+  ▼ yes
+memory review fork  (inherits system prompt; reads conversation snapshot +
+                     current MEMORY.md)
+  │
+  ▼
+a durable fact worth keeping?  (user preference, project convention,
+  │                             build/debug insight — NOT one-off task state)
+  │  no ──▶ Nothing to save
+  ▼ yes
+already an entry about this?
+  │  yes ──────────▶  memory_write(replace …)   refresh / correct it
+  ▼ no
+  └────────────────▶  memory_write(add …)       append new entry
+                          → ~/.gen/projects/<project>/memory/MEMORY.md
+```
+
+`memory_write` actions: `add`, `replace`, `remove`, operating on the memory
+store (the `MEMORY.md` index; long detail may spill into topic files like
+`debugging.md`, loaded on demand). "Nothing to save." is valid.
+
+**Anti-patterns (don't save):** one-off task state, transient errors,
+"what we did this session" narratives — those are not durable across sessions.
+
+**Store:** `~/.gen/projects/<project>/memory/MEMORY.md` (+ topic files,
+Claude-Code-style: concise index, details on demand). `<project>` is the **git
+repo root path, separators replaced** (the same encoding Claude Code uses, e.g.
+`-Users-me-work-gen-code`), so worktrees/subdirs of one repo share a store; fall
+back to the project root outside a repo.
+
+**Why user-level + project-partitioned, not in-repo:** isolates memory per
+project but keeps it **machine-local and out of the repo** — no commit/gitignore
+decision, no agent churn in git history. (Mirrors Claude Code's auto-memory.)
 
 **Injection integration (required).** `LoadMemoryFiles` currently reads only
 user-authored files (`GEN.md`/`CLAUDE.md`/rules); it does **not** read this
@@ -253,15 +285,24 @@ Fresh `core.Agent` (`core.NewAgent`) run with `ThinkAct` in a goroutine — **no
 `subagent.Executor` (which is built for named, user-facing subagents with
 registry/hooks/session-persistence a silent reviewer must not carry).
 
+**Construction & seeding:** the fork inherits the parent's `system.System`
+verbatim, is seeded with the parent's **message snapshot** (`SetMessages`) plus
+an injected user message carrying the review prompt, then runs `ThinkAct` under
+a **tight cap** — `MaxTurns ≈ 16` and a context deadline (≈5 min); drop the
+result if it exceeds either.
+
 Invariants (each one cost hermes a production bug):
 
 1. **Run AFTER the user reply is delivered.** Gate on `Result.StopReason ==
    StopEndTurn` (skip cancelled/interrupted/max-turns).
 2. **Inherit the parent's cached system prompt byte-for-byte** for prefix-cache
    parity (Anthropic/OpenRouter). Hermes measured ~26% cost reduction.
-3. **Tool whitelist at dispatch.** Fork's `tools[]` matches the parent (cache-key
-   parity) but a static permission func allows only `memory_write` +
-   `skill_manage`.
+3. **Toolset whitelist at dispatch.** Fork's `tools[]` matches the parent
+   (cache-key parity) but a static permission func allows only the **memory +
+   skill toolsets** — both **read and write**: it must read current memory and
+   list/view existing skills (to dedupe and choose add-vs-replace / patch-vs-
+   create), and write via `memory_write` / `skill_manage`. Everything else
+   denied.
 4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge` (would
    deadlock the TUI); auto-deny any approval.
 5. **Best-effort.** Wrap in recover; review failure never affects the user turn.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -148,6 +148,12 @@ start**. Acceptable, since memory mainly serves future turns/sessions.
 
 ### 3b. Skill flow — when to create vs update
 
+> **Umbrella** = a broad, **class-level** skill (e.g. `go-testing`,
+> `code-review`) that accumulates many specific learnings over time — as opposed
+> to a **narrow, session-specific** skill (`fix-flaky-test-pr-1234`). The whole
+> flow prefers extending an umbrella over spawning narrow skills, so the
+> collection stays "broad and few", not "narrow and many".
+
 **Precondition (whether a skill review runs at all):** this turn did real work
 (tool-iters ≥ K, §2), the turn ended cleanly (`StopEndTurn`), and the skill arm
 is enabled. The trigger is about *work done* — not about whether a skill was

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -1,270 +1,265 @@
-# Self-learning loop — design (L1 reflect, L2 curate)
+# Self-learning loop — design (L1 capture, L2 curate)
 
-Design for the self-learning loop proposed in
-[#46](https://github.com/genai-io/gen-code/issues/46). [#52](https://github.com/genai-io/gen-code/issues/52)
-is Layer 1 (L1).
+Design for the self-learning loop in [#46](https://github.com/genai-io/gen-code/issues/46).
+[#52](https://github.com/genai-io/gen-code/issues/52) is Layer 1 (L1).
 
-**Decision after design discussion:** gen-code uses an **out-of-band** write
-model split into two stages — L1 *reflects and stages*, L2 *curates and
-commits*. L1 never writes memory/skills directly.
+**Decision** (after comparing against the hermes-agent reference implementation
+at `agent/background_review.py` + `agent/curator.py`): gen-code uses an
+**out-of-band, two-layer** loop, aligned with how hermes does it in production:
 
-This doc covers: how three systems approach self-evolving memory (horizontal
-comparison), the two-stage loop, what L1 reflects on, where reflections are
-stored, the trigger, the fork mechanics + invariants, and phasing.
+- **L1 — per-turn capture (direct write).** After a turn, fork a fresh
+  `core.Agent` that reflects on the turn and writes memory/skill updates
+  **directly**. Useful on its own, the moment it ships.
+- **L2 — periodic curator (maintenance).** Runs on idle/schedule, not per turn.
+  Evaluates the *collection's* health and dedups / prunes / consolidates /
+  archives. Keeps the directly-written collection from drifting.
+
+This doc covers: the horizontal comparison, why L1 direct-write still needs L2,
+the L1 capture mechanics, the L2 evaluation basis, storage layout, and phasing.
 
 ---
 
 ## 1. How three systems do self-evolving memory (horizontal comparison)
 
-There are two fundamentally different places the "write memory" decision can
-live:
+Two fundamentally different places the "write memory" decision can live:
 
-- **In-band** — the *main* agent writes memory itself, mid-session, using its
-  file tools, on its own judgment.
-- **Out-of-band** — after a turn, a *separate* agent reviews the turn and
-  writes.
+- **In-band** — the *main* agent writes memory itself, mid-session, on its own
+  judgment, using its file tools.
+- **Out-of-band** — after a turn, a *separate* agent reviews and writes.
 
-| Axis | Hermes (`background_review.py`) | Claude Code (auto memory) | gen-code (decided) |
+| Axis | Hermes (`background_review.py` + `curator.py`) | Claude Code (auto memory) | gen-code (decided) |
 |---|---|---|---|
-| Where the write decision lives | **Out-of-band**: forked review agent | **In-band**: the main agent | **Out-of-band**, two-stage |
-| When | After a turn (forked goroutine/thread) | During the session, whenever the model judges it worthwhile | After a turn (L1 fork) → periodically (L2 curator) |
-| Trigger | Cadence: user-turns (memory) + tool-iters (skills) | Model judgment + explicit "remember this" | Cadence (same two signals) for L1; threshold for L2 |
-| Who decides what to keep | A review prompt in the fork | The main agent with full live context | L1 fork proposes; **L2 decides what actually commits** |
-| Writes directly to memory/skills? | **Yes** (fork has the write tools) | Yes (main agent's own tool calls) | **No at L1** — L1 stages; L2 commits |
-| Extra model calls | Yes (one per review) | No (it's the main agent) | Yes (L1 fork + L2 curator) |
-| Storage | `MEMORY.md` + `USER.md` | `MEMORY.md` (index, first 200 lines/25KB loaded each session) + topic files (on demand) | injection already built (`GEN.md`/`CLAUDE.md` via reminder providers); + `.gen/reflections/` (L1 staging) and `.gen/memory/` (L2 output) |
+| Write decision | **Out-of-band** review fork | **In-band** main agent | **Out-of-band**, aligned with Hermes |
+| When | After a turn (L1), + idle (L2 curator) | During the session, on model judgment | After a turn (L1), + idle (L2) |
+| L1 writes directly? | **Yes** — fork has memory + skill tools, persists immediately | Yes (main agent's own tool calls) | **Yes** (L1 captures directly) |
+| L2 role | Curator: archive stale / consolidate / pin-unpin / audit | (none — in-band only) | Curator: evaluate + dedup/prune/consolidate |
+| Trigger | turns (memory) + tool-iters (skill); curator on idle | model judgment + explicit "remember this" | same two signals; L2 on idle |
+| Storage | `~/.hermes/MEMORY.md` + `USER.md`; `~/.hermes/skills/<name>/` | `MEMORY.md` (index, first 200 lines/25KB loaded) + topic files | `.gen/memory/` + `.gen/skills/agent-created/` |
 
-**What gen-code already has** (built in the reminder/compaction work): the
-*injection* side. Memory is loaded and re-injected as `<system-reminder>`
+**What gen-code already has** (from the reminder/compaction work): the
+*injection* side — memory is loaded and re-injected as `<system-reminder>`
 blocks (`memory-user`/`memory-project`), refreshed from disk on PostCompact.
-What is missing is the *write/reflect* side — `internal/reminder` injects but
-never persists.
+What is missing is the *write* side (`internal/reminder` injects but never
+persists) and the *curation* side.
 
-**Why out-of-band + staged for gen-code** (first-principles, not "copy
-Hermes"):
+**Why out-of-band + direct-write for gen-code** (first-principles):
 
-- In-band (Claude Code style) is cheapest and the decider has full context, but
-  it spends main-context tokens on a memory tool + MEMORY.md index every
-  session and relies on the model proactively self-writing. It also can only
-  *append* in the flow of work — it has no natural moment to step back and ask
-  "is the existing memory redundant / too big / stale?"
-- Out-of-band keeps the main turn clean and lets a dedicated prompt do a
-  thorough review. The cost (an extra model call) is acceptable because it runs
-  after the reply is delivered.
-- **Splitting reflect (L1) from commit (L2)** is the key refinement over
-  Hermes' direct-write fork. A single turn is a *local* view; durable
-  memory/skill edits should be made with a *global* view (the current memory in
-  full + multiple reflections). One observation may be noise; a pattern across
-  reflections is signal. Staging also keeps L1 low-risk: it only appends to a
-  journal and never corrupts the live memory, giving a clean audit trail. This
-  maps onto #46's existing L1/L2 layering.
+- In-band (Claude Code) is cheapest and the decider has full context, but it
+  spends main-context tokens every session and only appends in the flow of
+  work — no natural moment to step back and prune. Out-of-band keeps the main
+  turn clean and lets a dedicated prompt review thoroughly after the reply.
+- **L1 writes directly** (rather than staging proposals for L2 to commit)
+  because direct write makes Phase 1 useful on its own and matches the
+  production-proven hermes shape. The churn risk of a local, frequent,
+  append-only writer is handled by L2, not by deferring all writes.
 
 ---
 
-## 2. The two-stage loop
+## 2. Two layers: capture (L1) → curate (L2)
 
-```
-┌──────── main agent.Run loop ────────┐
-│ ThinkAct → Result → emit TurnEvent  │   user gets the reply here
-└───────────────┬─────────────────────┘
-                │ TurnEvent on Outbox
-                ▼
-        L1 Reviewer (event consumer)
-        ├── counters (turns_since_memory, iters_since_skill)
-        ├── trigger check (Result.ToolUses, StopReason)
-        └── on fire → fork a fresh core.Agent
-                          │  reflect on the turn snapshot
-                          ▼
-              append ONE structured reflection record
-              to .gen/reflections/         ← stages, does NOT touch memory/skills
+Different **scope**, not just different cadence:
 
-        ... (later, on threshold / schedule) ...
+- **L1 = capture.** Local view (this one turn), frequent, additive. Good at
+  "spotting something new", blind to the collection as a whole.
+- **L2 = groundskeeper.** Global view (the whole memory/skill collection),
+  periodic, consolidating.
 
-        L2 Curator
-        ├── reads accumulated reflections + current memory + current skills
-        ├── consolidates / dedupes / prunes / resolves contradictions
-        └── commits memory_write + skill_manage   ← the only writer of real memory/skills
-```
+**Why direct-write L1 still needs L2.** Because L1 only ever sees one turn and
+writes immediately, over many turns the collection *drifts* in ways no single
+L1 write can fix:
 
-- **L1 — reflect + stage** (this issue, #52). Per-turn, out-of-band fork.
-  Reflects on the just-finished turn and appends one reflection record. Never
-  writes memory/skills. Never blocks the user reply. Never busts the main
-  conversation's prefix cache.
-- **L2 — curate + commit** (next, separate issue). Periodic. Reads the staged
-  reflections together with the *current* memory/skill state and commits the
-  actual updates, with the global context needed to consolidate rather than
-  blindly append.
+1. **Duplication / overlap** — L1 re-discovers and re-writes near-duplicate
+   entries/skills. L2 merges.
+2. **Contradiction / staleness** — a preference changes; a skill goes out of
+   date. L1 can't know "this conflicts with an older entry". L2 reconciles and
+   archives.
+3. **Unbounded growth** — direct appends bloat `MEMORY.md` past the injection
+   budget (first 200 lines / 25KB). L2 trims/compacts so the injected index
+   stays useful.
+4. **Reorg / promotion** — a one-off note may deserve promotion to an umbrella
+   skill; scattered notes get consolidated. L2 restructures.
+5. **Lifecycle** — pin/unpin, archive long-unused items.
+
+hermes uses `agent/curator.py` (idle-triggered, not per-turn) for exactly this.
 
 ---
 
-## 3. What L1 reflects on (targets)
+## 3. L1 — per-turn capture (this issue, #52)
 
-Three categories — not just skills/memory:
-
-1. **Memory candidates** — durable user/project facts: who the user is,
-   preferences, project conventions, build/debug insights.
-2. **Skill candidates** — "how to do this class of task": a procedure/workflow
-   update to an existing skill, or a new skill.
-3. **Self-assessment + memory/skill health (meta)** — the agent's
-   correctness / efficiency / effectiveness this turn (did it do well? wasted
-   steps? mistakes worth a durable lesson?), **and** observations about the
-   *existing* memory/skills (stale? redundant? `MEMORY.md` getting too big?).
-
-Category 3 is what makes this a *reflection* loop and not just an append loop:
-without it, L2 could only grow memory, never evaluate or prune it. It is the
-concrete form of "reflect on the current memory scale + the agent's
-correctness/efficiency/effectiveness."
-
----
-
-## 4. Reflection record (L1 staging output)
-
-- **Location:** `.gen/reflections/` (append-only; one record per L1 fire).
-  Distinct from `.gen/memory/` (L2 output) and from user-curated skills.
-- **Format:** one file per record (e.g. `<timestamp>-<turn>.md`) with YAML
-  frontmatter + markdown body, so it is both machine-readable (L2) and
-  human-auditable.
-- **Suggested fields:**
-  - `turn_id`, `session_id`, `time`, `trigger` (memory | skill | combined)
-  - `memory_candidates`: proposed durable facts (each with a short rationale)
-  - `skill_candidates`: proposed skill updates/new skills (target skill, change)
-  - `self_assessment`: correctness / efficiency / effectiveness notes
-  - `memory_health`: observations on existing memory/skills (stale, redundant,
-    oversized) — input for L2 pruning
-- L2 consumes and may delete/compact processed records (open question on
-  retention).
-
----
-
-## 5. Trigger — two signals (unchanged)
-
-L1 fires on two independent signals rather than one counter:
+### Trigger — two signals
 
 | Review kind | Signal | Default | Rationale |
 |---|---|---|---|
 | Memory | user turns since last review | every 10 turns | User-modeling drifts on conversational cadence, not work intensity. |
 | Skills | tool iterations within the turn | when this turn ≥ 10 tool iters | Skill capture should fire when the agent actually *did* work; tool-iter count is the cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
 
-Both intervals are config-overridable; `0` disables that arm. Combined when
-both fire on the same turn.
+Both config-overridable; `0` disables that arm. Combined when both fire on the
+same turn. The trigger is a **pure event consumer** subscribed to
+`core.Agent.Outbox()`, reading `TurnEvent` (`Result.Turns/ToolUses/StopReason`).
+No `internal/core` changes; counters live in the consumer and hydrate from
+history on resume.
 
-The trigger is a **pure event consumer** subscribed to `core.Agent.Outbox()`,
-reading `TurnEvent` (which already carries `Result.Turns`, `Result.ToolUses`,
-`Result.StopReason`). No `internal/core` changes needed; counters live in the
-consumer.
+### What L1 writes — directly
+
+- **Memory**: durable user/project facts → `.gen/memory/MEMORY.md` / `USER.md`.
+- **Skill**: how to do a class of task → `.gen/skills/agent-created/<name>/`
+  (create or patch an agent-created skill; never touch user-curated/pinned).
+
+Three review prompts picked by which triggers fired (memory-only / skill-only /
+combined). "Nothing to save" is valid; for skills it should not be the default.
+Skill prompt embeds an anti-pattern list (no environment-dependent failures, no
+negative tool claims, no transient errors, no one-off task narratives).
+
+### Fork mechanics + invariants
+
+Fresh `core.Agent` (`core.NewAgent`), **not** `subagent.Executor`. Invariants
+(each cost hermes a production bug):
+
+1. **Run AFTER the user reply is delivered**; gate on `Result.StopReason ==
+   StopEndTurn` (skip cancelled/interrupted/max-turns).
+2. **Inherit the parent's cached system prompt byte-for-byte** (prefix-cache
+   parity; hermes measured ~26% cost reduction).
+3. **Tool whitelist at dispatch**: fork's `tools[]` matches the parent (cache
+   key parity) but a static permission func allows only `memory_write` +
+   `skill_manage`.
+4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge`
+   (would deadlock the TUI); auto-deny any approval.
+5. **Best-effort**: wrap in recover; failure never affects the user turn.
+6. **No session-scoped side effects** (no hooks, no session persistence).
+7. **Suppress fork status**; only a one-line `💾 Self-improvement review:
+   <summary>` surfaces on the main outbox. Silent on "nothing to save".
+8. **≤1 in-flight fork per session**; drop new triggers while one runs (log,
+   no queue).
+
+### Emit usage telemetry (so L2 can evaluate later)
+
+L2's strongest evaluation signal is *usage* (see §4), and gen-code does not
+record it today. As part of normal operation (not the fork), record a light
+usage log: per-skill last-used / invoke count, and memory-recall hits. This is
+telemetry to *inform* L2 — distinct from the memory/skill writes themselves.
+Minimal hooks: skill invocation (Skill tool / reminder injection) and memory
+reference. Can land with L1 or just before L2.
 
 ---
 
-## 6. Fork mechanics + invariants
+## 4. L2 — periodic curator (next issue)
 
-The fork is a freshly-constructed `core.Agent` (`core.NewAgent`), **not**
-`subagent.Executor` (which is built for named, user-facing subagents with
-registry/hooks/session-persistence that a silent reviewer must not carry).
+Evaluates the collection's health, then dedups / prunes / consolidates /
+promotes / archives. Only touches agent-created / unprotected items.
 
-Key change from the original draft: the L1 fork's only write tool is a
-**`reflection_write`** that appends to `.gen/reflections/`. It does **not** get
-`memory_write` / `skill_manage` — those belong to L2.
+### Evaluation basis
 
-Invariants (each one cost Hermes a production bug; we copy them):
+**(A) Usage / behavioral data (dynamic — the strongest signal):**
+- skill activity: last-used time + frequency (archive long-idle; pin/unpin by
+  activity).
+- memory hit: was an entry ever recalled/relevant.
+- correction signals: a user correction attributable to a memory/skill entry is
+  strong evidence it is wrong → reconcile/remove.
 
-1. **Run AFTER the user reply is delivered.** Never compete with the main turn.
-2. **Inherit the parent's cached system prompt byte-for-byte** for prefix-cache
-   parity (Anthropic / OpenRouter). Hermes measured ~26% cost reduction.
-3. **Tool whitelist at dispatch time.** Fork's `tools[]` matches the parent (so
-   the cache key matches) but a static permission func denies everything except
-   `reflection_write`.
-4. **Auto-deny approval prompts** on the worker — use `tool.WithPermission`
-   (static), never `agent.PermissionBridge` (would deadlock against the TUI).
-5. **Best-effort only.** Wrap the spawn in recover; review failure must never
-   affect the user's session.
-6. **No session-scoped side effects** from the fork (no hooks, no session
-   persistence, no external memory plugins).
-7. **Suppress all status output.** Only a one-line summary surfaces:
-   `💾 Self-improvement review: <summary>` on the main outbox
-   (`MessageEvent`, `From: "l1-review"`). Silent on "nothing to record."
-8. **Hydrate counters from history on resume**, so cadence isn't reset by a
-   process restart.
+Requires the usage telemetry from §3; without it L2 can only do static
+evaluation.
 
-Module map:
+**(B) Collection intrinsics (static — model reads and judges):**
+- size vs injection budget (200 lines / 25KB) → trim/compact.
+- redundancy/overlap → merge.
+- contradiction → reconcile, keep newest.
+- dangling references / stale facts → fix or archive.
+- provenance/protection → what L2 is allowed to change.
 
-| Concern | Module |
+### Maps to the original reflection dimensions
+
+| Dimension | L2 basis |
 |---|---|
-| L1 trigger + fork | new `internal/selflearn/l1` (subscribes to `core.Agent.Outbox()`, owns counters, spawns forks) |
-| Wire-up | `internal/agent/session.go::Task.Start` (start consumer), `stopLocked` (tear down) |
-| Fork construction | `core.NewAgent` directly, restricted `core.Tools` |
-| System prompt inheritance | pass the parent's `system.System` instance verbatim |
-| Reflection write tool | new `reflection_write` → `.gen/reflections/` |
-| L2 curator (next phase) | new `internal/selflearn/l2`; `memory_write` + `skill_manage` |
+| scale | size vs injection budget (static) |
+| effective | usage: used? helped? (dynamic) |
+| correct | contradiction + correction signals |
+| efficient | redundancy/overlap (lean collection) |
+
+### How it decides
+
+Hybrid: **hard heuristics** (deterministic, cheap: "idle 30 days → archive
+candidate", "over budget → must trim", "protected → never touch") +
+**LLM judgment** (semantic: "do these two skills overlap?", "which contradicting
+memory wins?", "promote to umbrella?"). L2 is a periodic agent run that reads
+the whole collection + the usage log, produces an assessment, then executes.
+
+### Trigger
+
+Idle/periodic (e.g. idle ≥ N hours and ≥ M since last run), not per-turn.
+Exact policy TBD (open question).
 
 ---
 
-## 7. Phasing
+## 5. Storage layout
 
-- **Phase 1 — L1 reflect + stage (this issue, #52).** Trigger + fork +
-  `reflection_write` + reflection-record schema. Output: records in
-  `.gen/reflections/`. No live memory/skill writes yet.
-  - Prereq: a minimal reflection store (`.gen/reflections/` writer). This is
-    much lighter than the old prereqs because L1 no longer needs `memory_write`
-    or `skill_manage`.
-- **Phase 2 — L2 curate + commit (next, new issue).** Reads accumulated
-  reflections + current memory/skills; consolidates/prunes; commits via
-  `memory_write` + `skill_manage`.
-  - Prereqs (moved here from L1): `skill_manage` tool with patch semantics; a
-    first-class memory writer (`.gen/memory/MEMORY.md` + `USER.md`). gen-code's
-    injection side already reads these once they exist.
+| What | Path | Writer |
+|---|---|---|
+| Agent memory | `.gen/memory/MEMORY.md` | L1 writes, L2 maintains |
+| User profile | `.gen/memory/USER.md` | L1 writes, L2 maintains |
+| Agent-created skills | `.gen/skills/agent-created/<name>/` | L1 writes, L2 maintains |
+| Usage log | `.gen/usage/` (or similar) | normal operation; L2 reads |
 
-This revises #52's original acceptance criteria, which had the L1 fork calling
-`memory_write` + `skill_manage` directly. Under the staged model, #52 = "reflect
-+ stage"; the real writes move to the L2 issue.
+Agent-created skills stay isolated from user-curated ones so L2 lifecycle ops
+(archive/consolidate) never surprise the user. Injection already reads
+`GEN.md`/`CLAUDE.md` via reminder providers; `.gen/memory/MEMORY.md` slots into
+the same injection path.
+
+---
+
+## 6. Phasing + prerequisites
+
+- **Phase 1 — L1 capture (this issue, #52).** Trigger + fork + direct
+  memory/skill writes + the three review prompts. Useful on its own.
+  - Prereqs: `skill_manage` tool with patch semantics; a first-class memory
+    writer (`.gen/memory/MEMORY.md` + `USER.md`). (These move back to L1 since
+    L1 now writes directly.)
+- **Phase 2 — L2 curator (next, new issue).** Evaluation (usage + intrinsics) +
+  dedup/prune/consolidate/archive.
+  - Prereq: usage telemetry (§3) for activity-based evaluation.
 
 ### Concrete next steps (Phase 1)
 
 1. New package `internal/selflearn/l1`: `Reviewer` (counters + Outbox
    subscription + trigger), `forkAgent(parent, snapshot, mode)` (restricted
    `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
-2. `reflection_write` tool + `.gen/reflections/` writer with the record schema
-   from §4.
-3. Reflection prompt templates (memory / skill / combined), rewritten for
-   gen-code terminology. Each must emit a structured reflection record, and
-   "nothing to record" is a valid output.
-4. Wire-up in `Task.Start` / `stopLocked`; gate on `Result.StopReason ==
-   StopEndTurn` (skip cancelled/interrupted/max-turns).
-5. Concurrency cap: ≤1 in-flight fork per session; drop new triggers while a
-   prior fork runs (log a warning, no queueing).
-6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
-   concurrency cap, reflection-record shape.
+2. `memory_write` + `skill_manage` tools (Phase-1 prereqs) and their stores
+   under `.gen/`.
+3. Review prompt templates (memory / skill / combined), rewritten for gen-code
+   terminology.
+4. Wire-up in `Task.Start` / `stopLocked`; gate on `StopEndTurn`.
+5. Concurrency cap ≤1; drop-and-log on overlap.
+6. Light usage telemetry hooks (so L2 has data when it ships).
+7. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
+   concurrency cap, restricted-toolset enforcement.
 
 ---
 
-## 8. Open questions
+## 7. Open questions
 
-- **Reflection-record retention.** Does L2 delete processed records, or
-  compact them into a processed-archive? Avoid unbounded `.gen/reflections/`.
-- **L2 trigger.** Cadence (every N reflections), schedule, or on-demand
-  (`/curate`)? Out of scope for #52 but needs an answer before Phase 2.
-- **On-disk skill layout.** `.gen/skills/agent-created/` vs mixed with user
-  skills (so L2 lifecycle ops don't surprise the user).
-- **Cache parity on non-Anthropic providers.** Verify system-prompt
-  inheritance helps (or at least doesn't hurt) across gen-code's providers.
-- **Memory-health signal quality.** How reliably can a single-turn fork judge
-  "existing memory is redundant/stale" without loading the full memory? May
-  need to give the L1 fork read access to `MEMORY.md` (read-only) for category-3
-  reflection.
+- **L2 trigger policy** (idle thresholds / schedule / on-demand `/curate`).
+- **On-disk skill layout** confirmation (`.gen/skills/agent-created/`).
+- **Usage-telemetry shape** — what exactly to log, where, retention.
+- **Cache parity on non-Anthropic providers** — verify system-prompt
+  inheritance helps (or doesn't hurt) across gen-code's providers.
+- **Concurrency across writers** — L1 fork(s) vs a running L2 writing the same
+  files; serialize or atomic-replace.
 
 ---
 
 ## References
 
-- Hermes-agent L1 reference: `agent/background_review.py`; triggers in
-  `agent/conversation_loop.py:432` (memory) and `:4191` (skills).
+- hermes-agent L1: `agent/background_review.py` (fork, prompts, direct writes);
+  triggers in `agent/conversation_loop.py` (memory ~`:387–394`, skill
+  ~`:4046–4051`, guard `:4062`); L2 curator: `agent/curator.py`
+  (idle-triggered: archive stale / consolidate / pin-unpin / audit).
 - Claude Code memory model: <https://code.claude.com/docs/en/memory>
-  (CLAUDE.md vs auto memory; in-band agent-written memory).
+  (CLAUDE.md vs in-band auto memory).
 - gen-code turn loop & outbox: `internal/core/agent_impl.go` (`Run`,
-  `TurnEvent` emission, `ThinkAct`).
-- gen-code injection side (already built): `internal/reminder` providers
-  (`memory-user`/`memory-project`), PostCompact re-emit.
-- Session wire-up point: `internal/agent/session.go` (`Task.Start`).
-- Permission model: `internal/agent/permission.go` (`PermissionBridge` — what
-  L1 must avoid), `internal/tool/perm` (static permission funcs L1 uses).
+  `TurnEvent`, `ThinkAct`).
+- gen-code injection side (built): `internal/reminder` providers, PostCompact
+  re-emit.
+- Session wire-up: `internal/agent/session.go` (`Task.Start`).
+- Permission model: `internal/agent/permission.go` (`PermissionBridge` — avoid),
+  `internal/tool/perm` (static funcs L1 uses).
 - Parent issue: <https://github.com/genai-io/gen-code/issues/46>;
   L1: <https://github.com/genai-io/gen-code/issues/52>

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -10,6 +10,8 @@ main turn's prompt cache. Collection-level grooming (dedup, contradictions,
 unbounded growth) is the job of a later **L2 curator**, designed in its own
 issue (rationale in §8).
 
+**Contents.** [§1 Compare](#1-three-systems-compared) · [§2 Architecture](#2-architecture) · [§3 Trigger](#3-trigger--two-arms) · [§4 Memory](#4-memory-flow) · [§5 Skill](#5-skill-flow) · [§6 Fork & UI](#6-fork-mechanics--invariants) · [§7 Filesystem](#7-filesystem-layout) · [§8 L1 vs L2](#8-l1-vs-l2--where-grooming-lives) · [§9 Phasing](#9-phasing--next-steps) · [§10 Open questions](#10-open-questions)
+
 ---
 
 ## 1. Three systems compared
@@ -53,7 +55,7 @@ sequenceDiagram
     F->>S: read existing entries
     F->>S: memory_write / skill_manage
     F-->>R: actions summary
-    R-->>U: 💾 Self-improvement review: one-line summary
+    R-->>U: Self-improvement review (recap block)
 ```
 
 Key points the diagram encodes:
@@ -165,12 +167,12 @@ flowchart TD
     R0 --> C{durable new fact<br/>worth keeping?}
     C -- no --> Z[Nothing to save]
     C -- yes --> H{index near<br/>25 KB hard cap?}
-    H -- yes --> P1[must prune more first<br/>before this write fits]
+    H -- yes --> P1[loop: pick another<br/>entry to retire]
     H -- no --> D{existing entry<br/>covers it?}
     D -- yes --> R1[memory_write replace]
     D -- no --> N[memory_write add]
-    P1 --> ALL[~/.gen/projects/&lt;project&gt;/memory/]
-    R1 --> ALL
+    P1 -. retry .-> S
+    R1 --> ALL[~/.gen/projects/&lt;project&gt;/memory/]
     N --> ALL
 ```
 
@@ -319,21 +321,28 @@ flowchart TD
     E -- no --> Z[Nothing to save]
 ```
 
-**UPDATE preferred over CREATE.** Keeps the library broad and avoids
-near-duplicates. `skill_manage(patch, …)` to fix/extend;
-`skill_manage(write_file, …)` to add a `references/` / `templates/` /
-`scripts/` support file (plus a pointer line in `SKILL.md`). Patch in place,
-at the existing scope.
+**Trigger conditions per action.** Within a review pass, the model picks an
+action only when the semantic conditions below hold. The permission layer
+(§5.5) then allows or vetoes each dispatch.
 
-**DELETE when superseded.** `skill_manage(delete, name)`. Triggers:
-- the new learning supersedes the whole skill (replace rather than coexist);
-- the skill encoded a transient/environment-dependent failure that has since
-  been fixed (the skill is now wrong);
-- the skill turned out to encode an anti-pattern.
+| Action | Semantic triggers | Permission · Allowed targets |
+|---|---|---|
+| **CREATE** | **All four:** ① turn produced a non-trivial, generalizable technique / fix / pattern; ② **no** existing skill (agent OR user) covers this class; ③ name is class-level (`go-table-tests` ✅, `fix-pr-1234` ❌); ④ not an anti-pattern (env-dependent failure, tool negative claim, transient error, one-off narrative). | `allowCreate=true` · `agent-created` only |
+| **UPDATE** | **Any one:** ① a skill loaded / consulted this turn was proven wrong / incomplete / outdated; ② an existing umbrella skill covers the new learning; ③ user voiced a style / format / workflow correction that belongs in the skill governing that task. | `allowUpdate=true` · `agent-created`, plus `user-created` iff `allowUpdateUserCreated=true` |
+| **DELETE** | **Any one:** ① superseded wholesale — the new learning replaces the entire skill; ② transient / environment-dependent failure the skill encoded is now resolved (skill is now wrong); ③ skill turned out to encode an anti-pattern. | `allowDelete=true` · `agent-created` only (no config opens user-created) |
 
-**CREATE is the last resort.** Names must be **class-level** (`go-table-tests`,
-not `fix-pr-1234`). The level decision is in the diagram: reusable / general
-→ user (`~/.gen/skills/`), project-specific → project (`./.gen/skills/`).
+A single pass may chain multiple actions (e.g. delete one obsolete + patch
+one umbrella + create one new); each is independently evaluated. The
+preference order is **UPDATE > DELETE > CREATE** — keeps the library broad
+and avoids near-duplicates.
+
+**Tool surface per action.** UPDATE uses `skill_manage(patch, …)` to
+fix/extend, or `skill_manage(write_file, …)` to add a `references/` /
+`templates/` / `scripts/` support file (plus a pointer line in `SKILL.md`).
+DELETE uses `skill_manage(delete, name)`. CREATE uses
+`skill_manage(create, name, content, level)` where the **level**
+(`~/.gen/skills/` user-wide vs `./.gen/skills/` project) follows the
+diagram's *reusable across projects?* branch.
 
 ### 5.2 Provenance and L1 write scope
 
@@ -419,14 +428,17 @@ Eight invariants, each one cost Hermes a production bug:
 3. **Toolset whitelist at dispatch.** `tools[]` matches the parent (cache-key
    parity); a static permission func allows only the **memory + skill
    toolsets** (read *and* write — needs read for dedupe). All else denied.
+   Within `skill_manage`, individual actions are **further gated** by the
+   §5.5 boolean permissions.
 4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge`
    (would deadlock the TUI). Approvals auto-deny.
 5. **Best-effort.** Wrap in `recover`; review failure never affects the user
    turn.
 6. **No session-scoped side effects** (no hooks, no session persistence).
-7. **Suppress fork status.** Only one line surfaces on the main outbox:
-   `💾 Self-improvement review: <summary>` (`MessageEvent`,
-   `From: "l1-review"`). Silent on "Nothing to save."
+7. **Suppress fork status.** Fork's internal events stay private; the only
+   thing reaching the main outbox is the delimiter-bounded recap defined in
+   §"User-visible surface" (`MessageEvent`, `From: "l1-review"`), plus the
+   live status-bar tail. Silent on "Nothing to save."
 8. **≤1 in-flight fork per session.** Drop new triggers while one runs (log,
    no queue). Counters are **not** reset on drop — the threshold stays
    tripped and re-fires next clean turn.
@@ -571,7 +583,9 @@ Concrete steps:
    arms + intervals; gate reviews on `StopEndTurn`.
 5. Concurrency cap ≤1; drop-and-log on overlap.
 6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
-   concurrency cap, restricted-toolset enforcement.
+   concurrency cap, restricted-toolset enforcement, **permission gate** (each
+   legal §5.5 combination behaves as expected; the three illegal combinations
+   from §3.1 are rejected at startup; `allowUpdateUserCreated` toggle).
 
 **Phase 2 — L2 curator** (separate issue). Deferred; see §8.
 

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -85,7 +85,7 @@ flowchart TD
 | Arm | Signal | Default | Why this signal |
 |---|---|---|---|
 | Memory | user turns since last review | every **10** user turns | User-modelling drifts on conversational cadence, not work intensity. |
-| Skills | tool iterations **this turn** | when turn ≥ **10** tool-iters | Skill capture should fire when the agent actually *did* work; tool-iters is a cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
+| Skills | **accumulated** tool iterations **since last skill review** | total ≥ **10** tool-iters since last review | Skill capture should fire after meaningful cumulative work; tool-iters is a cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
 
 Both arms count independently and may fire on the same turn (combined prompt).
 Counters live in the reviewer and **hydrate from history on session resume**
@@ -93,30 +93,55 @@ Counters live in the reviewer and **hydrate from history on session resume**
 
 ### 3.1 Configuration
 
-The two arms are toggled and tuned independently via `settings.json` (a new
-`selfLearn` section, merged across user / project / local layers like other
-gen-code settings):
+Settings live under `selfLearn` in `settings.json`, merged across user /
+project / local layers like other gen-code settings.
 
 ```json
 {
   "selfLearn": {
-    "memory": { "enabled": false, "everyTurns": 10 },
-    "skills": { "enabled": false, "everyToolIters": 10 }
+    "memory": {
+      "enabled": false,
+      "everyTurns": 10,
+      "maxKB": 25
+    },
+    "skills": {
+      "enabled": false,
+      "everyToolIters": 10,
+      "allowCreate": true,
+      "allowUpdate": true,
+      "allowDelete": true,
+      "allowUpdateUserCreated": false
+    }
   }
 }
 ```
 
-- `memory.enabled` / `skills.enabled` — enable each arm separately. Running
-  memory-evolving without skill-evolving (or vice versa) is supported.
-- `memory.everyTurns` — memory cadence in user turns.
-- `skills.everyToolIters` — skill threshold in tool iterations this turn.
-- **When both arms are off, no reviewer goroutine is started** — zero
-  overhead, no extra model calls, nothing written.
-- **Default: off (opt-in).** L1 forks an extra model call per cadence and
-  writes files automatically; ship opt-in, default-on later once trusted
-  (Claude Code ships auto-memory on — we can match).
-- Optional escape hatch: env override `GEN_DISABLE_SELF_LEARN=1`, mirroring
-  Claude Code's `CLAUDE_CODE_DISABLE_AUTO_MEMORY`.
+**Fields.**
+
+| Field | Default | Meaning |
+|---|---|---|
+| `memory.enabled` / `skills.enabled` | `false` | Independently toggle each arm. Both off ⇒ no reviewer goroutine, zero overhead. |
+| `memory.everyTurns` | 10 | Memory cadence in user turns. |
+| `memory.maxKB` | 25 | Hard cap on every memory file. Default = injection cap; lower values force more aggressive pruning. May not exceed 25 (would break the §4.2 invariant). 1 KB ≈ 180 EN words ≈ 340 中文字 (UTF-8). |
+| `skills.everyToolIters` | 10 | Cumulative tool-iters since last skill review (§3 table). |
+| `skills.allowCreate` | `true` | L1 may create new agent-created skills. |
+| `skills.allowUpdate` | `true` | L1 may patch existing agent-created skills. |
+| `skills.allowDelete` | `true` | L1 may delete agent-created skills (never user-created). |
+| `skills.allowUpdateUserCreated` | `false` | Advanced opt-in: extends `allowUpdate` to also patch user-created skills (§5.5). |
+
+**Startup validation** rejects three illegal combinations:
+
+| Rejected | Reason |
+|---|---|
+| `allowCreate=true, allowUpdate=false` | Created skills could never be refined → unfixable errors accumulate. |
+| `allowCreate=true, allowUpdate=true, allowDelete=false` | "Only-add, never-subtract" violates §4.1 / §5.1 retire policy. |
+| `allowUpdateUserCreated=true, allowUpdate=false` | Depends on `allowUpdate`; combination is meaningless. |
+
+**Default off (opt-in).** L1 forks an extra model call per cadence and writes
+files automatically; ship opt-in, default-on later once trusted.
+
+**Env override.** `GEN_DISABLE_SELF_LEARN=1` disables everything regardless of
+config, mirroring Claude Code's `CLAUDE_CODE_DISABLE_AUTO_MEMORY`.
 
 ---
 
@@ -158,16 +183,24 @@ flagged in the prompt as suspect.
 
 ### 4.2 Size budgets
 
-| What | Cap | Where enforced | Behavior at cap |
+| What | Cap | Source | At cap |
 |---|---|---|---|
-| Single memory file on disk (index or topic) | **25 000 chars (~25 KB)** | `internal/selflearn/memory.go memoryFileCharLimit` | `memory_write add/replace` returns an error; the reviewer must prune first |
-| `MEMORY.md` injected into system prompt | **25 KB (25 × 1024 bytes)** — matches Claude Code | `internal/core/system/memory.go autoMemoryByteCap` | Truncated on a line boundary with a marker |
-| Topic file count | none yet | — | Review prompt biases toward consolidation; flagged in §10 for L2 |
+| Single memory file on disk (index or topic) | **`memory.maxKB`** (default 25 KB, user-lowerable per §3.1) | `internal/selflearn/memory.go memoryFileCharLimit` | `memory_write add/replace` returns an error; reviewer must prune first |
+| `MEMORY.md` injected into system prompt | **25 KB** — matches Claude Code | `internal/core/system/memory.go autoMemoryByteCap` | Truncated on a line boundary |
+| Topic file count | unbounded (see §10) | — | Review prompt biases toward consolidation |
 
-**Invariant (intentional).** The on-disk per-file cap **equals** the injection
-cap. Anything that fits on disk fits when injected, so L1 never produces a
-file the loader has to truncate. The hard write cap is a safety net; the
-review prompt is the active policy.
+**Invariant.** `memory.maxKB ≤ 25 KB` is enforced at config load. So the
+on-disk per-file cap is always ≤ the injection cap, and L1 never produces a
+file the loader has to truncate.
+
+**Capacity reference.**
+
+| `maxKB` | ≈ EN words | ≈ 中文字 (UTF-8) | Feel |
+|---|---|---|---|
+| 5 | 900 | 1 700 | short note |
+| 10 | 1 800 | 3 400 | short blog post |
+| 15 | 2 700 | 5 100 | long blog post |
+| 25 *(default)* | 4 500 | 8 500 | short report |
 
 ### 4.3 Store anatomy
 
@@ -246,6 +279,21 @@ cache and waste the parity savings from §6 invariant #2.
 > naming convention, not a stored field — the flow prefers extending an
 > umbrella over spawning narrow skills so the library stays "broad and few".
 
+### 5.0 Trigger layers
+
+Three independent layers gate every skill action:
+
+| Layer | Decides | Where |
+|---|---|---|
+| **Cadence** | Whether *any* review pass runs at all | `Reviewer.Observe`: `itersSinceSkill >= everyToolIters` (§3) |
+| **Semantic** | Which action (create / update / delete) and on which target | Review prompt + model judgment, against §5.1 flow |
+| **Permission** | Final allow / deny of each tool call | `skill_manage` dispatch checks `allowCreate / allowUpdate / allowDelete` (§5.5) |
+
+Cadence triggers a pass; semantic decides what to attempt; permission can
+veto each tool call. The review prompt is assembled per-config so the model
+doesn't waste turns proposing forbidden actions — but the permission layer
+remains the hard floor.
+
 ### 5.1 Decision flow — UPDATE / DELETE / CREATE
 
 L1 must **retire**, not only add. A skill the conversation just proved wrong,
@@ -294,10 +342,12 @@ not `fix-pr-1234`). The level decision is in the diagram: reusable / general
 struct grows one field (`Origin string`). Skills live directly in gen-code's
 existing two scopes — no `agent-created/` subdir, no loader change.
 
-**Scope of L1 writes (Phase 1).** L1 creates / patches / **deletes** only
-`origin: agent-created` skills. It **reads** user-created skills (to avoid
-duplication) but never modifies or deletes them. The future L2 likewise
-touches only agent-owned content.
+**Scope of L1 writes.** By default L1 creates / patches / **deletes** only
+`origin: agent-created` skills. It reads user-created skills (to avoid
+duplication) but never modifies or deletes them. The single exception is the
+advanced opt-in `allowUpdateUserCreated` (§5.5), which extends `patch` to
+user-created — create and delete on user-created **remain impossible at any
+config setting**.
 
 ### 5.3 Tool surface
 
@@ -323,6 +373,31 @@ prompt's preference order; the hard guarantee against drift comes from L2.
 **Three review prompts**, picked by which arms fired (memory / skill /
 combined). The skill prompt is **active** (most working sessions produce ≥1
 update or retirement) and embeds the anti-pattern list.
+
+### 5.5 Action permissions
+
+Three booleans + one advanced opt-in (see §3.1) control what L1 may do.
+The first three operate **only on `origin: agent-created`** skills.
+
+Meaningful combinations:
+
+| `create` | `update` | `delete` | What L1 does |
+|---|---|---|---|
+| ✅ | ✅ | ✅ | *Default.* Grows and maintains its own subset. |
+| ❌ | ✅ | ✅ | Freezes the set; only refines and prunes. |
+| ❌ | ✅ | ❌ | Most conservative; only patches existing. |
+| ❌ | ❌ | ❌ | Equivalent to `enabled: false`. |
+
+Of the 8 boolean tuples: 4 meaningful, 2 rejected at startup (§3.1), 2 no-ops.
+
+**`allowUpdateUserCreated`** is the single door that lets `allowUpdate`
+extend to user-created skills (Hermes-style "patch the skill just used"). It
+is off by default; turning it on rewrites user-authored files when warranted
+by the §5.1 flow.
+
+**Prompt synthesis.** Disallowed actions are stripped from the review prompt
+so the model doesn't propose them. `allowUpdateUserCreated=true` swaps in
+"patch any loaded skill including user-authored" as the top preference.
 
 ---
 
@@ -367,6 +442,58 @@ Eight invariants, each one cost Hermes a production bug:
 | Writes | `memory_write` → `~/.gen/projects/<project>/memory/`; `skill_manage` → `~/.gen/skills/<name>/` (user) or `./.gen/skills/<name>/` (project), with `origin: agent-created` |
 | Provenance | add `Origin` to skill frontmatter struct (`internal/skill/types.go`); absent ⇒ `user-created` |
 | Injection read | memory: extend `LoadMemoryFiles` with a new "auto" source. Skills: no change (existing user/project loader covers it). |
+
+### User-visible surface
+
+Three places the user encounters self-learning.
+
+**Settings — `/config` Self-Learning panel.** `/config` opens a multi-panel
+settings page (left sidebar + right pane); Self-Learning is one panel among
+others (Provider, Permissions, Appearance, …). The panel groups §3.1
+config into two sections (Memory / Skills) with checkboxes for the three
+skill permissions; `allowUpdateUserCreated` lives under a collapsed
+**Advanced** with a ⚠ "rewrites your authored files" caption.
+
+Panel rules:
+- Sub-fields grey out while the section's `enabled` is off.
+- `maxKB` field shows live equivalence: `⟨25⟩ ≈ 4500 EN words / 8500 中文字`.
+- Illegal config combinations (§3.1) surface as inline warnings; save is
+  disabled until resolved.
+- Panels with unsaved changes get a `•` marker in the sidebar.
+
+**Runtime — status bar.** Hidden while idle. Surfaces only during an active
+review or the brief post-completion window. Label is single-word `evolving`
+(gerund — echoes the project theme); a braille spinner conveys activity;
+the target name comes from the fork's most recent tool call.
+
+| State | Status bar shows | Duration |
+|---|---|---|
+| Idle / disabled | — | hidden |
+| Review just started | `evolving ⠋` | until first tool call |
+| Fork called `skill_manage(name=X)` | `evolving ⠋ X` | until next tool call (debounce ≥ 400 ms) |
+| Fork called `memory_write(file="t.md")` | `evolving ⠋ memory · t` | same |
+| Review done | `evolved · N changes` | 2 s, then hide |
+| Failed / timed out | `evolving failed` | 3 s, then hide |
+
+No emoji; the spinner is structural Unicode, the label is text. Skill
+actions show the name directly (no `creating/deleting` prefix — "evolving"
+already conveys the verb); memory actions are `memory` or `memory · <topic>`.
+
+**Completion — in-stream summary.** After each successful review pass, the
+main outbox surfaces a delimiter-bounded block (`MessageEvent`,
+`From: "l1-review"`):
+
+```
+─────────────────────────────────────────────────
+Self-improvement review
+  · updated skill   go-testing      (added flaky-test guidance)
+  · saved memory    "user prefers concise output"
+  · retired skill   outdated-migrate-tool
+─────────────────────────────────────────────────
+```
+
+Silent on "Nothing to save." The status bar is the live tail; this block is
+the recap — two layers, distinct purposes.
 
 ---
 
@@ -467,9 +594,6 @@ Concrete steps:
   enforces shape by prompt (UPDATE > DELETE > CREATE, class-level naming);
   the hard guarantee against drift comes from L2 using usage telemetry to
   retire what nobody invokes.
-- **Let L1 patch user-authored skills?** Phase 1 default is no. Hermes allows
-  patching a just-used user skill (its preference #1); revisit if "fix the
-  skill I just used" turns out important.
 - **Commit agent-created project skills?** They live in-repo at
   `./.gen/skills/` mixed with user skills (distinguished by `origin`). Team
   choice whether to commit auto-generated ones; can be filtered by `origin`.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -22,6 +22,7 @@ issue (rationale in §8).
 | Trigger signals | turns (memory) + tool-iters (skill) | model judgment + explicit "remember this" | **turns + tool-iters** |
 | Memory scope | **global** `~/.hermes/MEMORY.md` + `USER.md` | **per-project** `~/.claude/projects/<repo>/memory/` (index + topic files) | **per-project** `~/.gen/projects/<project>/memory/` (Claude-Code-aligned) |
 | Skill scope | global, with provenance flags | global, with provenance | **user + project**, `origin: agent-created` field |
+| Eviction policy | review prompt steers retire; L2 curator does deep grooming | in-band agent prunes stale entries to stay under index cap | review prompt steers **retire + replace before add**; on-disk cap ≡ inject cap (25 KB); L2 deferred for deep grooming |
 | Cache parity | inherits cached system prompt verbatim (≈26% cost cut measured) | n/a (no fork) | inherits verbatim |
 
 **Why this mix.** Hermes' out-of-band shape is the production-proven one (best
@@ -121,37 +122,88 @@ gen-code settings):
 
 ## 4. Memory flow
 
+### 4.1 Decision flow — addition AND subtraction
+
+L1 is **not only allowed to remove — it is required to**. Claude Code's
+in-band agent keeps its index lean by pruning expired info before the cap
+forces a truncation; gen-code's out-of-band reviewer inherits that policy by
+prompt. Every review pass scans the existing index first and retires stale,
+superseded, or merged-PR-specific entries **before** considering new
+additions. A pass that only adds is a missed pruning opportunity.
+
 ```mermaid
 flowchart TD
     A[memory cadence due<br/>+ StopEndTurn + arm enabled] --> B[fork reads<br/>snapshot + MEMORY.md]
-    B --> C{durable fact<br/>worth keeping?}
+    B --> S{any entry now stale,<br/>superseded, or obsolete?}
+    S -- yes --> R0[memory_write remove<br/>or replace · prune first]
+    S -- no --> C
+    R0 --> C{durable new fact<br/>worth keeping?}
     C -- no --> Z[Nothing to save]
-    C -- yes --> D{existing entry<br/>covers it?}
-    D -- yes --> R[memory_write replace]
+    C -- yes --> H{index near<br/>25 KB hard cap?}
+    H -- yes --> P1[must prune more first<br/>before this write fits]
+    H -- no --> D{existing entry<br/>covers it?}
+    D -- yes --> R1[memory_write replace]
     D -- no --> N[memory_write add]
-    R --> P[~/.gen/projects/&lt;project&gt;/memory/]
-    N --> P
+    P1 --> ALL[~/.gen/projects/&lt;project&gt;/memory/]
+    R1 --> ALL
+    N --> ALL
 ```
 
 **Tool actions:** `add` / `replace` / `remove`. "Nothing to save." is a valid
-outcome.
+outcome — but a pass that does **only** add (no retirement of anything) is
+flagged in the prompt as suspect.
 
 **Anti-patterns (don't save):** one-off task state, transient errors,
 "what-we-did-this-session" narratives — none are durable across sessions.
 
-**Store layout.** `~/.gen/projects/<project>/memory/MEMORY.md` is the index;
-long detail spills into topic files (`debugging.md`, …) loaded on demand.
-`<project>` is the git-repo root path with `/` → `-` (Claude Code's encoding,
-e.g. `-Users-me-work-gen-code`), so worktrees of one repo share a store. Fall
-back to cwd outside a repo. User-level + project-partitioned is
-**machine-local, out of the repo** — no commit/gitignore decision, no agent
-churn in git history.
+### 4.2 Size budgets
 
-**Injection lifecycle (reuses existing infrastructure).**
+| What | Cap | Where enforced | Behavior at cap |
+|---|---|---|---|
+| Single memory file on disk (index or topic) | **25 000 chars (~25 KB)** | `internal/selflearn/memory.go memoryFileCharLimit` | `memory_write add/replace` returns an error; the reviewer must prune first |
+| `MEMORY.md` injected into system prompt | **25 KB (25 × 1024 bytes)** — matches Claude Code | `internal/core/system/memory.go autoMemoryByteCap` | Truncated on a line boundary with a marker |
+| Topic file count | none yet | — | Review prompt biases toward consolidation; flagged in §10 for L2 |
+
+**Invariant (intentional).** The on-disk per-file cap **equals** the injection
+cap. Anything that fits on disk fits when injected, so L1 never produces a
+file the loader has to truncate. The hard write cap is a safety net; the
+review prompt is the active policy.
+
+### 4.3 Store anatomy
+
+```mermaid
+flowchart LR
+    subgraph store["~/.gen/projects/&lt;project&gt;/memory/"]
+        IDX["MEMORY.md (index)<br/>≤25 KB hard cap<br/>injected at session start"]
+        T1["debugging.md<br/>≤25 KB · read on demand"]
+        T2["perf.md<br/>≤25 KB · read on demand"]
+        T3["…<br/>≤25 KB · read on demand"]
+        IDX -. one-line pointer .-> T1
+        IDX -. one-line pointer .-> T2
+        IDX -. one-line pointer .-> T3
+    end
+```
+
+The **index** is always injected (capped at 25 KB). **Topic files** are read
+on demand by the agent's file tools when the index pointer is dereferenced;
+they don't pay the prompt budget on their own, but their *count* can drift
+upward — handled by §10 / L2.
+
+### 4.4 Store layout
+
+`~/.gen/projects/<project>/memory/MEMORY.md` is the index; long detail spills
+into topic files (`debugging.md`, …) loaded on demand. `<project>` is the
+git-repo root path with `/` → `-` (Claude Code's encoding, e.g.
+`-Users-me-work-gen-code`), so worktrees of one repo share a store; fall back
+to cwd outside a repo. User-level + project-partitioned is **machine-local,
+out of the repo** — no commit/gitignore decision, no agent churn in git
+history.
+
+### 4.5 Injection lifecycle (reuses existing infrastructure)
 
 | When | What happens |
 |---|---|
-| Session start | Read `MEMORY.md` index (cap ~200 lines / 25 KB) → inject as `<system-reminder source="memory-auto">` on first user message. Topic files are read on demand by file tools, not injected. |
+| Session start | Read `MEMORY.md` index → inject as `<system-reminder source="memory-auto">` on first user message. Topic files are read on demand by file tools, not injected. |
 | PostCompact | Re-read from disk + re-emit reminders (same path as `GEN.md` / `CLAUDE.md`). |
 | cwd change | Re-read, because `<project>` changes. |
 
@@ -160,10 +212,29 @@ This requires one small read-side change: extend `LoadMemoryFiles` with a new,
 `GEN.md` / `CLAUDE.md` never mix. Without this read side, L1 writes would
 never be injected.
 
-**Write→visibility lag (by design).** L1 writes out-of-band while the running
-session's memory was injected at a load point, so a fresh write becomes
-visible at the next load point (next PostCompact / next session) — not
-live-patched. Acceptable: memory primarily serves future turns.
+### 4.6 Write→visibility lag (by design)
+
+L1 writes out-of-band; the running session's memory was injected at a load
+point, so a fresh write becomes visible at the **next** load point — not
+live-patched.
+
+```mermaid
+sequenceDiagram
+    participant M as Main session
+    participant L1 as L1 reviewer
+    participant Disk as MEMORY.md
+
+    Note over M: session start: MEMORY.md cached in prompt
+    M->>L1: turn N ends, Observe()
+    L1->>Disk: memory_write
+    Note over M: turns N+1, N+2, … still see the OLD cached prompt
+    Note over M,Disk: PostCompact OR next session
+    Disk-->>M: re-read + re-inject (new content visible)
+```
+
+Acceptable: memory primarily serves future turns / sessions, not the very
+turn that produced the learning. Live-patching would invalidate the prefix
+cache and waste the parity savings from §6 invariant #2.
 
 ---
 
@@ -175,47 +246,83 @@ live-patched. Acceptable: memory primarily serves future turns.
 > naming convention, not a stored field — the flow prefers extending an
 > umbrella over spawning narrow skills so the library stays "broad and few".
 
+### 5.1 Decision flow — UPDATE / DELETE / CREATE
+
+L1 must **retire**, not only add. A skill the conversation just proved wrong,
+superseded, or obsolete is deleted in the same review pass that learned the
+replacement; otherwise the library grows monotonically and drifts toward
+narrow, overlapping noise. Usage-based retirement (skills nobody invokes any
+more) is L2's job — but in-pass "this skill is wrong, kill it" lives at L1.
+
 ```mermaid
 flowchart TD
-    A[turn ≥ K tool-iters<br/>+ StopEndTurn + arm enabled] --> B[fork reads turn snapshot]
-    B --> C{loaded skill<br/>was wrong / outdated?}
+    A[turn ≥ K tool-iters<br/>+ StopEndTurn + arm enabled] --> B[fork reads turn snapshot<br/>+ existing skill inventory]
+    B --> X{any agent-created skill<br/>now wrong / superseded /<br/>encodes an anti-pattern?}
+    X -- yes --> XD[DELETE · skill_manage delete<br/>or replace with new learning]
+    X -- no --> C
+    XD --> C{loaded skill<br/>was wrong / outdated?}
     C -- yes --> U1[UPDATE · patch that skill]
     C -- no --> D{existing umbrella<br/>covers this?}
     D -- yes --> U2[UPDATE · patch umbrella<br/>+/- references/templates/scripts]
     D -- no --> E{new class of task<br/>no skill covers?}
-    E -- yes --> N[CREATE · class-level umbrella<br/>origin: agent-created]
+    E -- yes --> L{reusable across<br/>projects?}
+    L -- yes --> N1[CREATE · ~/.gen/skills/&lt;name&gt;/<br/>origin: agent-created]
+    L -- no --> N2[CREATE · ./.gen/skills/&lt;name&gt;/<br/>origin: agent-created]
     E -- no --> Z[Nothing to save]
 ```
 
-**UPDATE preferred.** Keeps the library broad and avoids near-duplicates.
-`skill_manage(patch, …)` to fix/extend; `skill_manage(write_file, …)` to add
-a `references/`, `templates/`, or `scripts/` support file (plus a pointer
-line in `SKILL.md`). Patch in place, at the existing scope.
+**UPDATE preferred over CREATE.** Keeps the library broad and avoids
+near-duplicates. `skill_manage(patch, …)` to fix/extend;
+`skill_manage(write_file, …)` to add a `references/` / `templates/` /
+`scripts/` support file (plus a pointer line in `SKILL.md`). Patch in place,
+at the existing scope.
 
-**CREATE as last resort.** Names must be **class-level** (`go-table-tests`,
-not `fix-pr-1234`). L1 picks the level: reusable/general → user
-(`~/.gen/skills/`), project-specific → project (`./.gen/skills/`).
+**DELETE when superseded.** `skill_manage(delete, name)`. Triggers:
+- the new learning supersedes the whole skill (replace rather than coexist);
+- the skill encoded a transient/environment-dependent failure that has since
+  been fixed (the skill is now wrong);
+- the skill turned out to encode an anti-pattern.
+
+**CREATE is the last resort.** Names must be **class-level** (`go-table-tests`,
+not `fix-pr-1234`). The level decision is in the diagram: reusable / general
+→ user (`~/.gen/skills/`), project-specific → project (`./.gen/skills/`).
+
+### 5.2 Provenance and L1 write scope
 
 **Provenance is a frontmatter field, not a directory.** Add
 `origin: agent-created` to `SKILL.md`; absent ⇒ `user-created`. The `Skill`
 struct grows one field (`Origin string`). Skills live directly in gen-code's
 existing two scopes — no `agent-created/` subdir, no loader change.
 
-**Scope of L1 writes (Phase 1).** L1 only creates/patches
+**Scope of L1 writes (Phase 1).** L1 creates / patches / **deletes** only
 `origin: agent-created` skills. It **reads** user-created skills (to avoid
-duplication) but never modifies them. The future L2 likewise touches only
-agent-owned content.
+duplication) but never modifies or deletes them. The future L2 likewise
+touches only agent-owned content.
 
-**`skill_manage` actions.** `create`, `edit` (full rewrite — rare), `patch`,
+### 5.3 Tool surface
+
+`skill_manage` actions: `create`, `edit` (full rewrite — rare), `patch`,
 `write_file`, `remove_file`, `delete`. **`patch`** is targeted
 find-and-replace with a fuzzy-match chain (exact → line-trimmed → whitespace/
 indent/escape/unicode-normalized → block-anchor → context-similarity) and an
 **escape-drift guard** (rejects matches where transport-added `\'` / `\"`
 backslashes don't exist in the file).
 
+### 5.4 Soft size budget (prompt-enforced)
+
+Unlike memory, skills have **no hard byte cap in code** — a per-skill or
+total-count cap would be arbitrary. L1 enforces shape through the review
+prompt's preference order; the hard guarantee against drift comes from L2.
+
+| What | Bound | Mechanism |
+|---|---|---|
+| Single skill body (`SKILL.md`) | none in code | Prompt: keep at class level; factor session-specific detail into `references/` |
+| Number of agent-created skills | none in code | Prompt: preference is **UPDATE > DELETE > CREATE**; CREATE is last resort |
+| Support files per skill | none in code | Prompt: consolidate when topics overlap |
+
 **Three review prompts**, picked by which arms fired (memory / skill /
 combined). The skill prompt is **active** (most working sessions produce ≥1
-update) and embeds the anti-pattern list.
+update or retirement) and embeds the anti-pattern list.
 
 ---
 
@@ -277,25 +384,36 @@ Eight invariants, each one cost Hermes a production bug:
 
 # Memory (new "auto" source, machine-local, per-project)
 ~/.gen/projects/<encoded-cwd>/memory/
-├── MEMORY.md           index, ≤200 lines / 25 KB injected
+├── MEMORY.md           index, ≤25 KB on disk and injected (caps match)
 ├── debugging.md        topic file, read on demand
 └── ...
 ```
 
 ---
 
-## 8. Why a later L2 curator (deferred)
+## 8. L1 vs L2 — where grooming lives
 
-L1 writes with a **local** view (one turn) and **frequently**. Across many
-turns the collection drifts in ways no single L1 write can fix:
-duplicate/overlapping entries, contradictions, stale facts, unbounded
-`MEMORY.md` growth past the injection budget. A separate, idle-triggered
-**L2 curator** evaluates the whole collection and dedups / prunes /
-consolidates / archives — the role Hermes' `agent/curator.py` plays. Its
-evaluation basis (usage telemetry + collection intrinsics) and trigger policy
-are out of scope here and tracked in a separate L2 issue.
+L1 already does **in-pass retirement** (§4.1 / §5.1): retire stale memory
+entries before adding, delete an obsolete skill when its replacement is
+learned, prune to fit when the 25 KB hard cap is near. That is the floor —
+without it L1 would be a pure accumulator.
 
-One L1-side implication worth flagging now: L2's strongest signal will be
+What L1 **cannot** do well from its local view:
+
+| Drift symptom | Why L1 misses it | L2's basis |
+|---|---|---|
+| Two skills overlap (different sessions wrote each) | L1 sees one turn at a time | Whole-collection scan |
+| A skill nobody invokes any more | L1 has no usage signal | Usage telemetry |
+| Two memory facts contradict, written months apart | L1 doesn't re-evaluate past entries | Idle full pass |
+| Topic-file count creeping up | L1 only judges per-write | Idle full pass |
+| `MEMORY.md` slowly approaching cap from many small adds | L1's per-pass prune is local | Idle full pass |
+
+A separate, idle-triggered **L2 curator** evaluates the whole collection and
+dedups / consolidates / archives — the role Hermes' `agent/curator.py` plays.
+Its evaluation basis (usage telemetry + collection intrinsics) and trigger
+policy are out of scope here and tracked in a separate L2 issue.
+
+**L1-side implication worth flagging now:** L2's strongest signal will be
 **usage** (which skill was used when), which gen-code doesn't record today.
 A light usage log can land with L1 or just before L2 — flagged so it isn't
 forgotten.
@@ -341,6 +459,14 @@ Concrete steps:
   re-learned per repo. Options: (a) accept and let the user curate
   `~/.gen/GEN.md` by hand; (b) extend L1 to choose user vs project level,
   mirroring how skills already do. Recommend (b) once Phase 1 is stable.
+- **Topic-file count is unbounded.** Per-file cap (25 KB) bounds size but
+  not count — the reviewer can keep creating new topics indefinitely. L1's
+  review prompt biases toward consolidation, but only L2's idle full pass
+  can reliably retire orphans. Acceptable for Phase 1; tracked for L2.
+- **Skill body and skill count have no hard caps in code** (§5.4). L1
+  enforces shape by prompt (UPDATE > DELETE > CREATE, class-level naming);
+  the hard guarantee against drift comes from L2 using usage telemetry to
+  retire what nobody invokes.
 - **Let L1 patch user-authored skills?** Phase 1 default is no. Hermes allows
   patching a just-used user skill (its preference #1); revisit if "fix the
   skill I just used" turns out important.

--- a/notes/active/l1-background-review.md
+++ b/notes/active/l1-background-review.md
@@ -1,92 +1,49 @@
-# Self-learning loop — design (L1 capture, L2 curate)
+# L1 — Background Review (per-turn self-learning)
 
-Design for the self-learning loop in [#46](https://github.com/genai-io/gen-code/issues/46).
-[#52](https://github.com/genai-io/gen-code/issues/52) is Layer 1 (L1).
+Design for Layer 1 of the self-learning loop in
+[#46](https://github.com/genai-io/gen-code/issues/46). This is
+[#52](https://github.com/genai-io/gen-code/issues/52).
 
-**Decision** (after comparing against the hermes-agent reference implementation
-at `agent/background_review.py` + `agent/curator.py`): gen-code uses an
-**out-of-band, two-layer** loop, aligned with how hermes does it in production:
+**Decision** (after comparing against the hermes-agent reference,
+`agent/background_review.py`): gen-code uses an **out-of-band** review that
+**writes memory/skills directly** per turn — useful on its own the moment it
+ships. A later, separate **L2 curator** keeps the collection healthy; its design
+is deferred to its own issue (a short rationale is in §5).
 
-- **L1 — per-turn capture (direct write).** After a turn, fork a fresh
-  `core.Agent` that reflects on the turn and writes memory/skill updates
-  **directly**. Useful on its own, the moment it ships.
-- **L2 — periodic curator (maintenance).** Runs on idle/schedule, not per turn.
-  Evaluates the *collection's* health and dedups / prunes / consolidates /
-  archives. Keeps the directly-written collection from drifting.
-
-This doc covers: the horizontal comparison, why L1 direct-write still needs L2,
-the L1 capture mechanics, the L2 evaluation basis, storage layout, and phasing.
+This doc focuses on L1: comparison, trigger, what it writes, fork mechanics, and
+phasing.
 
 ---
 
-## 1. How three systems do self-evolving memory (horizontal comparison)
+## 1. How three systems do self-evolving memory (comparison)
 
-Two fundamentally different places the "write memory" decision can live:
+Two places the "write memory" decision can live: **in-band** (the main agent
+writes mid-session, on its own judgment) vs **out-of-band** (a separate agent
+reviews after a turn and writes).
 
-- **In-band** — the *main* agent writes memory itself, mid-session, on its own
-  judgment, using its file tools.
-- **Out-of-band** — after a turn, a *separate* agent reviews and writes.
-
-| Axis | Hermes (`background_review.py` + `curator.py`) | Claude Code (auto memory) | gen-code (decided) |
+| Axis | Hermes (`background_review.py`) | Claude Code (auto memory) | gen-code (decided) |
 |---|---|---|---|
-| Write decision | **Out-of-band** review fork | **In-band** main agent | **Out-of-band**, aligned with Hermes |
-| When | After a turn (L1), + idle (L2 curator) | During the session, on model judgment | After a turn (L1), + idle (L2) |
-| L1 writes directly? | **Yes** — fork has memory + skill tools, persists immediately | Yes (main agent's own tool calls) | **Yes** (L1 captures directly) |
-| L2 role | Curator: archive stale / consolidate / pin-unpin / audit | (none — in-band only) | Curator: evaluate + dedup/prune/consolidate |
-| Trigger | turns (memory) + tool-iters (skill); curator on idle | model judgment + explicit "remember this" | same two signals; L2 on idle |
-| Storage | `~/.hermes/MEMORY.md` + `USER.md`; `~/.hermes/skills/<name>/` | `MEMORY.md` (index, first 200 lines/25KB loaded) + topic files | `.gen/memory/` + `.gen/skills/agent-created/` |
+| Write decision | **Out-of-band** review fork | **In-band** main agent | **Out-of-band** (aligned with Hermes) |
+| When | After a turn | During the session, on model judgment | After a turn |
+| Writes directly? | **Yes** (fork has memory + skill tools) | Yes (main agent's own tool calls) | **Yes** |
+| Trigger | turns (memory) + tool-iters (skill) | model judgment + explicit "remember this" | same two signals |
+| Storage | `~/.hermes/MEMORY.md` + `USER.md`, `~/.hermes/skills/<name>/` | `MEMORY.md` index (first 200 lines/25KB loaded) + topic files | `.gen/memory/` + `.gen/skills/agent-created/` |
 
-**What gen-code already has** (from the reminder/compaction work): the
-*injection* side — memory is loaded and re-injected as `<system-reminder>`
-blocks (`memory-user`/`memory-project`), refreshed from disk on PostCompact.
-What is missing is the *write* side (`internal/reminder` injects but never
-persists) and the *curation* side.
+**gen-code already has the *injection* side** (from the reminder/compaction
+work): memory loads + re-injects as `<system-reminder>` blocks
+(`memory-user`/`memory-project`), refreshed from disk on PostCompact. What's
+missing is the *write* side — `internal/reminder` injects but never persists.
+L1 adds the write side.
 
-**Why out-of-band + direct-write for gen-code** (first-principles):
-
-- In-band (Claude Code) is cheapest and the decider has full context, but it
-  spends main-context tokens every session and only appends in the flow of
-  work — no natural moment to step back and prune. Out-of-band keeps the main
-  turn clean and lets a dedicated prompt review thoroughly after the reply.
-- **L1 writes directly** (rather than staging proposals for L2 to commit)
-  because direct write makes Phase 1 useful on its own and matches the
-  production-proven hermes shape. The churn risk of a local, frequent,
-  append-only writer is handled by L2, not by deferring all writes.
+**Why out-of-band + direct-write:** in-band (Claude Code) is cheapest but spends
+main-context tokens every session and only appends in the flow of work.
+Out-of-band keeps the main turn clean and lets a dedicated prompt review after
+the reply is delivered. Direct write (vs staging proposals) makes Phase 1 useful
+on its own and matches the production-proven hermes shape.
 
 ---
 
-## 2. Two layers: capture (L1) → curate (L2)
-
-Different **scope**, not just different cadence:
-
-- **L1 = capture.** Local view (this one turn), frequent, additive. Good at
-  "spotting something new", blind to the collection as a whole.
-- **L2 = groundskeeper.** Global view (the whole memory/skill collection),
-  periodic, consolidating.
-
-**Why direct-write L1 still needs L2.** Because L1 only ever sees one turn and
-writes immediately, over many turns the collection *drifts* in ways no single
-L1 write can fix:
-
-1. **Duplication / overlap** — L1 re-discovers and re-writes near-duplicate
-   entries/skills. L2 merges.
-2. **Contradiction / staleness** — a preference changes; a skill goes out of
-   date. L1 can't know "this conflicts with an older entry". L2 reconciles and
-   archives.
-3. **Unbounded growth** — direct appends bloat `MEMORY.md` past the injection
-   budget (first 200 lines / 25KB). L2 trims/compacts so the injected index
-   stays useful.
-4. **Reorg / promotion** — a one-off note may deserve promotion to an umbrella
-   skill; scattered notes get consolidated. L2 restructures.
-5. **Lifecycle** — pin/unpin, archive long-unused items.
-
-hermes uses `agent/curator.py` (idle-triggered, not per-turn) for exactly this.
-
----
-
-## 3. L1 — per-turn capture (this issue, #52)
-
-### Trigger — two signals
+## 2. Trigger — two signals
 
 | Review kind | Signal | Default | Rationale |
 |---|---|---|---|
@@ -94,155 +51,121 @@ hermes uses `agent/curator.py` (idle-triggered, not per-turn) for exactly this.
 | Skills | tool iterations within the turn | when this turn ≥ 10 tool iters | Skill capture should fire when the agent actually *did* work; tool-iter count is the cheap, provider-agnostic proxy (tokens are per-provider and post-hoc). |
 
 Both config-overridable; `0` disables that arm. Combined when both fire on the
-same turn. The trigger is a **pure event consumer** subscribed to
-`core.Agent.Outbox()`, reading `TurnEvent` (`Result.Turns/ToolUses/StopReason`).
-No `internal/core` changes; counters live in the consumer and hydrate from
-history on resume.
+same turn.
 
-### What L1 writes — directly
+The trigger is a **pure event consumer** subscribed to `core.Agent.Outbox()`,
+reading `TurnEvent` (which already carries `Result.Turns`, `Result.ToolUses`,
+`Result.StopReason`). No `internal/core` changes; counters live in the consumer
+and hydrate from history on session resume.
+
+---
+
+## 3. What L1 writes — directly
 
 - **Memory**: durable user/project facts → `.gen/memory/MEMORY.md` / `USER.md`.
 - **Skill**: how to do a class of task → `.gen/skills/agent-created/<name>/`
-  (create or patch an agent-created skill; never touch user-curated/pinned).
+  (create or patch an agent-created skill; never touch user-curated/pinned ones,
+  so the future L2 curator can manage them without surprises).
 
-Three review prompts picked by which triggers fired (memory-only / skill-only /
-combined). "Nothing to save" is valid; for skills it should not be the default.
-Skill prompt embeds an anti-pattern list (no environment-dependent failures, no
-negative tool claims, no transient errors, no one-off task narratives).
+Three review prompts, picked by which triggers fired:
 
-### Fork mechanics + invariants
+- **memory-only**: user persona, preferences, expectations. "Nothing to save."
+  is a valid output.
+- **skill-only**: be active (most working sessions produce ≥1 update); preference
+  order = update a loaded skill → update an umbrella → add a support file →
+  create a new umbrella. Embeds an anti-pattern list (no environment-dependent
+  failures, no negative tool claims, no transient errors, no one-off task
+  narratives). "Nothing to save." is valid but not the default.
+- **combined**: both, when both triggers fire on the same turn.
 
-Fresh `core.Agent` (`core.NewAgent`), **not** `subagent.Executor`. Invariants
-(each cost hermes a production bug):
+---
 
-1. **Run AFTER the user reply is delivered**; gate on `Result.StopReason ==
+## 4. Fork mechanics + invariants
+
+Fresh `core.Agent` (`core.NewAgent`) run with `ThinkAct` in a goroutine — **not**
+`subagent.Executor` (which is built for named, user-facing subagents with
+registry/hooks/session-persistence a silent reviewer must not carry).
+
+Invariants (each one cost hermes a production bug):
+
+1. **Run AFTER the user reply is delivered.** Gate on `Result.StopReason ==
    StopEndTurn` (skip cancelled/interrupted/max-turns).
-2. **Inherit the parent's cached system prompt byte-for-byte** (prefix-cache
-   parity; hermes measured ~26% cost reduction).
-3. **Tool whitelist at dispatch**: fork's `tools[]` matches the parent (cache
-   key parity) but a static permission func allows only `memory_write` +
+2. **Inherit the parent's cached system prompt byte-for-byte** for prefix-cache
+   parity (Anthropic/OpenRouter). Hermes measured ~26% cost reduction.
+3. **Tool whitelist at dispatch.** Fork's `tools[]` matches the parent (cache-key
+   parity) but a static permission func allows only `memory_write` +
    `skill_manage`.
-4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge`
-   (would deadlock the TUI); auto-deny any approval.
-5. **Best-effort**: wrap in recover; failure never affects the user turn.
+4. **Static `tool.WithPermission` only** — never `agent.PermissionBridge` (would
+   deadlock the TUI); auto-deny any approval.
+5. **Best-effort.** Wrap in recover; review failure never affects the user turn.
 6. **No session-scoped side effects** (no hooks, no session persistence).
-7. **Suppress fork status**; only a one-line `💾 Self-improvement review:
-   <summary>` surfaces on the main outbox. Silent on "nothing to save".
-8. **≤1 in-flight fork per session**; drop new triggers while one runs (log,
-   no queue).
+7. **Suppress fork status.** Only a one-line `💾 Self-improvement review:
+   <summary>` surfaces on the main outbox (`MessageEvent`, `From: "l1-review"`).
+   Silent on "nothing to save".
+8. **≤1 in-flight fork per session.** Drop new triggers while one runs (log, no
+   queue).
 
-### Emit usage telemetry (so L2 can evaluate later)
+Module map:
 
-L2's strongest evaluation signal is *usage* (see §4), and gen-code does not
-record it today. As part of normal operation (not the fork), record a light
-usage log: per-skill last-used / invoke count, and memory-recall hits. This is
-telemetry to *inform* L2 — distinct from the memory/skill writes themselves.
-Minimal hooks: skill invocation (Skill tool / reminder injection) and memory
-reference. Can land with L1 or just before L2.
-
----
-
-## 4. L2 — periodic curator (next issue)
-
-Evaluates the collection's health, then dedups / prunes / consolidates /
-promotes / archives. Only touches agent-created / unprotected items.
-
-### Evaluation basis
-
-**(A) Usage / behavioral data (dynamic — the strongest signal):**
-- skill activity: last-used time + frequency (archive long-idle; pin/unpin by
-  activity).
-- memory hit: was an entry ever recalled/relevant.
-- correction signals: a user correction attributable to a memory/skill entry is
-  strong evidence it is wrong → reconcile/remove.
-
-Requires the usage telemetry from §3; without it L2 can only do static
-evaluation.
-
-**(B) Collection intrinsics (static — model reads and judges):**
-- size vs injection budget (200 lines / 25KB) → trim/compact.
-- redundancy/overlap → merge.
-- contradiction → reconcile, keep newest.
-- dangling references / stale facts → fix or archive.
-- provenance/protection → what L2 is allowed to change.
-
-### Maps to the original reflection dimensions
-
-| Dimension | L2 basis |
+| Concern | Module |
 |---|---|
-| scale | size vs injection budget (static) |
-| effective | usage: used? helped? (dynamic) |
-| correct | contradiction + correction signals |
-| efficient | redundancy/overlap (lean collection) |
-
-### How it decides
-
-Hybrid: **hard heuristics** (deterministic, cheap: "idle 30 days → archive
-candidate", "over budget → must trim", "protected → never touch") +
-**LLM judgment** (semantic: "do these two skills overlap?", "which contradicting
-memory wins?", "promote to umbrella?"). L2 is a periodic agent run that reads
-the whole collection + the usage log, produces an assessment, then executes.
-
-### Trigger
-
-Idle/periodic (e.g. idle ≥ N hours and ≥ M since last run), not per-turn.
-Exact policy TBD (open question).
+| Trigger + fork | new `internal/selflearn/l1` (subscribes to `core.Agent.Outbox()`, owns counters) |
+| Wire-up | `internal/agent/session.go::Task.Start` (start), `stopLocked` (tear down) |
+| Fork | `core.NewAgent` directly, restricted `core.Tools` |
+| System prompt | pass the parent's `system.System` verbatim |
+| Writes | `memory_write` → `.gen/memory/`; `skill_manage` → `.gen/skills/agent-created/` |
 
 ---
 
-## 5. Storage layout
+## 5. Why a later L2 curator (rationale only — design deferred)
 
-| What | Path | Writer |
-|---|---|---|
-| Agent memory | `.gen/memory/MEMORY.md` | L1 writes, L2 maintains |
-| User profile | `.gen/memory/USER.md` | L1 writes, L2 maintains |
-| Agent-created skills | `.gen/skills/agent-created/<name>/` | L1 writes, L2 maintains |
-| Usage log | `.gen/usage/` (or similar) | normal operation; L2 reads |
+L1 writes with a **local** view (one turn) and **frequently**. Over many turns
+the collection drifts in ways no single L1 write can fix: duplicate/overlapping
+entries, contradictions and stale facts, unbounded `MEMORY.md` growth past the
+injection budget. A separate, idle-triggered **L2 curator** evaluates the whole
+collection and dedups/prunes/consolidates/archives — the same role hermes'
+`agent/curator.py` plays. Its evaluation basis (usage telemetry + collection
+intrinsics) and trigger policy are out of scope here and tracked in a separate
+L2 issue.
 
-Agent-created skills stay isolated from user-curated ones so L2 lifecycle ops
-(archive/consolidate) never surprise the user. Injection already reads
-`GEN.md`/`CLAUDE.md` via reminder providers; `.gen/memory/MEMORY.md` slots into
-the same injection path.
+One L1-side implication worth noting now: L2's strongest signal will be **usage**
+(which skill was used, when), which gen-code doesn't record today. A light usage
+log can be added with L1 or just before L2 — flagged so it isn't forgotten.
 
 ---
 
 ## 6. Phasing + prerequisites
 
-- **Phase 1 — L1 capture (this issue, #52).** Trigger + fork + direct
-  memory/skill writes + the three review prompts. Useful on its own.
+- **Phase 1 — L1 (this issue, #52).** Trigger + fork + direct memory/skill writes
+  + the three review prompts.
   - Prereqs: `skill_manage` tool with patch semantics; a first-class memory
-    writer (`.gen/memory/MEMORY.md` + `USER.md`). (These move back to L1 since
-    L1 now writes directly.)
-- **Phase 2 — L2 curator (next, new issue).** Evaluation (usage + intrinsics) +
-  dedup/prune/consolidate/archive.
-  - Prereq: usage telemetry (§3) for activity-based evaluation.
+    writer (`.gen/memory/MEMORY.md` + `USER.md`). gen-code's injection side
+    already reads these once they exist.
+- **Phase 2 — L2 curator (separate issue).** Deferred (see §5).
 
 ### Concrete next steps (Phase 1)
 
 1. New package `internal/selflearn/l1`: `Reviewer` (counters + Outbox
    subscription + trigger), `forkAgent(parent, snapshot, mode)` (restricted
    `core.Agent`, runs `ThinkAct`, surfaces the one-line summary).
-2. `memory_write` + `skill_manage` tools (Phase-1 prereqs) and their stores
-   under `.gen/`.
+2. `memory_write` + `skill_manage` tools and their stores under `.gen/`.
 3. Review prompt templates (memory / skill / combined), rewritten for gen-code
    terminology.
 4. Wire-up in `Task.Start` / `stopLocked`; gate on `StopEndTurn`.
 5. Concurrency cap ≤1; drop-and-log on overlap.
-6. Light usage telemetry hooks (so L2 has data when it ships).
-7. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
+6. Tests: trigger cadence (turns / iters / combined), interrupted-turn skip,
    concurrency cap, restricted-toolset enforcement.
 
 ---
 
-## 7. Open questions
+## 7. Open questions (L1)
 
-- **L2 trigger policy** (idle thresholds / schedule / on-demand `/curate`).
-- **On-disk skill layout** confirmation (`.gen/skills/agent-created/`).
-- **Usage-telemetry shape** — what exactly to log, where, retention.
-- **Cache parity on non-Anthropic providers** — verify system-prompt
-  inheritance helps (or doesn't hurt) across gen-code's providers.
-- **Concurrency across writers** — L1 fork(s) vs a running L2 writing the same
-  files; serialize or atomic-replace.
+- **On-disk skill layout** — confirm `.gen/skills/agent-created/` (isolated from
+  user-curated skills).
+- **Cache parity on non-Anthropic providers** — verify system-prompt inheritance
+  helps (or at least doesn't hurt) across gen-code's providers.
+- **Usage telemetry** — whether to land the minimal usage log in this phase (for
+  the future L2) or defer it entirely.
 
 ---
 
@@ -250,12 +173,12 @@ the same injection path.
 
 - hermes-agent L1: `agent/background_review.py` (fork, prompts, direct writes);
   triggers in `agent/conversation_loop.py` (memory ~`:387–394`, skill
-  ~`:4046–4051`, guard `:4062`); L2 curator: `agent/curator.py`
-  (idle-triggered: archive stale / consolidate / pin-unpin / audit).
-- Claude Code memory model: <https://code.claude.com/docs/en/memory>
-  (CLAUDE.md vs in-band auto memory).
-- gen-code turn loop & outbox: `internal/core/agent_impl.go` (`Run`,
-  `TurnEvent`, `ThinkAct`).
+  ~`:4046–4051`, guard `:4062`). L2 (for context): `agent/curator.py`
+  (idle-triggered maintenance).
+- Claude Code memory model: <https://code.claude.com/docs/en/memory> (in-band
+  contrast).
+- gen-code turn loop & outbox: `internal/core/agent_impl.go` (`Run`, `TurnEvent`,
+  `ThinkAct`).
 - gen-code injection side (built): `internal/reminder` providers, PostCompact
   re-emit.
 - Session wire-up: `internal/agent/session.go` (`Task.Start`).


### PR DESCRIPTION
Design note for L1 of the self-learning loop (#46 / #52). Docs-only; lands `notes/active/l1-background-review.md`. Phase 1 implementation follows separately on `feat/selflearn-l1`.

## What L1 is

A **background reviewer** that runs after each clean turn in its own forked agent, reads the just-completed conversation, and writes directly to two stores:

- **Auto-memory** — per-project durable facts at `~/.gen/projects/<project>/memory/`, injected into every future session's system prompt.
- **Skill library** — class-level techniques marked `origin: agent-created`, living alongside user-authored skills in `~/.gen/skills/` (user-wide) and `./.gen/skills/` (project).

Best-effort, out-of-band, **eviction-first**. Never blocks the user turn; retires stale entries before adding new ones; every action gated by config.

## Problems it solves

- Sessions no longer start at zero — durable user preferences and project conventions are auto-captured instead of re-explained per session.
- Skills that prove wrong in a session get patched in the same review pass; mistakes stop repeating.
- Obsolete skills get retired in the pass that learns their replacement — the library doesn't grow monotonically.
- Non-trivial fixes / debug paths / tool-usage patterns are captured as class-level skills instead of evaporating at session end.
- `GEN.md` / `CLAUDE.md` stops being the only place durable context can live, without ever mixing user-authored instructions with agent-written memory.

## Key decisions in this doc

- **Out-of-band fork**, not in-band — dedicated review prompt, preserves prefix cache (≈26% cost cut per Hermes measurements), failures never affect the user reply.
- **Direct write, no proposal queue** — useful from day one; L2 curator handles collection-level drift later (deferred to a separate issue).
- **Per-project memory** (Claude-Code-aligned), **dual-scope skills** (user / project, distinguished by `origin` frontmatter — not a subdir).
- **Two-arm trigger**: turn cadence for memory + cumulative tool-iters since last review for skills. Counters reset only on the arm that fired; drop-don't-reset on overlap.
- **Eviction is L1's job, not just L2's**. Memory uses a `maxKB` hard cap (default 25, max 25 — matches the injection cap so the loader never truncates). Skills use prompt-enforced **UPDATE > DELETE > CREATE** preference with explicit trigger conditions per action (§5.1 table).
- **Three-boolean skill permission scheme** + one advanced opt-in:
  - `allowCreate` / `allowUpdate` / `allowDelete` (default all on; agent-created scope only)
  - `allowUpdateUserCreated` (default off; opens `patch` — never create/delete — on user-authored)
  - Startup rejects three illegal combinations (no-update-with-create, only-add-never-subtract, advanced-without-base).
- **Fork mechanics**: 8 production-tested invariants inherited from Hermes (StopEndTurn gate, cached system prompt verbatim for prefix-cache parity, restricted toolset whitelist + action-level allowlist, static permission, best-effort + recover, no session side effects, output suppression, ≤1 in-flight).
- **User-visible surface**: `/config` multi-panel page with a Self-Learning panel (grouped Memory / Skills config, inline validation). Runtime status bar shows `evolving <target>` only while a review is active; hidden on idle. Completion as a delimiter-bounded recap block in the main outbox.

## Doc structure

§0 Overview · §1 Three-system compare (Hermes / Claude Code / gen-code) · §2 Architecture · §3 Trigger arms + config schema · §4 Memory flow (decision, size budgets, anatomy, lifecycle, lag) · §5 Skill flow (trigger layers, decision flow with explicit CREATE/UPDATE/DELETE conditions, action permissions) · §6 Fork mechanics + module map + user-visible surface · §7 Filesystem · §8 L1 vs L2 grooming split · §9 Phasing · §10 Open questions

6 mermaid diagrams: architecture sequence, two-arm trigger state machine, memory decision flow with eviction loop, memory store anatomy, write→visibility lag timeline, skill decision flow.

## What's not in this PR

- Implementation (tracked under #52; on `feat/selflearn-l1`).
- L2 curator design (deferred to its own issue).

#52's design portion is fully specced by this doc.
