### PR TITLE
feat(tui): add scrolling support for command suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,7 @@ install-format-tools:
 	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 
 check-format-tools:
-	@command -v goimports >/dev/null || { \
-		echo "goimports is required. Install it with: make install-format-tools"; \
-		exit 1; \
-	}
+	@command -v goimports >/dev/null || go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 
 format: check-format-tools
 	@gofmt -w $(GOFILES)

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -128,10 +128,11 @@ func (s *State) UpdateSuggestions(input string) {
 }
 
 const (
-	fileScanMaxResults     = 500
-	fileScanMaxDirsVisited = 2000
-	fileScanMaxDepth       = 6
-	fileSuggestionViewSize = 8
+	fileScanMaxResults        = 500
+	fileScanMaxDirsVisited    = 2000
+	fileScanMaxDepth          = 6
+	fileSuggestionViewSize    = 8
+	commandSuggestionViewSize = 8
 )
 
 func (s *State) updatefileSuggestions(query string) {
@@ -294,13 +295,15 @@ func (s *State) MoveDown() {
 }
 
 func (s *State) MovePageUp() {
-	s.selectedIdx = max(s.selectedIdx-fileSuggestionViewSize, 0)
+	pageSize := s.suggestionViewSize()
+	s.selectedIdx = max(s.selectedIdx-pageSize, 0)
 	s.clampViewStart()
 }
 
 func (s *State) MovePageDown() {
+	pageSize := s.suggestionViewSize()
 	maxIdx := s.maxSelectedIdx()
-	s.selectedIdx += fileSuggestionViewSize
+	s.selectedIdx += pageSize
 	if s.selectedIdx > maxIdx {
 		s.selectedIdx = maxIdx
 	}
@@ -328,16 +331,13 @@ func (s *State) maxSelectedIdx() int {
 }
 
 func (s *State) clampViewStart() {
-	if s.suggestionType != TypeFile {
-		s.viewStart = 0
-		return
-	}
-	total := len(s.fileSuggestions)
+	viewSize := s.suggestionViewSize()
+	total := s.totalSuggestions()
 	if total == 0 {
 		s.viewStart = 0
 		return
 	}
-	maxStart := max(total-fileSuggestionViewSize, 0)
+	maxStart := max(total-viewSize, 0)
 	if s.viewStart > maxStart {
 		s.viewStart = maxStart
 	}
@@ -346,9 +346,23 @@ func (s *State) clampViewStart() {
 	}
 	if s.selectedIdx < s.viewStart {
 		s.viewStart = s.selectedIdx
-	} else if s.selectedIdx >= s.viewStart+fileSuggestionViewSize {
-		s.viewStart = s.selectedIdx - fileSuggestionViewSize + 1
+	} else if s.selectedIdx >= s.viewStart+viewSize {
+		s.viewStart = s.selectedIdx - viewSize + 1
 	}
+}
+
+func (s *State) suggestionViewSize() int {
+	if s.suggestionType == TypeFile {
+		return fileSuggestionViewSize
+	}
+	return commandSuggestionViewSize
+}
+
+func (s *State) totalSuggestions() int {
+	if s.suggestionType == TypeFile {
+		return len(s.fileSuggestions)
+	}
+	return len(s.suggestions)
 }
 
 func (s *State) GetSelected() string {
@@ -446,29 +460,48 @@ func (s *State) renderfileSuggestions(width int) string {
 }
 
 func (s *State) renderCommandSuggestions(width int) string {
-	const maxItems = 5
-	items := s.suggestions
-	if len(items) > maxItems {
-		items = items[:maxItems]
+	total := len(s.suggestions)
+	viewSize := min(commandSuggestionViewSize, total)
+
+	start := s.viewStart
+	if start+viewSize > total {
+		start = total - viewSize
 	}
+	if start < 0 {
+		start = 0
+	}
+	end := min(start+viewSize, total)
+	items := s.suggestions[start:end]
 
 	boxWidth := max(width-2, 40)
 	contentWidth := max(boxWidth-2, 20)
 
 	var lines []string
+	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Primary).Bold(true)
+	header := "Commands:"
+	if total > viewSize {
+		header = fmt.Sprintf("Commands (%d/%d):", s.selectedIdx+1, total)
+	}
+	lines = append(lines, headerStyle.Render(header))
+
 	for i, cmd := range items {
 		cmdName := "/" + cmd.Name
 		maxDescLen := max(contentWidth-len(cmdName)-3, 10)
 		desc := truncateWithEllipsis(cmd.Description, maxDescLen)
 
-		line := fmt.Sprintf("%s - %s", cmdName, desc)
-
-		if i == s.selectedIdx {
+		if start+i == s.selectedIdx {
+			line := fmt.Sprintf("%s - %s", cmdName, desc)
 			lines = append(lines, selectedSuggestionStyle().Render(line))
 		} else {
 			lines = append(lines, commandNameStyle().Render(cmdName)+commandDescStyle().Render(" - "+desc))
 		}
 	}
+
+	hint := "Tab/Enter to select · Esc to cancel"
+	if total > viewSize {
+		hint = "↑/↓ scroll · Tab/Enter · Esc"
+	}
+	lines = append(lines, "", commandDescStyle().Render(hint))
 
 	content := strings.Join(lines, "\n")
 	return suggestionBoxStyle().Width(boxWidth).Render(content)


### PR DESCRIPTION
<!-- Thanks for contributing! Keep this concise. -->

## What & why

<!-- What does this change and what problem does it solve? -->

  Previously the command suggestion popup hard-coded a limit of 5 items
  with no scrolling — any commands beyond 5 were invisible and
  unreachable via cursor keys. Now it uses an 8-item scrollable viewport
  with header, position indicator, and navigation hints, matching the
  file suggestion behavior.

  Also auto-installs goimports in check-format-tools instead of erroring,
  so make build succeeds without a manual setup step.


Before the change:
<img width="800" height="254" alt="recording-1" src="https://github.com/user-attachments/assets/0e7e9028-11f8-43a8-b34f-20a33cdb288e" />

after the change:
<img width="800" height="144" alt="recording-2" src="https://github.com/user-attachments/assets/933fa8ea-1a07-4bf4-a283-fba188b2b035" />


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

<!-- How did you verify this? Commands run, cases covered. -->

```bash
GOCACHE=/private/tmp/gencode-go-build-cache go test ./...
```

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [ ] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [ ] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [ ] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
