### PR TITLE
Add Getting Started page and clean up README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,10 @@
   <p><strong>Open-source AI coding assistant for the terminal</strong></p>
   <p>
     <a href="https://github.com/genai-io/gen-code/releases"><img src="https://img.shields.io/github/v/release/genai-io/gen-code?style=flat-square" alt="Release"></a>
-    <a href="https://github.com/genai-io/gen-code/stargazers"><img src="https://img.shields.io/github/stars/genai-io/gen-code?style=flat-square" alt="Stars"></a>
-    <a href="https://goreportcard.com/report/github.com/genai-io/gen-code"><img src="https://goreportcard.com/badge/github.com/genai-io/gen-code?style=flat-square" alt="Go Report Card"></a>
-    <a href="https://pkg.go.dev/github.com/genai-io/gen-code"><img src="https://pkg.go.dev/badge/github.com/genai-io/gen-code.svg" alt="Go Reference"></a>
+    <a href="https://genai-io.github.io/gen-code/"><img src="https://img.shields.io/badge/Website-0d9488?style=flat-square" alt="Website"></a>
+    <a href="https://genai-io.github.io/gen-code/getting-started.html"><img src="https://img.shields.io/badge/Getting%20Started-0d9488?style=flat-square" alt="Getting Started"></a>
+    <a href="docs/index.md"><img src="https://img.shields.io/badge/Docs-0d9488?style=flat-square" alt="Docs"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
-  </p>
-  <p>
-    🌐 <a href="https://genai-io.github.io/gen-code/">Website</a> ·
-    📖 <a href="docs/index.md">Docs</a> ·
-    🚀 <a href="docs/guides/getting-started.md">Getting Started</a>
   </p>
   <p>
     <strong>English</strong> · <a href="README.zh.md">简体中文</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,15 +3,10 @@
   <p><strong>面向终端的开源 AI 编程助手</strong></p>
   <p>
     <a href="https://github.com/genai-io/gen-code/releases"><img src="https://img.shields.io/github/v/release/genai-io/gen-code?style=flat-square" alt="Release"></a>
-    <a href="https://github.com/genai-io/gen-code/stargazers"><img src="https://img.shields.io/github/stars/genai-io/gen-code?style=flat-square" alt="Stars"></a>
-    <a href="https://goreportcard.com/report/github.com/genai-io/gen-code"><img src="https://goreportcard.com/badge/github.com/genai-io/gen-code?style=flat-square" alt="Go Report Card"></a>
-    <a href="https://pkg.go.dev/github.com/genai-io/gen-code"><img src="https://pkg.go.dev/badge/github.com/genai-io/gen-code.svg" alt="Go Reference"></a>
+    <a href="https://genai-io.github.io/gen-code/"><img src="https://img.shields.io/badge/%E5%AE%98%E7%BD%91-0d9488?style=flat-square" alt="官网"></a>
+    <a href="https://genai-io.github.io/gen-code/getting-started.html"><img src="https://img.shields.io/badge/%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B-0d9488?style=flat-square" alt="快速开始"></a>
+    <a href="docs/index.md"><img src="https://img.shields.io/badge/%E6%96%87%E6%A1%A3-0d9488?style=flat-square" alt="文档"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
-  </p>
-  <p>
-    🌐 <a href="https://genai-io.github.io/gen-code/">官网</a> ·
-    📖 <a href="docs/index.md">文档</a> ·
-    🚀 <a href="docs/guides/getting-started.md">快速开始</a>
   </p>
   <p>
     <a href="README.md">English</a> · <strong>简体中文</strong>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Getting Started — Gen Code</title>
