### PR TITLE
fix(provider): tidy provider list layout + animated refresh status

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -49,11 +49,12 @@ type ProviderStatusExpiredMsg = kit.StatusExpiredMsg
 // UpdateProvider routes provider connection and selection messages.
 func UpdateProvider(deps OverlayDeps, state *ProviderState, msg tea.Msg) (tea.Cmd, bool) {
 	switch msg := msg.(type) {
-	case ProviderSpinnerTickMsg:
-		// Keep ticking while work is in flight; stop once it completes.
+	case ProviderConnectingMsg:
+		// Keep ticking the spinner while connect/refresh is in flight; stop once
+		// the matching ProviderConnectResultMsg lands and IsBusy goes false.
 		if state.Selector.IsBusy() {
 			state.Selector.AdvanceSpinner()
-			return providerSpinnerTickCmd(), true
+			return providerConnectingTickCmd(), true
 		}
 		return nil, true
 	case ProviderConnectResultMsg:
@@ -211,7 +212,7 @@ type ProviderSelector struct {
 	lastConnectAuthIdx int // item index that triggered the connection
 	lastConnectSuccess bool
 
-	// spinnerTick advances on each ProviderSpinnerTickMsg; used to pick a braille
+	// spinnerTick advances on each ProviderConnectingMsg; used to pick a braille
 	// frame while a connect/refresh is in flight.
 	spinnerTick int
 }
@@ -221,13 +222,15 @@ type ProviderSelector struct {
 // thinking-spinner tick).
 const providerSpinnerInterval = 90 * time.Millisecond
 
-// ProviderSpinnerTickMsg drives the in-flight braille spinner animation.
-type ProviderSpinnerTickMsg struct{}
+// ProviderConnectingMsg is the periodic "still connecting/refreshing" tick that
+// advances the in-flight spinner; the terminal counterpart to
+// ProviderConnectResultMsg, which signals the work is done.
+type ProviderConnectingMsg struct{}
 
-// providerSpinnerTickCmd schedules the next spinner frame.
-func providerSpinnerTickCmd() tea.Cmd {
+// providerConnectingTickCmd schedules the next connecting tick (spinner frame).
+func providerConnectingTickCmd() tea.Cmd {
 	return tea.Tick(providerSpinnerInterval, func(time.Time) tea.Msg {
-		return ProviderSpinnerTickMsg{}
+		return ProviderConnectingMsg{}
 	})
 }
 
@@ -1052,7 +1055,7 @@ func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authId
 		}
 	}
 	// Start the spinner alongside the async work.
-	return tea.Batch(providerSpinnerTickCmd(), work)
+	return tea.Batch(providerConnectingTickCmd(), work)
 }
 
 // connectAuthMethod initiates an async connection to a provider auth method.
@@ -1084,7 +1087,7 @@ func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authId
 			NewStatus: llm.StatusConnected,
 		}
 	}
-	return tea.Batch(providerSpinnerTickCmd(), work)
+	return tea.Batch(providerConnectingTickCmd(), work)
 }
 
 // HandleConnectResult updates the selector state with connection result.

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -241,8 +241,8 @@ const (
 	providerStatusConnecting = "Connecting..."
 )
 
