### PR TITLE
chore(governance): add community interaction templates and policies

### DIFF
--- a/.gen/skills/release/SKILL.md
+++ b/.gen/skills/release/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: release
+description: >-
+  Create a new versioned release with changelog. Bumps version in code, updates CHANGELOG.md,
+  commits, tags, and pushes using the repository release flow. GitHub Actions creates the release
+  and uses only the current changelog section as release notes. Use when the user says "release",
+  "cut a release", "bump version", "new release".
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Edit
+argument-hint: "<version>"
+---
+
+# Release — Version Bump, Tag, and Changelog
+
+Create a new release with a structured changelog and author attribution.
+
+## Arguments
+
+- `<version>` — The version to release (e.g. `1.19.1`, `v2.0.0`). The `v` prefix is optional in input but always used for the git tag.
+
+If no version is given, detect the current version and suggest the next one (see Step 1).
+
+## Workflow
+
+### 1. Detect current version and suggest the next
+
+Read the current version and identify changes since the last tag:
+
+1. Read the code version from `cmd/gen/main.go`:
+   ```bash
+   grep 'var version = ' cmd/gen/main.go
+   ```
+
+2. Get the latest git tag:
+   ```bash
+   git describe --tags --abbrev=0
+   ```
+   Strip the `v` prefix for comparison.
+
+3. **Compare.** If the code version and tag version differ, warn the user — the code may be out of sync with releases.
+
+4. Get commits since the latest tag:
+   ```bash
+   git log --oneline <prev_tag>..HEAD
+   ```
+
+5. **Suggest the next semver bump** based on commit content:
+   - **Major** (`X.0.0`): commits with `BREAKING CHANGE`, or that remove/rename public APIs
+   - **Minor** (`x.Y.0`): `feat:` commits, new functionality, new features
+   - **Patch** (`x.y.Z`): `fix:` commits, bug fixes, docs, chores, refactors
+
+   Default to **patch** if the commits don't clearly indicate otherwise.
+
+6. **Ask the user.** Use AskUserQuestion, showing the current code version and the suggested next version:
+   - Option 1: the suggested version (e.g. `v1.19.1` — patch)
+   - Option 2: one step larger bump (e.g. `v1.20.0` — minor)
+   - The "Other" option lets the user enter a custom version.
+
+   Example: if current is `1.19.0` and commits are all `fix:` and `chore:`, offer:
+   ```
+   Current version: 1.19.0 → suggest v1.19.1 (patch)
+   Options: [v1.19.1, v1.20.0]
+   ```
+
+### 2. Update the changelog
+
+Add a new `CHANGELOG.md` section for the target version. Keep older sections in place. The format must match:
+
+```markdown
+## [vX.Y.Z] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+Use the commit log from Step 1 as source material. Group entries under `Added`, `Changed`, or `Fixed` based on conventional commit prefixes.
+
+Write only the current version section in `CHANGELOG.md`. Do not pass the entire file as manual release notes later; the GitHub Actions workflow extracts the current version section automatically.
+
+### 3. Bump the version in source code
+
+Update the version string in `cmd/gen/main.go`:
+
+```go
+var version = "<new_version>"
+```
+
+### 4. Commit, tag, and push
+
+Stage the version bump and changelog update, then commit with sign-off:
+
+```bash
+git add cmd/gen/main.go CHANGELOG.md
+git commit -s -m "chore: bump version to <new_version>"
+```
+
+Push the release using the Makefile helper:
+
+```bash
+make release-push VERSION=v<new_version>
+```
+
+This target validates that the working tree is clean, the tag does not already exist, and `CHANGELOG.md` contains the matching section before it pushes `main` and the tag.
+
+The tag push triggers the GitHub Actions release workflow (`.github/workflows/release.yml`) which builds binaries, creates the GitHub release, and uses only the current changelog section as release notes.
+
+### 5. Wait for the release to be created
+
+Poll until the GitHub release exists:
+
+```bash
+gh release view v<new_version>
+```
+
+Wait up to 3 minutes, checking every 15 seconds. If the release doesn't appear, warn the user that the workflow may have failed and ask whether to investigate.
+
+## Important Notes
+
+- Always use `git commit -s` to include the DCO sign-off.
+- Never force push to main.
+- If the version string is already set to the target version, skip the bump and warn the user.
+- If there are uncommitted changes in the working tree (other than the version bump and changelog update), stop and ask the user to commit or stash them first.
+- Prefer `make release-push VERSION=v<new_version>` over manual tag and push commands.
+- The GitHub Actions workflow handles binary builds, release creation, and current-version release notes extraction.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Report a problem with Gen Code
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug! Please fill in as much as you can.
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: Duplicate check
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true
+        - label: This is a functional bug, not a security vulnerability (those must go through [SECURITY.md](https://github.com/genai-io/gen-code/blob/main/SECURITY.md))
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including expected vs. actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Run `gen ...`
+        2. Type `/...`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Run `gen --version` and fill in the rest.
+      value: |
+        - Gen Code version:
+        - OS / arch:
+        - Go version (if building from source):
+        - Provider / model:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant output. Run with `GEN_DEBUG=1` and attach `~/.gen/debug.log` if useful.
+        ⚠️ **Redact API keys, tokens, and any other secrets** before pasting — this issue is public.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/genai-io/gen-code/discussions
+    about: Ask questions, share ideas, and discuss usage here.
+  - name: 📖 Documentation
+    url: https://genai-io.github.io/gen-code/docs.html
+    about: Guides, concepts, and reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: Duplicate check
+      options:
+        - label: I searched existing issues and discussions and didn't find a duplicate
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, if any.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for contributing! Keep this concise. -->
+
+## What & why
+
+<!-- What does this change and what problem does it solve? -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Docs
+- [ ] Other:
+
+## Testing
+
+<!-- How did you verify this? Commands run, cases covered. -->
+
+```bash
+GOCACHE=/private/tmp/gencode-go-build-cache go test ./...
+```
+
+## Checklist
+
+- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
+- [ ] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
+- [ ] Tests pass locally
+- [ ] Docs updated (if behavior or config changed)
+- [ ] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+yanmxa@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ go build -o gen ./cmd/gen
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.25+
 - An LLM API key (Anthropic, OpenAI, or Google)
 
 ### Project Structure
@@ -63,17 +63,15 @@ GEN_DEBUG=1 ./gen
 
 ### Report Bugs
 
-Open an issue with:
-- Steps to reproduce
-- Expected vs actual behavior
-- OS, Go version, and provider used
+Use the [Bug report](https://github.com/genai-io/gen-code/issues/new?template=bug_report.yml)
+template. For security vulnerabilities, follow [SECURITY.md](SECURITY.md) instead —
+do not open a public issue.
 
 ### Suggest Features
 
-Open an issue describing:
-- The problem you're solving
-- Your proposed solution
-- Alternative approaches considered
+Use the [Feature request](https://github.com/genai-io/gen-code/issues/new?template=feature_request.yml)
+template. For open-ended ideas, start a
+[discussion](https://github.com/genai-io/gen-code/discussions) first.
 
 ### Submit Code
 
@@ -109,8 +107,14 @@ chore: maintenance tasks
 
 ## Code of Conduct
 
-Be respectful and constructive. We welcome contributors of all backgrounds and experience levels.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+All participants are expected to uphold these standards.
+
+## Security
+
+Found a security vulnerability? Please do **not** open a public issue.
+See our [security policy](SECURITY.md) for private reporting instructions.
 
 ## Questions?
 
-Open an issue or start a discussion. We're happy to help!
+Start a [discussion](https://github.com/genai-io/gen-code/discussions). We're happy to help!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Gen Code, please report it
+privately via GitHub's built-in reporting system:
+
+1. Go to the [Security Advisories][advisories] tab
+2. Click **Report a vulnerability**
+3. Fill in the form with a clear description of the issue and steps to reproduce
+
+We make a best effort to acknowledge reports within a few business days and to
+follow up with an initial assessment shortly after. Response times depend on
+maintainer availability.
+
+### What to include
+
+- A detailed description of the vulnerability
+- Steps to reproduce (ideally a minimal proof of concept)
+- Affected versions (or commit range)
+- Any known mitigations
+
+### Disclosure
+
+We follow a coordinated disclosure process:
+
+- A GitHub Security Advisory (GHSA) will be created to track the issue
+- Patches are developed in private, temporary forks
+- A CVE will be requested if warranted
+- Credits are given to the reporter (unless anonymity is requested)
+
+## Supported Versions
+
+Only the latest release receives security patches. We recommend always using
+the most recent version.
+
+## Security Model
+
+Gen Code is a CLI tool that:
+
+- Reads and writes files to your local filesystem
+- Sends prompts and code context to LLM providers (Anthropic, OpenAI, Google)
+- Stores session transcripts locally in `~/.gen/`
+
+**Do not** use Gen Code with untrusted extensions, MCP servers, or hooks
+without auditing them first.
+
+[advisories]: https://github.com/genai-io/gen-code/security/advisories


### PR DESCRIPTION
## Summary

Stand up the community-interaction process so first-time visitors land in a clear flow:

- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1; reports go to a maintainer email.
- **SECURITY.md** — vulnerabilities are reported privately via GitHub Security Advisories; response window is phrased as best-effort to match maintainer capacity.
- **.github/ISSUE_TEMPLATE/** — structured bug + feature templates with duplicate-check, security-redirect, and a redact-secrets warning on the bug Logs field; `config.yml` disables blank issues and routes questions to Discussions / docs.
- **.github/PULL_REQUEST_TEMPLATE.md** — Conventional Commits + DCO sign-off + CoC acknowledgement in a single checklist.
- **CONTRIBUTING.md** — links to CoC and SECURITY; points bug/feature reporters at the issue templates rather than restating fields; routes open questions to Discussions; syncs the required Go version (`1.25+`) with `go.mod`.
- **.gen/skills/release/SKILL.md** — adds the release workflow skill alongside the existing `qa` and `simplify` skills (gated by `!.gen/skills/` in `.gitignore`).

## Test plan

- [ ] Verify GitHub renders both issue templates (bug, feature) and the Discussions/docs links from the chooser.
- [ ] Open a dummy PR draft and confirm the PR template loads with the consolidated checklist.
- [ ] Confirm `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CONTRIBUTING.md` show up in the repo Community Standards check (Insights → Community).
- [ ] Confirm the GitHub Security Advisories link in `SECURITY.md` reaches the right page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)