### PR TITLE
Add on-site docs index page

### DIFF
--- a/site/docs.html
+++ b/site/docs.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Docs — Gen Code</title>
+<meta name="description" content="Gen Code documentation: getting started, guides, concepts, reference, and architecture.">
+<meta property="og:title" content="Docs — Gen Code">
+<meta property="og:description" content="Getting started, guides, concepts, reference, and architecture for Gen Code.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://genai-io.github.io/gen-code/docs.html">
+<meta property="og:image" content="https://genai-io.github.io/gen-code/gen-code.png">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='monospace'>%E2%9C%A6</text></svg>">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <span class="logo"><a href="index.html">&lt; GEN <span class="spark">✦</span> /&gt;</a></span>
+    <div class="nav-links">
+      <a href="index.html#features">Features</a>
+      <a href="index.html#benchmark">Benchmark</a>
+      <a href="getting-started.html">Get Started</a>
+      <a href="docs.html">Docs</a>
+      <a class="nav-cta" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header class="page-hero">
+  <div class="wrap">
+    <h1>Documentation</h1>
+    <p>Everything from your first prompt to the internals.</p>
+  </div>
+</header>
+
+<section style="padding-top: 24px;">
+  <div class="wrap">
+    <div class="grid">
+
+      <div class="card doc-card">
+        <h3><span class="ico">🚀</span> Start here</h3>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/architecture.md">Architecture overview</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/operations/development.md">Local development</a></li>
+        </ul>
+      </div>
+
+      <div class="card doc-card">
+        <h3><span class="ico">📘</span> Guides</h3>
+        <ul>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/guides/writing-a-skill.md">Writing a skill</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/guides/writing-a-subagent.md">Writing a subagent</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/guides/writing-a-plugin.md">Writing a plugin</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/guides/explore-mode.md">Explore mode</a></li>
+        </ul>
+      </div>
+
+      <div class="card doc-card">
+        <h3><span class="ico">🧠</span> Concepts</h3>
+        <ul>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/concepts/harness-channels.md">Harness channels &amp; identity</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/concepts/permission-model.md">Permission model</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/concepts/extension-model.md">Extension model</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/concepts/data-flow.md">Data flow</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/concepts/compaction.md">Context compaction</a></li>
+        </ul>
+      </div>
+
+      <div class="card doc-card">
+        <h3><span class="ico">📑</span> Reference</h3>
+        <ul>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/slash-commands.md">Slash commands</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/configuration.md">Configuration</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/package-map.md">Package map</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/token-limits.md">Token limits</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/cost-tracking.md">Cost tracking</a></li>
+        </ul>
+      </div>
+
+      <div class="card doc-card">
+        <h3><span class="ico">🏗️</span> Architecture &amp; packages</h3>
+        <ul>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/architecture.md">Architecture</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/packages/index.md">Package index</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/reference/dependency-rules.md">Dependency rules</a></li>
+        </ul>
+      </div>
+
+      <div class="card doc-card">
+        <h3><span class="ico">🛠️</span> Operations</h3>
+        <ul>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/operations/testing.md">Testing</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/operations/benchmark.md">Benchmark</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/operations/release.md">Release</a></li>
+          <li><a href="https://github.com/genai-io/gen-code/blob/main/docs/operations/troubleshooting.md">Troubleshooting</a></li>
+        </ul>
+      </div>
+
+    </div>
+
+    <div class="cta-box" style="margin-top: 48px;">
+      <h2>Looking for the full tree?</h2>
+      <p>Browse every document, including per-package design pages, on GitHub.</p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="https://github.com/genai-io/gen-code/tree/main/docs">Browse all docs</a>
+        <a class="btn btn-ghost" href="index.html">Back to home</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>© <span id="year"></span> Gen Code · Apache 2.0</span>
+    <span>
+      <a href="https://github.com/genai-io/gen-code">GitHub</a> ·
+      <a href="docs.html">Docs</a> ·
+      <a href="https://github.com/genai-io/gen-code/blob/main/CONTRIBUTING.md">Contributing</a>
+    </span>
+  </div>
+</footer>
+
+<script>
+  document.getElementById('year').innerText = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -22,7 +22,7 @@
       <a href="index.html#features">Features</a>
       <a href="index.html#benchmark">Benchmark</a>
       <a href="getting-started.html">Get Started</a>
-      <a href="https://github.com/genai-io/gen-code/tree/main/docs">Docs</a>
+      <a href="docs.html">Docs</a>
       <a class="nav-cta" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
     </div>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -23,7 +23,7 @@
       <a href="#features">Features</a>
       <a href="#benchmark">Benchmark</a>
       <a href="getting-started.html">Get Started</a>
-      <a href="https://github.com/genai-io/gen-code/tree/main/docs">Docs</a>
+      <a href="docs.html">Docs</a>
       <a class="nav-cta" href="https://github.com/genai-io/gen-code">★ Star on GitHub</a>
     </div>
   </div>

--- a/site/style.css
+++ b/site/style.css
@@ -189,6 +189,15 @@ footer a { color: var(--muted); }
 }
 .substeps li b { color: var(--accent-2); }
 
+/* ---- Docs index page ---- */
+.doc-card h3 { font-size: 16px; display: flex; align-items: center; gap: 9px; }
+.doc-card ul { list-style: none; margin-top: 14px; display: flex; flex-direction: column; gap: 9px; }
+.doc-card li a {
+  color: var(--text); font-size: 14px; display: inline-flex; align-items: baseline; gap: 7px;
+}
+.doc-card li a::before { content: "›"; color: var(--accent); font-weight: 700; }
+.doc-card li a:hover { color: var(--accent); text-decoration: none; }
+
 @media (max-width: 640px) {
   .grid { grid-template-columns: 1fr; }
   .nav-links a:not(.nav-cta) { display: none; }


### PR DESCRIPTION
Adds **`site/docs.html`** — a categorized documentation hub (Start here · Guides · Concepts · Reference · Architecture · Operations) styled consistently with the landing page. Individual docs link to their GitHub-rendered markdown; Getting Started links to the on-site page.

The **Docs** nav link on the landing and Getting Started pages now points to this on-site hub instead of jumping straight to GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)