+<meta name="description" content="Get started with Gen Code in three steps: install, launch and pick a theme, then connect your model.">
+<meta property="og:title" content="Getting Started — Gen Code">
+<meta property="og:description" content="Install, pick a theme, and connect your model — up and running in a couple of minutes.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://genai-io.github.io/gen-code/getting-started.html">
+<meta property="og:image" content="https://genai-io.github.io/gen-code/gen-code.png">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='monospace'>%E2%9C%A6</text></svg>">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <span class="logo"><a href="index.html">&lt; GEN <span class="spark">✦</span> /&gt;</a></span>
+    <div class="nav-links">
+      <a href="index.html#features">Features</a>
+      <a href="index.html#benchmark">Benchmark</a>
+      <a href="getting-started.html">Get Started</a>
+      <a href="https://github.com/genai-io/gen-code/tree/main/docs">Docs</a>
+      <a class="nav-cta" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header class="page-hero">
+  <div class="wrap">
+    <h1>Getting Started</h1>
+    <p>From install to your first prompt in a couple of minutes.</p>
+  </div>
+</header>
+
+<section style="padding-top: 24px;">
+  <div class="wrap">
+    <div class="steps">
+
+      <div class="step">
+        <div class="num">1</div>
+        <div class="step-body">
+          <h3>Install</h3>
+          <p>One command on macOS or Linux. Re-run anytime to upgrade.</p>
+          <div class="cmd">
+            <span class="prompt">$</span>
+            <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/gen-code/main/install.sh | bash</code>
+            <button class="copy-btn" onclick="copyEl('install-cmd', this)">Copy</button>
+          </div>
+          <p style="margin-top:14px;">Prefer Go? <code class="inline">go install github.com/genai-io/gen-code/cmd/gen@latest</code></p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="num">2</div>
+        <div class="step-body">
+          <h3>Launch &amp; pick a theme</h3>
+          <p>Start Gen Code by running <code class="inline">gen</code>. On first launch you'll pick a color theme — choose one, and you're ready to connect a model.</p>
+          <div class="cmd">
+            <span class="prompt">$</span>
+            <code id="run-cmd">gen</code>
+            <button class="copy-btn" onclick="copyEl('run-cmd', this)">Copy</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="num">3</div>
+        <div class="step-body">
+          <h3>Connect a model</h3>
+          <p>Type <code class="inline">/model</code> to open model settings, then:</p>
+          <ol class="substeps">
+            <li>In the <b>Provider</b> pane on the right, paste your API key — this loads that provider's available models.</li>
+            <li>Wait for the provider's models to finish loading.</li>
+            <li>Pick the model you want from the <b>Model</b> list, and start coding.</li>
+          </ol>
+          <p style="margin-top:14px;">Switch providers or models anytime with <code class="inline">/model</code>. Your choice is saved to <code class="inline">~/.gen/providers.json</code>.</p>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="cta-box" style="margin-top: 56px;">
+      <h2>You're set</h2>
+      <p>Explore slash commands with <code class="inline" style="background:var(--bg);">/help</code>, or dive into the docs.</p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="https://github.com/genai-io/gen-code/tree/main/docs">Read the docs</a>
+        <a class="btn btn-ghost" href="index.html">Back to home</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>© <span id="year"></span> Gen Code · Apache 2.0</span>
+    <span>
+      <a href="https://github.com/genai-io/gen-code">GitHub</a> ·
+      <a href="https://github.com/genai-io/gen-code/tree/main/docs">Docs</a> ·
+      <a href="https://github.com/genai-io/gen-code/blob/main/CONTRIBUTING.md">Contributing</a>
+    </span>
+  </div>
+</footer>
+
+<script>
+  function copyEl(id, btn) {
+    const text = document.getElementById(id).innerText;
+    navigator.clipboard.writeText(text).then(() => {
+      const old = btn.innerText;
+      btn.innerText = 'Copied!';
+      setTimeout(() => btn.innerText = old, 1500);
+    });
+  }
+  document.getElementById('year').innerText = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -12,169 +12,7 @@
 <meta property="og:image" content="https://genai-io.github.io/gen-code/gen-code.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='monospace'>%E2%9C%A6</text></svg>">