-// IsBusy reports whether a connect/refresh is in flight, so the shared spinner
-// keeps ticking and the row renders an animated frame.
+// IsBusy reports whether a connect/refresh is in flight, so the spinner-tick
+// loop keeps ticking and the row renders an animated frame.
 func (s *ProviderSelector) IsBusy() bool {
 	return s.active &&
 		(s.lastConnectResult == providerStatusRefreshing || s.lastConnectResult == providerStatusConnecting)
@@ -999,6 +999,11 @@ func (s *ProviderSelector) clampSelection() {
 
 // refreshAuthMethod re-fetches models for an already connected provider auth method.
 func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
+	if s.IsBusy() {
+		// A connect/refresh is already in flight; ignore re-entry so we don't
+		// start a second spinner-tick loop or a concurrent store write.
+		return nil
+	}
 	s.lastConnectResult = providerStatusRefreshing
 	s.lastConnectAuthIdx = authIdx
 	s.lastConnectSuccess = false
@@ -1052,6 +1057,11 @@ func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authId
 
 // connectAuthMethod initiates an async connection to a provider auth method.
 func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
+	if s.IsBusy() {
+		// A connect/refresh is already in flight; ignore re-entry so we don't
+		// start a second spinner-tick loop or a concurrent store write.
+		return nil
+	}
 	s.lastConnectResult = providerStatusConnecting
 	s.lastConnectAuthIdx = authIdx
 	s.lastConnectSuccess = false

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -48,6 +49,13 @@ type ProviderStatusExpiredMsg = kit.StatusExpiredMsg
 // UpdateProvider routes provider connection and selection messages.
 func UpdateProvider(deps OverlayDeps, state *ProviderState, msg tea.Msg) (tea.Cmd, bool) {
 	switch msg := msg.(type) {
+	case ProviderSpinnerTickMsg:
+		// Keep ticking while work is in flight; stop once it completes.
+		if state.Selector.IsBusy() {
+			state.Selector.AdvanceSpinner()
+			return providerSpinnerTickCmd(), true
+		}
+		return nil, true
 	case ProviderConnectResultMsg:
 		return state.Selector.HandleConnectResult(msg), true
 	case ProviderModelSelectedMsg:
@@ -202,6 +210,42 @@ type ProviderSelector struct {
 	lastConnectResult  string
 	lastConnectAuthIdx int // item index that triggered the connection
 	lastConnectSuccess bool
+
+	// spinnerTick advances on each ProviderSpinnerTickMsg; used to pick a braille
+	// frame while a connect/refresh is in flight.
+	spinnerTick int
+}
+
+// providerSpinnerInterval is the spin cadence while a connect/refresh runs —
+// fast enough to read as a smooth spinner (independent of the slower global
+// thinking-spinner tick).
+const providerSpinnerInterval = 90 * time.Millisecond
+
+// ProviderSpinnerTickMsg drives the in-flight braille spinner animation.
+type ProviderSpinnerTickMsg struct{}
+
+// providerSpinnerTickCmd schedules the next spinner frame.
+func providerSpinnerTickCmd() tea.Cmd {
+	return tea.Tick(providerSpinnerInterval, func(time.Time) tea.Msg {
+		return ProviderSpinnerTickMsg{}
+	})
+}
+
+// AdvanceSpinner moves the in-flight spinner to its next frame.
+func (s *ProviderSelector) AdvanceSpinner() { s.spinnerTick++ }
+
+// Transient in-flight result markers. While lastConnectResult equals one of
+// these, the row shows an animated spinner instead of static text.
+const (
+	providerStatusRefreshing = "Refreshing..."
+	providerStatusConnecting = "Connecting..."
+)
+
+// IsBusy reports whether a connect/refresh is in flight, so the shared spinner
+// keeps ticking and the row renders an animated frame.
+func (s *ProviderSelector) IsBusy() bool {
+	return s.active &&
+		(s.lastConnectResult == providerStatusRefreshing || s.lastConnectResult == providerStatusConnecting)
 }
 
 // providerStatusDisplayInfo contains display information for a provider status.
@@ -955,11 +999,11 @@ func (s *ProviderSelector) clampSelection() {
 
 // refreshAuthMethod re-fetches models for an already connected provider auth method.
 func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
-	s.lastConnectResult = "Refreshing..."
+	s.lastConnectResult = providerStatusRefreshing
 	s.lastConnectAuthIdx = authIdx
 	s.lastConnectSuccess = false
 
-	return func() tea.Msg {
+	work := func() tea.Msg {
 		ctx := context.Background()
 
 		llmProvider, err := llm.GetProvider(ctx, item.Provider, item.AuthMethod)
@@ -998,19 +1042,21 @@ func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authId
 		return ProviderConnectResultMsg{
 			AuthIdx:   authIdx,
 			Success:   true,
-			Message:   fmt.Sprintf("✓ Refreshed: %d models", len(models)),
+			Message:   fmt.Sprintf("● %d models", len(models)),
 			NewStatus: llm.StatusConnected,
 		}
 	}
+	// Start the spinner alongside the async work.
+	return tea.Batch(providerSpinnerTickCmd(), work)
 }
 
 // connectAuthMethod initiates an async connection to a provider auth method.
 func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
-	s.lastConnectResult = "Connecting..."
+	s.lastConnectResult = providerStatusConnecting
 	s.lastConnectAuthIdx = authIdx
 	s.lastConnectSuccess = false
 
-	return func() tea.Msg {
+	work := func() tea.Msg {
 		ctx := context.Background()
 		result, err := s.ConnectProvider(ctx, item.Provider, item.AuthMethod)
 		if err != nil {
@@ -1028,6 +1074,7 @@ func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authId
 			NewStatus: llm.StatusConnected,
 		}
 	}
+	return tea.Batch(providerSpinnerTickCmd(), work)
 }
 
 // HandleConnectResult updates the selector state with connection result.

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -51,8 +51,8 @@ func UpdateProvider(deps OverlayDeps, state *ProviderState, msg tea.Msg) (tea.Cm
 	switch msg := msg.(type) {
 	case ProviderConnectingMsg:
 		// Keep ticking the spinner while connect/refresh is in flight; stop once
-		// the matching ProviderConnectResultMsg lands and IsBusy goes false.
-		if state.Selector.IsBusy() {
+		// the matching ProviderConnectResultMsg lands and IsConnecting goes false.
+		if state.Selector.IsConnecting() {
 			state.Selector.AdvanceSpinner()
 			return providerConnectingTickCmd(), true
 		}
@@ -244,9 +244,9 @@ const (
 	providerStatusConnecting = "Connecting..."
 )
 
-// IsBusy reports whether a connect/refresh is in flight, so the spinner-tick
+// IsConnecting reports whether a connect/refresh is in flight, so the spinner-tick
 // loop keeps ticking and the row renders an animated frame.
-func (s *ProviderSelector) IsBusy() bool {
+func (s *ProviderSelector) IsConnecting() bool {
 	return s.active &&
 		(s.lastConnectResult == providerStatusRefreshing || s.lastConnectResult == providerStatusConnecting)
 }
@@ -1002,7 +1002,7 @@ func (s *ProviderSelector) clampSelection() {
 
 // refreshAuthMethod re-fetches models for an already connected provider auth method.
 func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
-	if s.IsBusy() {
+	if s.IsConnecting() {
 		// A connect/refresh is already in flight; ignore re-entry so we don't
 		// start a second spinner-tick loop or a concurrent store write.
 		return nil
@@ -1060,7 +1060,7 @@ func (s *ProviderSelector) refreshAuthMethod(item providerAuthMethodItem, authId
 
 // connectAuthMethod initiates an async connection to a provider auth method.
 func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authIdx int) tea.Cmd {
-	if s.IsBusy() {
+	if s.IsConnecting() {
 		// A connect/refresh is already in flight; ignore re-entry so we don't
 		// start a second spinner-tick loop or a concurrent store write.
 		return nil

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -12,6 +12,27 @@ import (
 	"github.com/genai-io/gen-code/internal/llm"
 )
 
+// connectResultFromCmd runs cmd (flattening a tea.Batch) and returns the first
+// ProviderConnectResultMsg it produces. connect/refresh commands batch the
+// spinner ticker alongside the async work, so the result is no longer the
+// top-level message.
+func connectResultFromCmd(cmd tea.Cmd) (ProviderConnectResultMsg, bool) {
+	if cmd == nil {
+		return ProviderConnectResultMsg{}, false
+	}
+	switch msg := cmd().(type) {
+	case ProviderConnectResultMsg:
+		return msg, true
+	case tea.BatchMsg:
+		for _, c := range msg {
+			if r, ok := connectResultFromCmd(c); ok {
+				return r, true
+			}
+		}
+	}
+	return ProviderConnectResultMsg{}, false
+}
+
 type connectFailProvider struct{}
 
 func (p *connectFailProvider) Stream(context.Context, llm.CompletionOptions) <-chan llm.StreamChunk {
@@ -321,9 +342,9 @@ func TestConnectAuthMethodFailsWhenModelsCannotBeLoaded(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected connectAuthMethod command")
 	}
-	msg, ok := cmd().(ProviderConnectResultMsg)
+	msg, ok := connectResultFromCmd(cmd)
 	if !ok {
-		t.Fatalf("unexpected message type %T", cmd())
+		t.Fatalf("expected a ProviderConnectResultMsg from connectAuthMethod")
 	}
 	if msg.Success {
 		t.Fatalf("expected failed connect result, got %+v", msg)

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -388,7 +388,7 @@ func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 }
 
 // providerSpinnerFrames is the braille spinner shown while a connect/refresh
-// is in flight, advanced by each ProviderSpinnerTickMsg.
+// is in flight, advanced by each ProviderConnectingMsg.
 var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 func (s *ProviderSelector) renderConnectResult() string {

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -359,9 +359,9 @@ func (s *ProviderSelector) renderHints() string {
 
 // ── Connection result ───────────────────────────────────────────────────────
 
-// appendConnectResult appends the inline connect/refresh result (e.g.
-// "Refreshed · 2 models") to a row's info column when it belongs to itemIdx,
-// separated from the env-var status by a gap.
+// appendConnectResult appends the inline connect/refresh result (an in-flight
+// spinner, or e.g. "● 2 models" once done) to a row's info column when it
+// belongs to itemIdx, separated from the env-var status by a gap.
 func (s *ProviderSelector) appendConnectResult(envInfo string, itemIdx int) string {
 	if s.lastConnectResult == "" || itemIdx != s.lastConnectAuthIdx {
 		return envInfo
@@ -373,11 +373,10 @@ func (s *ProviderSelector) appendConnectResult(envInfo string, itemIdx int) stri
 	return envInfo + "   " + result
 }
 
+// connectResultStyle styles a completed (non-in-flight) result; the in-flight
+// case is handled by renderConnectResult before this is called.
 func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 	if !s.lastConnectSuccess {
-		if s.IsBusy() {
-			return kit.DimStyle()
-		}
 		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
 	}
 	if strings.HasPrefix(s.lastConnectResult, "⚠") {
@@ -389,7 +388,7 @@ func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 }
 
 // providerSpinnerFrames is the braille spinner shown while a connect/refresh
-// is in flight, advanced by the shared animation tick.
+// is in flight, advanced by each ProviderSpinnerTickMsg.
 var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 func (s *ProviderSelector) renderConnectResult() string {

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -276,7 +276,10 @@ func (s *ProviderSelector) renderModelRow(item providerListItem, isSelected bool
 // ── Providers tab rows ──────────────────────────────────────────────────────
 
 // providerNameColumnWidth is the fixed width for provider name alignment.
-const providerNameColumnWidth = 16
+// Sized to fit the longest display name ("Z.ai (GLM series)", 17 cols) plus a
+// comfortable gap, so every row's API-key column lines up without crowding —
+// even the longest name keeps ~5 cols of breathing room before its key.
+const providerNameColumnWidth = 22
 
 func (s *ProviderSelector) renderProviderRow(item providerListItem, isSelected bool, itemIdx int) string {
 	p := item.Provider
@@ -293,15 +296,10 @@ func (s *ProviderSelector) renderProviderRow(item providerListItem, isSelected b
 	} else if len(p.AuthMethods) > 1 {
 		envInfo = kit.DimStyle().Render(fmt.Sprintf("%d auth methods", len(p.AuthMethods)))
 	}
+	envInfo = s.appendConnectResult(envInfo, itemIdx)
 
 	line := kit.FormatAlignedRow(statusStyle.Render(statusIcon), p.DisplayName, providerNameColumnWidth, envInfo)
-	result := kit.RenderSelectableRow(line, isSelected)
-
-	if s.lastConnectResult != "" && itemIdx == s.lastConnectAuthIdx {
-		result += "\n" + providerResultIndent + s.renderConnectResult()
-	}
-
-	return result
+	return kit.RenderSelectableRow(line, isSelected)
 }
 
 func (s *ProviderSelector) renderAuthMethod(item providerListItem, isSelected bool, itemIdx int) string {
@@ -319,16 +317,11 @@ func (s *ProviderSelector) renderAuthMethod(item providerListItem, isSelected bo
 	if statusDesc != "" && envInfo == "" {
 		envInfo = kit.DimStyle().Render(statusDesc)
 	}
+	envInfo = s.appendConnectResult(envInfo, itemIdx)
 
 	colWidth := providerNameColumnWidth - 2 // sub-item indent
 	line := "  " + kit.FormatAlignedRow(statusStyle.Render(statusIcon), am.DisplayName, colWidth, envInfo)
-	result := kit.RenderSelectableRow(line, isSelected)
-
-	if s.lastConnectResult != "" && itemIdx == s.lastConnectAuthIdx {
-		result += "\n" + providerResultIndent + "  " + s.renderConnectResult()
-	}
-
-	return result
+	return kit.RenderSelectableRow(line, isSelected)
 }
 
 // ── API key input ───────────────────────────────────────────────────────────
@@ -366,13 +359,23 @@ func (s *ProviderSelector) renderHints() string {
 
 // ── Connection result ───────────────────────────────────────────────────────
 
-// providerResultIndent is the fixed indent for connection result messages,
-// aligned with the provider name column.
-const providerResultIndent = "        "
+// appendConnectResult appends the inline connect/refresh result (e.g.
+// "Refreshed · 2 models") to a row's info column when it belongs to itemIdx,
+// separated from the env-var status by a gap.
+func (s *ProviderSelector) appendConnectResult(envInfo string, itemIdx int) string {
+	if s.lastConnectResult == "" || itemIdx != s.lastConnectAuthIdx {
+		return envInfo
+	}
+	result := s.renderConnectResult()
+	if envInfo == "" {
+		return result
+	}
+	return envInfo + "   " + result
+}
 
 func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 	if !s.lastConnectSuccess {
-		if s.lastConnectResult == "Connecting..." || s.lastConnectResult == "Refreshing..." {
+		if s.IsBusy() {
 			return kit.DimStyle()
 		}
 		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
@@ -380,9 +383,20 @@ func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 	if strings.HasPrefix(s.lastConnectResult, "⚠") {
 		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
 	}
-	return kit.SelectorStatusConnected()
+	// Plain success (e.g. "· 2 models") is supplementary info — the green status
+	// dot and key ✓ already signal success, so keep it dim to avoid competing.
+	return kit.DimStyle()
 }
 
+// providerSpinnerFrames is the braille spinner shown while a connect/refresh
+// is in flight, advanced by the shared animation tick.
+var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
 func (s *ProviderSelector) renderConnectResult() string {
+	// While in flight, show just the animated braille spinner (no text).
+	if s.IsBusy() {
+		frame := providerSpinnerFrames[s.spinnerTick%len(providerSpinnerFrames)]
+		return kit.DimStyle().Render(frame)
+	}
 	return s.connectResultStyle().Render(s.lastConnectResult)
 }

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -393,7 +393,7 @@ var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "
 
 func (s *ProviderSelector) renderConnectResult() string {
 	// While in flight, show just the animated braille spinner (no text).
-	if s.IsBusy() {
+	if s.IsConnecting() {
 		frame := providerSpinnerFrames[s.spinnerTick%len(providerSpinnerFrames)]
 		return kit.DimStyle().Render(frame)
 	}

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/genai-io/gen-code/internal/secret"
 )
 
@@ -73,14 +75,18 @@ func RenderSelectableRow(line string, isSelected bool) string {
 	return SelectorItemStyle().Render("  " + line)
 }
 
-// FormatAlignedRow formats "icon  name<padding>info" with name padded to colWidth.
+// alignedRowMinGap is the minimum spacing kept between the name and info
+// columns, so names longer than colWidth never collide with the info column.
+const alignedRowMinGap = 2
+
+// FormatAlignedRow formats "icon  name<padding>info" with name padded to
+// colWidth and always separated from info by at least alignedRowMinGap spaces.
 func FormatAlignedRow(icon, name string, colWidth int, info string) string {
-	nameWidth := len(name) // approximate; callers can use lipgloss.Width for ANSI-safe width
-	pad := ""
-	if nameWidth < colWidth {
-		pad = strings.Repeat(" ", colWidth-nameWidth)
+	gap := colWidth - lipgloss.Width(name) // display width, ANSI/Unicode safe
+	if gap < alignedRowMinGap {
+		gap = alignedRowMinGap
 	}
-	return fmt.Sprintf("%s  %s%s%s", icon, name, pad, info)
+	return fmt.Sprintf("%s  %s%s%s", icon, name, strings.Repeat(" ", gap), info)
 }
 
 // MapString extracts a string value from a generic map.
@@ -128,8 +134,11 @@ func RenderEnvVarStatus(envVar string) string {
 	if envVar == "" {
 		return ""
 	}
+	// The env-var name is secondary reference info (kept dim); the check mark
+	// carries the signal — green ✓ when configured, dim ✗ when not.
+	name := DimStyle().Render(envVar)
 	if secret.Resolve(envVar) != "" {
-		return SelectorStatusReady().Render(envVar + " ✓")
+		return name + " " + SelectorStatusConnected().Render("✓")
 	}
-	return SelectorStatusNone().Render(envVar + " ✗")
+	return name + " " + SelectorStatusNone().Render("✗")
 }


### PR DESCRIPTION
## Summary

Polishes the **Providers** tab in the model/provider selector overlay — fixing column alignment, quieting the API-key column, and reworking the connect/refresh feedback into an inline animated status.

## Changes

- **Reliable column alignment** (`kit/util.go`): `FormatAlignedRow` now measures display width via `lipgloss.Width` (ANSI/Unicode-safe) and always keeps a minimum gap. Previously, names longer than the fixed column (e.g. `Z.ai (GLM series)`, 17 cols) got zero padding and collided with the API-key column. The provider-name column was widened (16 → 22) for comfortable spacing.
- **Quieter API-key column** (`kit/util.go`): `RenderEnvVarStatus` now dims the env-var name and colors only the status mark — green `✓` when configured, dim `✗` when not — instead of rendering the whole key in loud orange. The check carries the signal.
- **Inline animated refresh status** (`on_provider*.go`):
  - The connect/refresh result renders inline after the env-var status instead of on a separate indented line.
  - While a connect/refresh is in flight, the row shows a fast braille spinner (`⠋`, 90 ms cadence) driven by a dedicated ticker (independent of the slower global thinking spinner), with no text.
  - Once loaded, it shows a compact `● N models`.

## Testing

- `go build ./...`
- `go test ./internal/app/input/ ./internal/app/kit/` (updated one test to unwrap the spinner-ticker batch from the connect command)

Animation can't be shown in a static screenshot; the spinner advances ~11 fps while refreshing and stops on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)