### PR TITLE
fix(session): drop unused path/filepath import (fixes red main CI)

### DIFF
--- a/internal/session/path.go
+++ b/internal/session/path.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"path/filepath"
 	"runtime"
 	"strings"
 )


### PR DESCRIPTION
`internal/session/path.go` imports `path/filepath` but only references it in a comment — PR #57 removed the actual usage and left the import. An unused import fails both `make format-check` (goimports) and `go build`, so **main's CI is currently red and every open PR fails the format check** on the merge-with-main.

Removing the import: `go build ./...` and `make format-check` are green.

One-line change; unblocks all PRs.