-<style>
-  :root {
-    --bg: #ffffff;
-    --bg-soft: #f6f8fa;
-    --card: #ffffff;
-    --border: #e3e7ec;
-    --text: #1a1f26;
-    --muted: #5b6573;
-    --accent: #0d9488;
-    --accent-2: #6366f1;
-    --green: #16a34a;
-    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  html { scroll-behavior: smooth; }
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--sans);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-  }
-  a { color: var(--accent); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  .wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
-  .mono { font-family: var(--mono); }
-
-  /* Nav */
-  nav {
-    position: sticky; top: 0; z-index: 10;
-    background: rgba(255,255,255,.85);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--border);
-  }
-  nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 60px; }
-  .logo { font-family: var(--mono); font-weight: 700; font-size: 18px; color: var(--text); }
-  .logo .spark { color: var(--accent); }
-  .nav-links { display: flex; gap: 24px; align-items: center; font-size: 14px; }
-  .nav-links a { color: var(--muted); }
-  .nav-links a:hover { color: var(--text); text-decoration: none; }
-  .nav-cta {
-    background: var(--accent); color: #fff !important;
-    padding: 7px 16px; border-radius: 7px; font-weight: 600;
-  }
-  .nav-cta:hover { text-decoration: none; opacity: .9; }
-
-  /* Hero */
-  .hero { text-align: center; padding: 90px 0 60px; }
-  .hero h1 { font-size: clamp(38px, 6vw, 60px); line-height: 1.1; letter-spacing: -1.5px; font-weight: 800; }
-  .hero h1 .grad {
-    background: linear-gradient(120deg, var(--accent), var(--accent-2));
-    -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
-  }
-  .hero p.sub { font-size: clamp(17px, 2.5vw, 21px); color: var(--muted); max-width: 640px; margin: 22px auto 0; }
-  .hero p.sub strong { color: var(--text); }
-  .badges { margin-top: 18px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
-  .badges img { height: 20px; }
-
-  /* Install box */
-  .install { margin: 36px auto 0; max-width: 640px; }
-  .cmd {
-    display: flex; align-items: center; gap: 12px;
-    background: var(--bg-soft); border: 1px solid var(--border);
-    border-radius: 10px; padding: 14px 16px;
-    font-family: var(--mono); font-size: 14px; text-align: left;
-  }
-  .cmd .prompt { color: var(--accent); user-select: none; }
-  .cmd code { flex: 1; color: var(--text); overflow-x: auto; white-space: nowrap; }
-  .copy-btn {
-    background: var(--border); color: var(--text); border: none;
-    padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;
-    font-family: var(--sans); white-space: nowrap;
-  }
-  .copy-btn:hover { background: #d4dae1; }
-  .hero-actions { margin-top: 22px; display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
-  .btn {
-    padding: 12px 24px; border-radius: 9px; font-weight: 600; font-size: 15px;
-    display: inline-flex; align-items: center; gap: 8px;
-  }
-  .btn-primary { background: var(--accent); color: #fff; }
-  .btn-primary:hover { text-decoration: none; opacity: .9; }
-  .btn-ghost { border: 1px solid var(--border); color: var(--text); }
-  .btn-ghost:hover { text-decoration: none; background: var(--bg-soft); }
-
-  .screenshot { margin: 56px auto 0; max-width: 920px; }
-  .screenshot img {
-    width: 100%; display: block; border-radius: 14px;
-    border: 1px solid var(--border);
-    box-shadow: 0 24px 50px -24px rgba(26,31,38,.25);
-  }
-
-  /* Sections */
-  section { padding: 64px 0; }
-  .section-title { font-size: 30px; font-weight: 700; letter-spacing: -.5px; text-align: center; }
-  .section-sub { color: var(--muted); text-align: center; margin-top: 8px; max-width: 600px; margin-left: auto; margin-right: auto; }
-
-  /* Feature grid */
-  .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; margin-top: 40px; }
-  .card {
-    background: var(--card); border: 1px solid var(--border);
-    border-radius: 12px; padding: 24px;
-  }
-  .card h3 { font-size: 17px; display: flex; align-items: center; gap: 10px; }
-  .card .ico { font-size: 20px; }
-  .card p { color: var(--muted); font-size: 14px; margin-top: 8px; }
-  .card code { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
-  .card.wide {
-    grid-column: 1 / -1;
-    background: linear-gradient(120deg, rgba(13,148,136,.06), rgba(99,102,241,.06));
-    display: flex; flex-direction: column; gap: 16px;
-  }
-  .levels { display: flex; flex-wrap: wrap; gap: 10px; }
-  .level {
-    display: flex; align-items: center; gap: 8px;
-    background: var(--bg); border: 1px solid var(--border);
-    border-radius: 999px; padding: 6px 14px; font-size: 13px;
-  }
-  .level b { color: var(--accent); font-family: var(--mono); }
-  .level .arrow { color: var(--muted); }
-  .soon {
-    font-family: var(--sans); font-size: 11px; font-weight: 600;
-    letter-spacing: .5px; text-transform: uppercase;
-    color: var(--accent-2); background: rgba(99,102,241,.1);
-    border: 1px solid rgba(99,102,241,.25);
-    padding: 2px 9px; border-radius: 999px; vertical-align: middle;
-  }
-
-  /* Benchmark table */
-  .bench-wrap { margin-top: 40px; overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
-  table { width: 100%; border-collapse: collapse; font-size: 14px; }
-  th, td { padding: 13px 18px; text-align: left; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-soft); color: var(--muted); font-weight: 600; }
-  tr:last-child td { border-bottom: none; }
-  td.adv { color: var(--green); font-weight: 600; }
-  .bench-note { color: var(--muted); font-size: 13px; text-align: center; margin-top: 16px; }
-
-  /* Providers */
-  .pills { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; margin-top: 36px; }
-  .pill {
-    background: var(--card); border: 1px solid var(--border);
-    padding: 8px 16px; border-radius: 999px; font-size: 14px; color: var(--text);
-  }
-
-  /* CTA */
-  .cta-box {
-    background: linear-gradient(120deg, rgba(94,234,212,.08), rgba(129,140,248,.08));
-    border: 1px solid var(--border); border-radius: 16px;
-    padding: 50px 30px; text-align: center; margin-top: 20px;
-  }
-  .cta-box h2 { font-size: 28px; }
-  .cta-box p { color: var(--muted); margin-top: 10px; }
-
-  footer { border-top: 1px solid var(--border); padding: 36px 0; color: var(--muted); font-size: 14px; }
-  footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px; }
-  footer a { color: var(--muted); }
-
-  @media (max-width: 640px) {
-    .grid { grid-template-columns: 1fr; }
-    .nav-links a:not(.nav-cta) { display: none; }
-    .hero { padding: 56px 0 40px; }
-  }
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 
@@ -184,6 +22,7 @@
     <div class="nav-links">
       <a href="#features">Features</a>
       <a href="#benchmark">Benchmark</a>
+      <a href="getting-started.html">Get Started</a>
       <a href="https://github.com/genai-io/gen-code/tree/main/docs">Docs</a>
       <a class="nav-cta" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
     </div>
@@ -211,8 +50,8 @@
     </div>
 
     <div class="hero-actions">
-      <a class="btn btn-primary" href="https://github.com/genai-io/gen-code">Get started →</a>
-      <a class="btn btn-ghost" href="#benchmark">See the benchmark</a>
+      <a class="btn btn-primary" href="getting-started.html">Get started →</a>
+      <a class="btn btn-ghost" href="https://github.com/genai-io/gen-code">View on GitHub</a>
     </div>
 
     <div class="screenshot">
@@ -299,7 +138,7 @@
       <p>Open source under Apache 2.0. Star the repo if it's useful — it genuinely helps.</p>
       <div class="hero-actions">
         <a class="btn btn-primary" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
-        <a class="btn btn-ghost" href="https://github.com/genai-io/gen-code/tree/main/docs/guides/getting-started.md">Read the guide</a>
+        <a class="btn btn-ghost" href="getting-started.html">Get started</a>
       </div>
     </div>
   </div>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,196 @@
+:root {
+  --bg: #ffffff;
+  --bg-soft: #f6f8fa;
+  --card: #ffffff;
+  --border: #e3e7ec;
+  --text: #1a1f26;
+  --muted: #5b6573;
+  --accent: #0d9488;
+  --accent-2: #6366f1;
+  --green: #16a34a;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+.mono { font-family: var(--mono); }
+
+/* Nav */
+nav {
+  position: sticky; top: 0; z-index: 10;
+  background: rgba(255,255,255,.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 60px; }
+.logo { font-family: var(--mono); font-weight: 700; font-size: 18px; color: var(--text); }
+.logo a { color: var(--text); }
+.logo a:hover { text-decoration: none; }
+.logo .spark { color: var(--accent); }
+.nav-links { display: flex; gap: 24px; align-items: center; font-size: 14px; }
+.nav-links a { color: var(--muted); }
+.nav-links a:hover { color: var(--text); text-decoration: none; }
+.nav-cta {
+  background: var(--accent); color: #fff !important;
+  padding: 7px 16px; border-radius: 7px; font-weight: 600;
+}
+.nav-cta:hover { text-decoration: none; opacity: .9; }
+
+/* Hero */
+.hero { text-align: center; padding: 90px 0 60px; }
+.hero h1 { font-size: clamp(38px, 6vw, 60px); line-height: 1.1; letter-spacing: -1.5px; font-weight: 800; }
+.hero h1 .grad {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+}
+.hero p.sub { font-size: clamp(17px, 2.5vw, 21px); color: var(--muted); max-width: 640px; margin: 22px auto 0; }
+.hero p.sub strong { color: var(--text); }
+.badges { margin-top: 18px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+.badges img { height: 20px; }
+
+/* Install / command box */
+.install { margin: 36px auto 0; max-width: 640px; }
+.cmd {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--bg-soft); border: 1px solid var(--border);
+  border-radius: 10px; padding: 14px 16px;
+  font-family: var(--mono); font-size: 14px; text-align: left;
+}
+.cmd .prompt { color: var(--accent); user-select: none; }
+.cmd code { flex: 1; color: var(--text); overflow-x: auto; white-space: nowrap; }
+.copy-btn {
+  background: var(--border); color: var(--text); border: none;
+  padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;
+  font-family: var(--sans); white-space: nowrap;
+}
+.copy-btn:hover { background: #d4dae1; }
+.hero-actions { margin-top: 22px; display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+.btn {
+  padding: 12px 24px; border-radius: 9px; font-weight: 600; font-size: 15px;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { text-decoration: none; opacity: .9; }
+.btn-ghost { border: 1px solid var(--border); color: var(--text); }
+.btn-ghost:hover { text-decoration: none; background: var(--bg-soft); }
+
+.screenshot { margin: 56px auto 0; max-width: 920px; }
+.screenshot img {
+  width: 100%; display: block; border-radius: 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 50px -24px rgba(26,31,38,.25);
+}
+
+/* Sections */
+section { padding: 64px 0; }
+.section-title { font-size: 30px; font-weight: 700; letter-spacing: -.5px; text-align: center; }
+.section-sub { color: var(--muted); text-align: center; margin-top: 8px; max-width: 600px; margin-left: auto; margin-right: auto; }
+
+/* Feature grid */
+.grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; margin-top: 40px; }
+.card {
+  background: var(--card); border: 1px solid var(--border);
+  border-radius: 12px; padding: 24px;
+}
+.card h3 { font-size: 17px; display: flex; align-items: center; gap: 10px; }
+.card .ico { font-size: 20px; }
+.card p { color: var(--muted); font-size: 14px; margin-top: 8px; }
+.card code { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
+.card.wide {
+  grid-column: 1 / -1;
+  background: linear-gradient(120deg, rgba(13,148,136,.06), rgba(99,102,241,.06));
+  display: flex; flex-direction: column; gap: 16px;
+}
+.levels { display: flex; flex-wrap: wrap; gap: 10px; }
+.level {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: 999px; padding: 6px 14px; font-size: 13px;
+}
+.level b { color: var(--accent); font-family: var(--mono); }
+.level .arrow { color: var(--muted); }
+.soon {
+  font-family: var(--sans); font-size: 11px; font-weight: 600;
+  letter-spacing: .5px; text-transform: uppercase;
+  color: var(--accent-2); background: rgba(99,102,241,.1);
+  border: 1px solid rgba(99,102,241,.25);
+  padding: 2px 9px; border-radius: 999px; vertical-align: middle;
+}
+
+/* Benchmark table */
+.bench-wrap { margin-top: 40px; overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
+table { width: 100%; border-collapse: collapse; font-size: 14px; }
+th, td { padding: 13px 18px; text-align: left; border-bottom: 1px solid var(--border); }
+th { background: var(--bg-soft); color: var(--muted); font-weight: 600; }
+tr:last-child td { border-bottom: none; }
+td.adv { color: var(--green); font-weight: 600; }
+.bench-note { color: var(--muted); font-size: 13px; text-align: center; margin-top: 16px; }
+
+/* Providers */
+.pills { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; margin-top: 36px; }
+.pill {
+  background: var(--card); border: 1px solid var(--border);
+  padding: 8px 16px; border-radius: 999px; font-size: 14px; color: var(--text);
+}
+
+/* CTA */
+.cta-box {
+  background: linear-gradient(120deg, rgba(94,234,212,.08), rgba(129,140,248,.08));
+  border: 1px solid var(--border); border-radius: 16px;
+  padding: 50px 30px; text-align: center; margin-top: 20px;
+}
+.cta-box h2 { font-size: 28px; }
+.cta-box p { color: var(--muted); margin-top: 10px; }
+
+footer { border-top: 1px solid var(--border); padding: 36px 0; color: var(--muted); font-size: 14px; }
+footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px; }
+footer a { color: var(--muted); }
+
+/* ---- Getting Started page ---- */
+.page-hero { text-align: center; padding: 64px 0 8px; }
+.page-hero h1 { font-size: clamp(30px, 5vw, 44px); font-weight: 800; letter-spacing: -1px; }
+.page-hero p { color: var(--muted); margin-top: 12px; font-size: 18px; }
+
+.steps { counter-reset: step; max-width: 760px; margin: 48px auto 0; display: flex; flex-direction: column; gap: 28px; }
+.step { display: flex; gap: 22px; align-items: flex-start; }
+.step .num {
+  flex: 0 0 auto; width: 38px; height: 38px; border-radius: 50%;
+  background: var(--accent); color: #fff; font-weight: 700; font-family: var(--mono);
+  display: flex; align-items: center; justify-content: center; font-size: 17px;
+}
+.step-body { flex: 1; min-width: 0; }
+.step-body h3 { font-size: 20px; font-weight: 700; }
+.step-body > p { color: var(--muted); margin-top: 6px; }
+.step-body .cmd { margin-top: 14px; }
+.step-body code.inline { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
+.substeps { margin: 16px 0 0; padding-left: 0; list-style: none; counter-reset: sub; display: flex; flex-direction: column; gap: 12px; }
+.substeps li {
+  position: relative; padding: 14px 16px 14px 46px;
+  background: var(--bg-soft); border: 1px solid var(--border); border-radius: 10px;
+  font-size: 14px; color: var(--text);
+}
+.substeps li::before {
+  counter-increment: sub; content: counter(sub, lower-alpha);
+  position: absolute; left: 14px; top: 13px;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--bg); border: 1px solid var(--accent); color: var(--accent);
+  font-family: var(--mono); font-size: 12px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+}
+.substeps li b { color: var(--accent-2); }
+
+@media (max-width: 640px) {
+  .grid { grid-template-columns: 1fr; }
+  .nav-links a:not(.nav-cta) { display: none; }
+  .hero { padding: 56px 0 40px; }
+}


### PR DESCRIPTION
## Site

- **New `site/getting-started.html`** — a 3-step guide (install → launch & pick a theme → connect a model, with the Provider/Model sub-steps) styled consistently with the landing page.
- **Extracted shared `site/style.css`** — the landing page's inline styles now live in one stylesheet shared by both pages, so theme changes happen in one place.
- Hero/CTA buttons and a new **Get Started** nav link point to the page.

## README (both EN & ZH)

- Replaced the emoji nav row (🌐 📖 🚀) with **flat badge buttons** merged into the badge row — no more loud blue-underlined links.
- Dropped the **Stars**, **Go Report**, and **Go Reference** badges for a cleaner header (Go Reference is for importable libraries; this is a CLI app).
- The **Getting Started** badge links to the hosted page.

Final header badges: `release` · `Website` · `Getting Started` · `Docs` · `license`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)