### PR TITLE
docs: add identity rework proposal — directory-based prompt configuration

### DIFF
--- a/docs/design/decisions/minimal-default-identity.md
+++ b/docs/design/decisions/minimal-default-identity.md
@@ -8,36 +8,105 @@ and `.gen/identities/` (project). Each identity is a directory containing:
 - `prompts/` — **optional** persona-layer prompt overrides
 - `skills/` — **optional** bundled skills, active only while this identity is
 
-**Core mechanism: embedded default + file-based override.** Default prompt
-content stays `//go:embed`'d in the binary. When an identity has a prompt file
-on disk, it overrides the embedded default. When it doesn't, the embedded
-default is used directly — no extraction to disk, no upgrade clobber.
+**Core mechanism: extracted defaults + file-based fallback.** Default prompt
+content (output, engineering, guidelines, environment) is compiled into the
+binary via `//go:embed` and **extracted to `default/prompts/` on disk**.
+These files serve as the **reference** for users creating custom identities.
+On every startup, the system verifies their integrity — if a user has modified
+them, they are **overwritten** with the canonical version.
 
 Custom identities only need to contain the **differences** from default.
+When an identity is missing a prompt file, the system falls back to
+`default/prompts/` on disk.
 
 The first new built-in identity: **`readonly`**, with minimal prompts and
 read-only tools.
 
-**Locked layers.** Identity can change persona (preamble, output style, tool
-permissions, bundled skills), but policy and core guidelines are
-harness-enforced and **never droppable** — they are not listed in `sections:`
-and are always injected.
+**Locked layers.** Policy is harness-enforced and **never droppable** —
+it is not listed in `sections:` and is always injected by the harness.
+
+## `sections:` and `prompts/` — who controls what
+
+There are two concerns when assembling the system prompt:
+
+1. **Which** sections to load, and in what **order**
+2. **What content** to use for each section
+
+These are separate, and the design separates them explicitly:
+
+| Concern | Controlled by | Description |
+|---|---|---|
+| Which sections + order | `sections:` in `identity.md` | **Single source of truth.** The complete, declarative list of persona-layer sections this identity loads, in order. |
+| Content for each section | `prompts/` directory | **Override mechanism.** Files here provide custom content for sections declared in `sections:`. |
+
+### The rules
+
+1. **`sections:` is the complete list.** Only sections listed in `sections:` are loaded.
+2. **`prompts/` only affects sections already in `sections:`.** A file in `prompts/` for a section NOT in `sections:` is **ignored** (with a warning).
+3. **Content resolution for each section in `sections:`:**
+   - Look for `<identity>/prompts/<section>.txt` → found? use it
+   - Not found? → fall back to `default/prompts/<section>.txt`
+   - Neither exists? → section is empty, not injected
+4. **Policy is never in `sections:`** — it is always injected by the harness at the end.
+
+### Why not use `prompts/` directory listing as the sections list?
+
+Because then there is no way to express "load this section from default without
+creating a file for it." Every identity would need a full copy of every section
+it wants to load. And "readonly" couldn't express "only load environment" without
+deleting files — but there are no files to delete since it uses fallback.
+
+With `sections:` as the explicit list, `readonly` simply declares `[environment]`
+and gets exactly that. A custom identity declares the full set it wants and only
+creates override files for what differs.
+
+### Examples
+
+```
+# code-reviewer: loads 4 sections, overrides 1
+sections: [output, engineering, guidelines, environment]
+prompts/
+  └── output.txt          ← custom output content
+
+# readonly: loads 1 section, no overrides
+sections: [environment]
+prompts/                  ← empty or absent; environment falls back to default
+
+# concise: loads 4 sections, overrides 2
+sections: [output, engineering, guidelines, environment]
+prompts/
+  ├── output.txt          ← custom output content
+  └── engineering.txt     ← custom engineering content
+  # guidelines, environment → fall back to default
+
+# ANTI-PATTERN: guidelines.txt exists but guidelines not in sections
+sections: [output, engineering, environment]
+prompts/
+  └── guidelines.txt      ← IGNORED (with warning): guidelines not in sections:
+```
 
 ## Directory structure
 
 ```
 ~/.gen/identities/
 │
-├── default/                        ← default identity (built-in, embedded in binary)
-│   └── identity.md                 ← one file, common case
+├── default/                        ← default identity (built-in, written on init)
+│   ├── identity.md                 ← frontmatter + preamble
+│   └── prompts/                    ← full set of default prompts (REFERENCE)
+│       ├── output.txt              ← extracted from binary; DO NOT MODIFY
+│       ├── engineering.txt         ← extracted from binary; DO NOT MODIFY
+│       ├── guidelines.txt          ← extracted from binary; DO NOT MODIFY
+│       └── environment.txt         ← extracted from binary; DO NOT MODIFY
 │
-├── readonly/                       ← read-only identity (built-in, embedded in binary)
-│   └── identity.md
+├── readonly/                       ← read-only identity (built-in, written on init)
+│   ├── identity.md
+│   └── prompts/                    ← mostly empty, everything falls back to default
+│       └── environment.txt         ← optional; can also be omitted (fallback)
 │
 └── code-reviewer/                  ← user-defined identity with overrides
     ├── identity.md                 ← frontmatter + preamble
     ├── prompts/                    ← OPTIONAL persona-layer overrides
-    │   └── output.txt              ← only overrides output; rest uses embedded default
+    │   └── output.txt              ← custom output; rest falls back to default
     └── skills/                     ← OPTIONAL bundled skills
         └── lint-rules/
             └── SKILL.md
@@ -53,9 +122,16 @@ and are always injected.
 Current:                                New:
 ~/.gen/identities/                      ~/.gen/identities/
 ├── README.md                           ├── default/
-└── ml-engineer.md    ← single .md file │   └── identity.md       ← frontmatter + preamble
+└── ml-engineer.md    ← single .md file │   ├── identity.md       ← frontmatter + preamble
+                                        │   └── prompts/          ← reference copies for users
+                                        │       ├── output.txt
+                                        │       ├── engineering.txt
+                                        │       ├── guidelines.txt
+                                        │       └── environment.txt
                                         ├── readonly/
-                                        │   └── identity.md
+                                        │   ├── identity.md
+                                        │   └── prompts/
+                                        │       └── (empty, all fallback)
                                         ├── code-reviewer/
                                         │   ├── identity.md
                                         │   ├── prompts/
@@ -64,6 +140,58 @@ Current:                                New:
                                         │       └── lint-rules/SKILL.md
                                         └── old-style.md          ← migrated, body→preamble
 ```
+
+## Why defaults on disk?
+
+Extracting defaults to `default/prompts/` serves a critical purpose:
+**users need a reference to know what they can customize.** When creating
+a custom identity, a user can look at `default/prompts/output.txt` to see
+the current default output prompt, then decide what to change.
+
+Without this, users would have to guess what sections exist, what the
+default content looks like, and what format to use. The disk copy is the
+source of truth that users can read — but not modify.
+
+### Integrity enforcement
+
+On **every startup**, the system verifies the integrity of
+`default/prompts/`:
+
+```go
+func verifyDefaultPrompts() error {
+    for _, filename := range builtin.PromptFiles {
+        diskPath := filepath.Join(defaultIdentityDir, "prompts", filename)
+        canonical := builtin.ReadPrompt(filename)
+        onDisk, err := os.ReadFile(diskPath)
+
+        if os.IsNotExist(err) {
+            // Missing — restore
+            os.WriteFile(diskPath, canonical, 0644)
+            continue
+        }
+
+        if bytes.Equal(onDisk, canonical) {
+            continue // Unchanged, OK
+        }
+
+        // User modified the file — overwrite with canonical version
+        log.Warn("default prompt modified, restoring: %s", filename)
+        os.WriteFile(diskPath, canonical, 0644)
+    }
+    return nil
+}
+```
+
+Key behaviors:
+- **Every startup**: integrity check runs, not just on init/upgrade
+- **Modified? Overwritten.** User changes to `default/prompts/` are reverted
+- **Missing? Restored.** Deleted files are re-extracted
+- **User-created identities are never touched** — only `default/prompts/`
+- **Policy is not in `default/prompts/`** — it is harness-enforced and
+  injected directly by the system
+
+Users who want to customize prompts should create their own identity
+directory, not modify `default/prompts/`.
 
 ## Identity resolution: global + project
 
@@ -81,64 +209,91 @@ project wins on name collision:
 This preserves the existing behavior where project-level config can
 override user-level config.
 
-## Fallback mechanism
+## Content resolution
 
-This is the core of the design. **Defaults stay embedded** in the binary
-via `//go:embed`. The fallback chain is:
+For each section declared in `sections:`, content is resolved as follows:
 
 ```
-Loading the "output" section for identity "code-reviewer":
+For identity "code-reviewer" with sections: [output, engineering, guidelines, environment]
 
-  1. ~/.gen/identities/code-reviewer/prompts/output.txt   ← identity's override file
-                                        doesn't exist? ↓
-  2. embedded default output.txt                           ← go:embed default (always exists)
+  output:
+    1. code-reviewer/prompts/output.txt     → found! use it (CUSTOM)
 
-No extraction to disk. No upgrade clobber.
+  engineering:
+    1. code-reviewer/prompts/engineering.txt → not found
+    2. default/prompts/engineering.txt       → found! use it (FALLBACK)
+
+  guidelines:
+    1. code-reviewer/prompts/guidelines.txt  → not found
+    2. default/prompts/guidelines.txt        → found! use it (FALLBACK)
+
+  environment:
+    1. code-reviewer/prompts/environment.txt → not found
+    2. default/prompts/environment.txt       → found! use it (FALLBACK)
+
+For identity "readonly" with sections: [environment]
+
+  environment:
+    1. readonly/prompts/environment.txt      → not found
+    2. default/prompts/environment.txt       → found! use it (FALLBACK)
+
+  Note: output, engineering, guidelines are NOT in sections: → not loaded at all.
+  Even if readonly/prompts/output.txt existed, it would be ignored.
 ```
 
 ```go
-// Default prompts are embedded in the binary, never extracted.
-// An identity only has files on disk for what it explicitly overrides.
-//
-//go:embed prompts/*
-var defaultPrompts embed.FS
+func resolveSections(identity *Identity) []ResolvedSection {
+    var resolved []ResolvedSection
 
-func resolvePrompt(identityDir string, sectionName string) string {
-    // 1. Look for the identity's own override file on disk
-    p := filepath.Join(identityDir, "prompts", sectionName+".txt")
-    if content, ok := readFile(p); ok {
-        return content
+    for _, sectionName := range identity.Sections {
+        content := ""
+
+        // 1. Look for the identity's own override file on disk
+        p := filepath.Join(identity.Dir, "prompts", sectionName+".txt")
+        if c, ok := readFile(p); ok {
+            content = c
+        } else {
+            // 2. Fall back to default identity's same-named file on disk
+            p = filepath.Join(defaultIdentityDir, "prompts", sectionName+".txt")
+            if c, ok := readFile(p); ok {
+                content = c
+            }
+        }
+
+        if content != "" {
+            resolved = append(resolved, ResolvedSection{
+                Name:    sectionName,
+                Content: content,
+            })
+        }
     }
-    // 2. Fall back to embedded default (always exists, no disk I/O needed)
-    content, _ := defaultPrompts.ReadFile("prompts/" + sectionName + ".txt")
-    return string(content)
+
+    // 3. Warn about orphan files in prompts/ not declared in sections:
+    warnOrphanFiles(identity.Dir, identity.Sections)
+
+    return resolved
 }
-```
 
-### What this means
-
-**default identity**: no `prompts/` directory on disk → all sections use
-embedded defaults directly (equivalent to current behavior, no disk copy)
-
-**readonly identity**: `identity.md` declares only `environment` in sections
-→ only environment is loaded; policy and core guidelines are always injected
-by the harness regardless
-
-**Custom identity**: only needs prompt files that **differ from default**.
-For example, to just change the output style:
-
-```
-code-reviewer/
-├── identity.md             ← frontmatter: sections, tools
-│                             body: preamble
-└── prompts/
-    └── output.txt          ← its own output; all else uses embedded default
+// warnOrphanFiles checks for files in prompts/ that are not in sections:
+// and warns the user. These files are ignored.
+func warnOrphanFiles(identityDir string, declaredSections []string) {
+    promptsDir := filepath.Join(identityDir, "prompts")
+    entries, _ := os.ReadDir(promptsDir)
+    declared := setOf(declaredSections)
+    for _, e := range entries {
+        name := strings.TrimSuffix(e.Name(), ".txt")
+        if !declared[name] {
+            log.Warn("identity %s: prompts/%s ignored — section not declared in sections:",
+                filepath.Base(identityDir), e.Name())
+        }
+    }
+}
 ```
 
 ## Locked layers vs persona layers
 
-Identity changes are scoped to the **persona layer**. Policy and core
-guidelines are harness-enforced and cannot be dropped:
+Identity changes are scoped to the **persona layer**. Policy is
+harness-enforced and cannot be dropped:
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -146,6 +301,8 @@ guidelines are harness-enforced and cannot be dropped:
 │                                             │
 │  • preamble (identity declaration)          │
 │  • output / engineering style               │
+│  • guidelines (tool usage, reminders, etc.) │
+│  • environment (date, cwd, platform)        │
 │  • tool permissions (integrated with        │
 │    existing permission layer)               │
 │  • bundled skills                           │
@@ -155,22 +312,26 @@ guidelines are harness-enforced and cannot be dropped:
 │ HARNESS-ENFORCED — NEVER DROPPABLE          │
 │                                             │
 │  • policy (safety contract)                 │
-│  • core guidelines (tool usage, reminders,  │
-│    task workflow)                           │
 └─────────────────────────────────────────────┘
 ```
 
 This means:
-- `sections:` in identity config only lists **persona-layer** sections
-  (`output`, `engineering`, `environment`)
-- `policy` and `guidelines` are never in `sections:` — they are always
-  injected by the harness after persona sections
+- `sections:` in identity config is the **complete list** of persona-layer
+  sections to load, in order
+- `prompts/` files only affect sections already declared in `sections:`
+- `policy` is never in `sections:` — it is always injected by the harness
+  after persona sections
 - An identity cannot accidentally (or intentionally) remove the safety
   contract
+- Default content for **all** persona sections is on disk under
+  `default/prompts/` for reference
 
 ## identity.md format
 
 Single file with YAML frontmatter + markdown body. The body is the preamble.
+
+**`sections:` is required.** It is the complete, declarative list of which
+sections this identity loads and in what order.
 
 ### default/identity.md
 
@@ -181,6 +342,7 @@ description: Built-in Gen Code persona — software engineering generalist
 sections:
   - output
   - engineering
+  - guidelines
   - environment
 ---
 
@@ -209,7 +371,9 @@ questions. You cannot modify files or execute commands.
 name: code-reviewer
 description: Code review specialist — read-only, focused on logic and style
 sections:
+  - output
   - engineering
+  - guidelines
   - environment
 ---
 
@@ -225,8 +389,14 @@ Be thorough. Cite file paths and line numbers. Suggest fixes.
 </output>
 ```
 
-Other sections (`engineering`, `environment`) use embedded defaults.
-`policy` and `guidelines` are always injected by the harness.
+Note: `output` **must be declared in `sections:`** for `prompts/output.txt`
+to take effect. If `output` were omitted from `sections:`, the file would be
+ignored with a warning.
+
+Other sections (`engineering`, `guidelines`, `environment`) are in
+`sections:` but have no override files → fall back to `default/prompts/`.
+
+Policy is always injected by the harness.
 
 ### my-custom/identity.md (user-defined, overrides output)
 
@@ -237,6 +407,7 @@ description: My custom role — concise output + engineering standards
 sections:
   - output
   - engineering
+  - guidelines
   - environment
 ---
 
@@ -330,119 +501,228 @@ Migration logic:
 
 This is run automatically on first startup after the upgrade.
 
-## Final system prompt assembly
-
-```
-default identity → sections: [output, engineering, environment]
-  + harness-injected: policy, guidelines
-
-  You are Gen Code, ...                                    ← preamble (from identity.md body)
-  <output>                                                 ← embedded default (go:embed)
-  ...
-  </output>
-  <engineering>                                            ← embedded default
-  ...
-  </engineering>
-  <environment>                                            ← embedded default
-  date: 2026-06-05  cwd: /project  platform: darwin/arm64
-  </environment>
-  <policy>                                                 ← HARNESS: always injected
-  ...
-  </policy>
-  <guidelines name="tool-usage">...</guidelines>           ← HARNESS: always injected
-  <guidelines name="system-reminders">...</guidelines>
-  ...
-
-readonly identity → sections: [environment]
-  + harness-injected: policy, guidelines
-
-  You are an AI assistant. ...                             ← preamble
-  <environment>                                            ← embedded default
-  date: 2026-06-05  cwd: /project  platform: darwin/arm64
-  </environment>
-  <policy>                                                 ← HARNESS: always injected
-  ...
-  </policy>
-  <guidelines>                                             ← HARNESS: always injected
-  ...
-  </guidelines>
-
-code-reviewer identity → sections: [engineering, environment]
-  + harness-injected: policy, guidelines
-
-  You are a code review specialist. ...                    ← preamble
-  <output>                                                 ← code-reviewer/prompts/output.txt (override)
-  Be thorough. Cite file paths and line numbers.
-  </output>
-  <engineering>                                            ← embedded default (no override file)
-  ...
-  </engineering>
-  <environment>                                            ← embedded default
-  ...
-  </environment>
-  <policy>                                                 ← HARNESS: always injected
-  ...
-  </policy>
-  <guidelines>                                             ← HARNESS: always injected
-  ...
-  </guidelines>
-```
-
 ## Initialization
 
-No disk extraction needed for built-in identities. Defaults stay embedded.
-Only user-created identities exist on disk:
+On `gen init` or first run, built-in identity content is extracted to
+`~/.gen/identities/`. On every startup, integrity is verified:
 
 ```go
 func Initialize(cwd string) {
     // Migrate flat .md files to directory structure (one-time)
     migrateFlatIdentityFiles()
 
-    // Ensure identity directories exist
-    os.MkdirAll(filepath.Join(userIdentitiesDir), 0755)
-    // Note: default & readonly are embedded, no disk extraction needed
+    // Extract built-in identity files to disk (if missing)
+    ensureIdentityDir("default", builtin.DefaultConfig, builtin.DefaultPrompts)
+    ensureIdentityDir("readonly", builtin.ReadonlyConfig, builtin.ReadonlyPrompts)
+
+    // Verify integrity of default prompts (every startup)
+    verifyDefaultPrompts()
 }
 
-// migrateFlatIdentityFiles migrates existing ~/.gen/identities/<name>.md
-// files into ~/.gen/identities/<name>/identity.md directories.
-func migrateFlatIdentityFiles() {
-    entries, _ := os.ReadDir(userIdentitiesDir)
-    for _, e := range entries {
-        if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+// ensureIdentityDir writes identity.md and prompts/ directory.
+// All identities: existing files are NOT overwritten (respecting user modifications).
+func ensureIdentityDir(name string, config []byte, prompts map[string][]byte) {
+    dir := filepath.Join(identitiesDir, name)
+    os.MkdirAll(filepath.Join(dir, "prompts"), 0755)
+
+    // identity.md — write only if doesn't exist
+    configPath := filepath.Join(dir, "identity.md")
+    if _, err := os.Stat(configPath); os.IsNotExist(err) {
+        os.WriteFile(configPath, config, 0644)
+    }
+
+    // prompts/ — write only if doesn't exist
+    for filename, content := range prompts {
+        p := filepath.Join(dir, "prompts", filename)
+        if _, err := os.Stat(p); os.IsNotExist(err) {
+            os.WriteFile(p, content, 0644)
+        }
+    }
+}
+
+// verifyDefaultPrompts checks integrity of default/prompts/ on every startup.
+// If any file is missing or modified, it is restored from the canonical version.
+func verifyDefaultPrompts() {
+    for _, filename := range builtin.DefaultPromptFiles {
+        diskPath := filepath.Join(defaultIdentityDir, "prompts", filename)
+        canonical := builtin.ReadDefaultPrompt(filename)
+
+        onDisk, err := os.ReadFile(diskPath)
+        if os.IsNotExist(err) {
+            log.Info("restoring missing default prompt: %s", filename)
+            os.WriteFile(diskPath, canonical, 0644)
             continue
         }
-        name := strings.TrimSuffix(e.Name(), ".md")
-        dir := filepath.Join(userIdentitiesDir, name)
-        os.MkdirAll(dir, 0755)
-        os.Rename(
-            filepath.Join(userIdentitiesDir, e.Name()),
-            filepath.Join(dir, "identity.md"),
-        )
+        if err != nil {
+            log.Warn("cannot read default prompt, restoring: %s (%v)", filename, err)
+            os.WriteFile(diskPath, canonical, 0644)
+            continue
+        }
+        if !bytes.Equal(onDisk, canonical) {
+            log.Warn("default prompt was modified, restoring: %s", filename)
+            os.WriteFile(diskPath, canonical, 0644)
+        }
     }
 }
 ```
 
 Key behaviors:
-- **Embedded defaults are never extracted to disk** — no upgrade clobber
-- **User overrides only exist on disk when explicitly created**
-- **Flat `.md` files are migrated one-time** on first startup after upgrade
-- **User-created identity directories are unaffected by init/upgrade**
+- **`default/` and `readonly/` directories are auto-created on first init**
+  — written only if they don't exist
+- **Default prompts are verified on every startup** — modified files are
+  overwritten with canonical versions from the binary
+- **`readonly/` prompt files are never overwritten** once they exist
+- **User-created identity directories are unaffected**
+- **No silent upgrades** — if a prompt changes across versions, it is
+  overwritten (the canonical version in the binary is always the source
+  of truth)
+
+## Where prompt content comes from
+
+### Built-in prompts: compiled into binary, extracted to disk
+
+Built-in identity prompt content is **embedded in the binary** (via
+`//go:embed`) and written out to `~/.gen/identities/` on init.
+
+```
+Source (embedded in binary):               User directory (after init):
+internal/identity/builtin/                 ~/.gen/identities/
+├── default/                              ├── default/
+│   ├── identity.md                       │   ├── identity.md    ← extracted on init
+│   └── prompts/                          │   └── prompts/
+│       ├── output.txt                    │       ├── output.txt ← extracted on init
+│       ├── engineering.txt               │       ├── engineering.txt
+│       ├── guidelines.txt                │       ├── guidelines.txt
+│       └── environment.txt               │       └── environment.txt
+└── readonly/                             ├── readonly/
+    └── identity.md                       │   ├── identity.md    ← extracted on init
+                                          │   └── prompts/
+                                          │       └── (empty or user-created)
+                                          └── code-reviewer/     ← user-created
+                                              ├── identity.md
+                                              └── prompts/
+                                                  └── output.txt
+```
+
+### Resolution flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ For each section name in identity.Sections (in order):          │
+│                                                                 │
+│   <identity>/prompts/<section>.txt exists?                      │
+│     ├── YES → use it (OVERRIDE)                                 │
+│     └── NO  → fall back to default/prompts/<section>.txt        │
+│                 ├── exists → use it (FALLBACK)                  │
+│                 └── doesn't → skip this section (not injected)  │
+│                                                                 │
+│ Then, always append: policy (harness-injected)                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+```
+Example: code-reviewer, sections: [output, engineering, guidelines, environment]
+
+  output:
+    code-reviewer/prompts/output.txt     → EXISTS → use it (CUSTOM)
+  engineering:
+    code-reviewer/prompts/engineering.txt → not found
+    default/prompts/engineering.txt       → EXISTS → use it (FALLBACK)
+  guidelines:
+    code-reviewer/prompts/guidelines.txt  → not found
+    default/prompts/guidelines.txt        → EXISTS → use it (FALLBACK)
+  environment:
+    code-reviewer/prompts/environment.txt → not found
+    default/prompts/environment.txt       → EXISTS → use it (FALLBACK)
+  + policy (harness)
+
+Example: readonly, sections: [environment]
+
+  environment:
+    readonly/prompts/environment.txt      → not found
+    default/prompts/environment.txt       → EXISTS → use it (FALLBACK)
+  + policy (harness)
+  (output, engineering, guidelines not in sections: → not loaded)
+```
+
+## Final system prompt assembly
+
+```
+default identity → sections: [output, engineering, guidelines, environment]
+  + harness-injected: policy
+
+  You are Gen Code, ...                                    ← preamble (from identity.md body)
+  <output>                                                 ← default/prompts/output.txt
+  ...
+  </output>
+  <engineering>                                            ← default/prompts/engineering.txt
+  ...
+  </engineering>
+  <guidelines name="tool-usage">...</guidelines>           ← default/prompts/guidelines.txt
+  <guidelines name="system-reminders">...</guidelines>
+  ...
+  <environment>                                            ← default/prompts/environment.txt
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+
+readonly identity → sections: [environment]
+  + harness-injected: policy
+
+  You are an AI assistant. ...                             ← preamble
+  <environment>                                            ← fallback to default/prompts/environment.txt
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+
+code-reviewer identity → sections: [output, engineering, guidelines, environment]
+  + harness-injected: policy
+
+  You are a code review specialist. ...                    ← preamble
+  <output>                                                 ← code-reviewer/prompts/output.txt (override)
+  Be thorough. Cite file paths and line numbers.
+  </output>
+  <engineering>                                            ← fallback to default/prompts/engineering.txt
+  ...
+  </engineering>
+  <guidelines>                                             ← fallback to default/prompts/guidelines.txt
+  ...
+  </guidelines>
+  <environment>                                            ← fallback to default/prompts/environment.txt
+  ...
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+```
 
 ## User experience
 
 ### Creating a custom identity
 
 ```bash
+# 0. Look at default prompts for reference
+ls ~/.gen/identities/default/prompts/
+# output.txt  engineering.txt  guidelines.txt  environment.txt
+cat ~/.gen/identities/default/prompts/output.txt
+# Shows the default output prompt — use as reference
+
 # 1. Create directory
 mkdir -p ~/.gen/identities/concise
 
-# 2. Write identity.md
+# 2. Write identity.md (sections: is the complete list)
 cat > ~/.gen/identities/concise/identity.md << 'EOF'
 ---
 name: concise
 description: Concise mode
 sections:
+  - output
   - engineering
+  - guidelines
   - environment
 ---
 
@@ -450,6 +730,7 @@ You are a concise, direct coding assistant. Get to the point.
 EOF
 
 # 3. (Optional) Override a section's prompt
+#    Must also be declared in sections: above
 mkdir -p ~/.gen/identities/concise/prompts
 cat > ~/.gen/identities/concise/prompts/output.txt << 'EOF'
 <output>
@@ -469,6 +750,48 @@ gen> /identity concise
 ✓ Identity switched: concise
 ```
 
+### Anti-pattern: override file without declaring section
+
+```bash
+# BAD: output.txt exists but output not in sections:
+cat > ~/.gen/identities/bad-identity/identity.md << 'EOF'
+---
+name: bad-identity
+description: This won't work as expected
+sections:
+  - engineering
+  - environment
+---
+
+I am a bad example.
+EOF
+
+cat > ~/.gen/identities/bad-identity/prompts/output.txt << 'EOF'
+<output>
+This will NEVER be loaded. section "output" is not in sections:
+</output>
+EOF
+
+# On startup:
+# WARN: identity bad-identity: prompts/output.txt ignored — section "output" not declared in sections:
+```
+
+### Modifying default prompts (NOT allowed — will be reverted)
+
+```bash
+# This will be reverted on next startup:
+vim ~/.gen/identities/default/prompts/output.txt
+
+# On next startup:
+# WARN: default prompt was modified, restoring: output.txt
+#
+# To customize output, create your own identity instead:
+# mkdir -p ~/.gen/identities/my-style/prompts
+# cp ~/.gen/identities/default/prompts/output.txt \
+#    ~/.gen/identities/my-style/prompts/output.txt
+# vim ~/.gen/identities/my-style/prompts/output.txt
+```
+
 ### Creating a project-level identity
 
 ```bash
@@ -481,6 +804,7 @@ name: project-role
 description: Project-specific conventions
 sections:
   - engineering
+  - guidelines
   - environment
 ---
 
@@ -499,13 +823,13 @@ rm -rf ~/.gen/identities/my-custom
 
 ```go
 type Identity struct {
-    Name        string   // Directory name, also the identity name
-    Description string   // One-liner
-    Preamble    string   // Identity declaration (body of identity.md)
-    Sections    []string // Persona-layer section names to load, in order
+    Name        string     // Directory name, also the identity name
+    Description string     // One-liner
+    Preamble    string     // Identity declaration (body of identity.md)
+    Sections    []string   // Complete list of persona-layer sections to load, in order
     Tools       ToolPolicy // Tool restrictions (merged with permission layer)
-    Dir         string   // Path to this identity's directory (empty for embedded default)
-    SkillsDir   string   // Path to bundled skills/ (empty if none)
+    Dir         string     // Path to this identity's directory
+    SkillsDir   string     // Path to bundled skills/ (empty if none)
 }
 ```
 
@@ -513,16 +837,17 @@ type Identity struct {
 
 ### Adding a new built-in identity
 
-1. Add `identity.md` content to embedded FS (`internal/identity/builtin/`)
-2. Register in the built-in identity list
-3. Done. No disk extraction needed
+1. Create a directory under `internal/identity/builtin/` with `identity.md`
+2. Optionally add `prompts/` files
+3. Add one line in `Initialize()`: `ensureIdentityDir("new-name", ...)`
+4. Done. On next `gen init`, it's written to disk
 
 ### Adding a new persona-layer section type
 
-1. Add a `.txt` file to the embedded default prompts
+1. Add a `.txt` file under the built-in default prompts
 2. Add one line to the section→slot mapping table
-3. Existing identities that declare the new section in their list will
-   automatically load it
+3. Existing identities that declare the new section in their `sections:` will
+   automatically load it (via fallback to `default/prompts/`)
 4. Identities that don't declare it are unaffected
 
 ### Community sharing
@@ -541,11 +866,11 @@ gen> /identity architect
 | Existing concept | Change |
 |---|---|
 | `~/.gen/identities/*.md` | Flat `.md` files migrated to `<name>/identity.md` directories |
-| `prompts/*.txt` (embedded) | Default prompts stay `//go:embed`'d, never extracted |
+| `prompts/*.txt` (embedded) | Default prompts extracted to `default/prompts/` on disk on init |
 | `.gen/identities/` (project) | **Kept** — project wins on name collision |
 | `applyDefaults()` | Hardcoded scope branches replaced by iterating over `Identity.Sections` |
 | `core.Scope` | Keep Main/Subagent concept, but persona-layer composition is identity-driven |
-| Policy & guidelines | **Harness-enforced** — always injected, never droppable |
+| Policy | **Harness-enforced** — always injected, never droppable, never on disk |
 | `/identity` | Scans both `.gen/identities/` and `~/.gen/identities/` |
 | `settings.json` | `"identity": "readonly"` points to the directory name |
 | Skill loader | Active identity's `skills/` added as a search root |
@@ -553,16 +878,19 @@ gen> /identity architect
 
 ## Default prompts content
 
-Files embedded in the binary under `prompts/` match the current
-`prompts/*.txt` content:
+Files under `default/prompts/` match the current `prompts/*.txt` content.
+They are extracted from the binary on init and integrity-verified on every
+startup:
 
-| File | Corresponding Slot | Layer | Description |
-|---|---|---|---|
-| `output.txt` | SlotIdentity | Persona | Tone, updates, behavior |
-| `engineering.txt` | SlotIdentity | Persona | Restraint, code conventions, error handling |
-| `environment.txt` | SlotEnvironment | Persona | Environment template (with `{{.Date}}` etc. variables) |
-| `policy.txt` | SlotPolicy | **Locked** | Safety contract (harness-enforced) |
-| `guidelines.txt` | SlotGuidelines | **Locked** | Tool usage, system reminders, task workflow (harness-enforced) |
+| File | Corresponding Slot | Description |
+|---|---|---|
+| `output.txt` | SlotIdentity | Tone, updates, behavior |
+| `engineering.txt` | SlotIdentity | Restraint, code conventions, error handling |
+| `guidelines.txt` | SlotGuidelines | Tool usage, system reminders, task workflow, when to ask |
+| `environment.txt` | SlotEnvironment | Environment template (with `{{.Date}}` etc. variables) |
+
+`policy.txt` is **not** on disk — it is injected directly by the harness
+and cannot be viewed, modified, or removed by the user.
 
 ## Decided questions
 
@@ -570,26 +898,46 @@ Files embedded in the binary under `prompts/` match the current
    (project) and `~/.gen/identities/` (user). Project wins on name collision.
    `identity/registry.go` already resolves both today.
 
-2. **Can the default identity be deleted?** → **Not applicable.** Default
-   identity is embedded in the binary, not extracted to disk. There is no
-   `~/.gen/identities/default/` directory to delete.
+2. **Can defaults be modified by users?** → **No.** `default/prompts/` files
+   are integrity-verified on every startup. Modified files are overwritten
+   with canonical versions from the binary. Users who want customization
+   should create their own identity directory.
 
-3. **Should upgrades update default prompts?** → **Yes, automatically.**
-   Default prompts are `//go:embed`'d. Upgrading the binary upgrades the
-   defaults — no disk extraction, no clobber risk, no user data loss.
-   User overrides in custom identities are unaffected.
+3. **What happens if a user deletes `default/prompts/`?** → **Restored on
+   next startup.** Missing files are re-extracted from the binary. Deleting
+   the `default/` directory entirely does not break the system — it will
+   be recreated on next init.
 
-4. **Can an identity remove the safety policy?** → **No.** `policy` and
-   `guidelines` are harness-enforced locked layers. They are never listed
-   in `sections:` and are always injected regardless of identity.
+4. **Should upgrades update default prompts?** → **Yes, automatically.**
+   Default prompts are verified on every startup against the canonical
+   version in the binary. When a new version ships updated prompts, they
+   overwrite the disk copies on next startup. Users who customized prompts
+   in their own identity directories are unaffected.
 
-5. **How are existing flat `.md` identities handled?** → **One-time migration.**
+5. **Can an identity remove the safety policy?** → **No.** Policy is not
+   extracted to disk, not listed in `sections:`, and always injected by
+   the harness. No identity can remove or modify it.
+
+6. **How are existing flat `.md` identities handled?** → **One-time migration.**
    On first startup after upgrade, `~/.gen/identities/<name>.md` is moved to
    `~/.gen/identities/<name>/identity.md`. Non-breaking.
+
+7. **Why extract defaults to disk instead of keeping them embedded-only?**
+   → Users need a reference to know what they can customize. When creating a
+   custom identity, the files under `default/prompts/` show exactly what
+   sections exist, what format they use, and what the current defaults are.
+   Without this, users would have to guess.
+
+8. **`sections:` vs `prompts/` — which one controls what gets loaded?**
+   → **`sections:` is the single source of truth.** It is the complete,
+   declarative list of persona-layer sections to load, in order. `prompts/`
+   files only provide override content for sections already declared in
+   `sections:`. A file in `prompts/` for an undeclared section is ignored
+   with a warning.
 
 ## References
 
 - [identity.go](../../internal/identity/identity.go) — Current Identity struct
 - [catalog.go](../../internal/core/system/catalog.go) — Current system prompt assembly
 - [section.go](../../internal/core/section.go) — Section and Slot types
-- [prompts/](../../internal/core/system/prompts/) — Currently embedded prompt files (stay embedded, not extracted)
+- [prompts/](../../internal/core/system/prompts/) — Currently embedded prompt files (will migrate to built-in default identity directory extracted on init)

--- a/docs/design/decisions/minimal-default-identity.md
+++ b/docs/design/decisions/minimal-default-identity.md
@@ -1,0 +1,491 @@
+# Proposal: Identity Rework — Directory-based Prompt Configuration
+
+## Summary
+
+Redesign Identity as a **directory structure** under `~/.gen/identities/`.
+Each identity is a directory containing:
+- `identity.yaml` — role configuration (name, preamble, section list, tool permissions)
+- `prompts/` — the prompt files used by this role
+
+**Core mechanism: file-based fallback.** When an identity is missing a prompt
+file, the same-named file from the `default` identity is used automatically.
+Custom identities only need to contain the **differences** from default.
+
+The first new built-in identity: **`readonly`**, with minimal prompts and
+read-only tools.
+
+## Directory structure
+
+```
+~/.gen/identities/
+│
+├── default/                        ← default identity (built-in, written on init)
+│   ├── identity.yaml               ← role configuration
+│   └── prompts/                    ← full set of default prompts
+│       ├── output.txt
+│       ├── engineering.txt
+│       ├── policy.txt
+│       ├── guidelines.txt
+│       └── environment.txt
+│
+├── readonly/                       ← read-only identity (built-in, written on init)
+│   ├── identity.yaml
+│   └── prompts/                    ← mostly empty, everything falls back to default
+│       └── environment.txt         ← optional; can also be omitted (fallback)
+│
+└── my-custom/                      ← user-defined identity
+    ├── identity.yaml
+    └── prompts/
+        └── output.txt              ← only overrides output; rest fall back to default
+```
+
+### Compared to current structure
+
+```
+Current:                                New:
+~/.gen/identities/                      ~/.gen/identities/
+├── README.md                           ├── default/
+└── ml-engineer.md    ← single .md file │   ├── identity.yaml
+                                        │   └── prompts/
+                                        │       ├── output.txt
+                                        │       ├── engineering.txt
+                                        │       ├── policy.txt
+                                        │       ├── guidelines.txt
+                                        │       └── environment.txt
+                                        ├── readonly/
+                                        │   ├── identity.yaml
+                                        │   └── prompts/
+                                        │       └── (empty, all fallback)
+                                        └── my-custom/
+                                            ├── identity.yaml
+                                            └── prompts/
+                                                └── output.txt
+```
+
+## Fallback mechanism
+
+This is the core of the design. When loading a section prompt for an identity,
+the system searches in this order:
+
+```
+Loading the "output" section for identity "readonly":
+
+  1. ~/.gen/identities/readonly/prompts/output.txt   ← identity's own
+  2. ~/.gen/identities/default/prompts/output.txt    ← fallback to default
+
+If neither exists → section is empty, not injected
+```
+
+```go
+func resolvePrompt(identityDir string, sectionName string) string {
+    // 1. Look for the identity's own prompt file
+    p := filepath.Join(identityDir, "prompts", sectionName+".txt")
+    if content, ok := readFile(p); ok {
+        return content
+    }
+    // 2. Fall back to default identity's same-named file
+    p = filepath.Join(defaultIdentityDir, "prompts", sectionName+".txt")
+    if content, ok := readFile(p); ok {
+        return content
+    }
+    // 3. Neither exists → don't inject this section
+    return ""
+}
+```
+
+### What this means
+
+**default identity**: all prompt files exist → uses entirely its own content
+(equivalent to current behavior)
+
+**readonly identity**: `prompts/` directory is basically empty → all sections
+would fall back to default's prompt files. But `identity.yaml` only declares
+the `environment` section, so only environment is loaded.
+
+**Custom identity**: only needs prompt files that **differ from default**.
+For example, to just change the output style:
+
+```
+my-custom/
+├── identity.yaml         ← declares sections: [output, engineering, policy, guidelines, environment]
+└── prompts/
+    └── output.txt        ← its own output; other four fall back to default
+```
+
+## identity.yaml format
+
+### default/identity.yaml
+
+```yaml
+name: default
+description: Built-in Gen Code persona — software engineering generalist
+
+preamble: |
+  You are Gen Code, an interactive AI assistant for software
+  engineering tasks running in a terminal.
+
+# Declares which sections to load.
+# Each section's prompt content is loaded from prompts/<name>.txt.
+# If the file doesn't exist, falls back to default identity's same-named file.
+sections:
+  - output
+  - engineering
+  - policy
+  - guidelines
+  - environment
+
+# Tool permissions
+tools:
+  # empty = all available
+```
+
+### readonly/identity.yaml
+
+```yaml
+name: readonly
+description: Read-only assistant — search, analyze, answer questions
+
+preamble: |
+  You are an AI assistant. You can read files, search code, and answer
+  questions. You cannot modify files or execute commands.
+
+sections:
+  - environment
+
+tools:
+  allow:
+    - Read
+    - Grep
+    - Glob
+    - WebSearch
+    - WebFetch
+    - Task
+```
+
+### code-reviewer/identity.yaml
+
+```yaml
+name: code-reviewer
+description: Code review specialist — read-only, focused on logic and style
+
+preamble: |
+  You are a code review specialist. Carefully read code to find bugs,
+  security vulnerabilities, performance issues, and style inconsistencies.
+
+sections:
+  - engineering
+  - policy
+  - environment
+
+tools:
+  allow:
+    - Read
+    - Grep
+    - Glob
+```
+
+### my-custom/identity.yaml (user-defined, overrides output)
+
+```yaml
+name: my-custom
+description: My custom role — concise output + engineering standards
+
+preamble: |
+  You are a concise coding assistant. One sentence per response, max.
+
+sections:
+  - output
+  - engineering
+  - policy
+  - guidelines
+  - environment
+
+tools: {}
+```
+
+Together with `my-custom/prompts/output.txt`:
+
+```
+<output>
+Always concise. Use bullet points. Never apologize.
+</output>
+```
+
+The other four sections (engineering, policy, guidelines, environment)
+automatically fall back to files in `default/prompts/`.
+
+## Initialization
+
+On `gen init` or first run, built-in identities are written to
+`~/.gen/identities/`:
+
+```go
+func Initialize(cwd string) {
+    ensureIdentityDir("default", builtin.DefaultIdentityConfig, builtin.DefaultPrompts)
+    ensureIdentityDir("readonly", builtin.ReadonlyIdentityConfig, builtin.ReadonlyPrompts)
+    // More built-in identities can be added in the future
+}
+
+// ensureIdentityDir writes identity.yaml and prompts/ directory.
+// default identity: prompt files can be overwritten on upgrade (user changes will be lost).
+// Other identities: existing files are NOT overwritten (respecting user modifications).
+func ensureIdentityDir(name string, config []byte, prompts map[string][]byte) {
+    dir := filepath.Join(identitiesDir, name)
+    os.MkdirAll(filepath.Join(dir, "prompts"), 0755)
+
+    // identity.yaml — write only if doesn't exist (all identities)
+    configPath := filepath.Join(dir, "identity.yaml")
+    if _, err := os.Stat(configPath); os.IsNotExist(err) {
+        os.WriteFile(configPath, config, 0644)
+    }
+
+    // prompts/ — default always updates; others write only if doesn't exist
+    for filename, content := range prompts {
+        p := filepath.Join(dir, "prompts", filename)
+        if name == "default" {
+            // Default identity: upgrades can overwrite prompt files
+            os.WriteFile(p, content, 0644)
+        } else if _, err := os.Stat(p); os.IsNotExist(err) {
+            os.WriteFile(p, content, 0644)
+        }
+    }
+}
+```
+
+Key behaviors:
+- **`default` and `readonly` directories are auto-created on first init**
+- **`default` prompt files are overwritten on upgrade** — new Gen Code
+  versions will update the default prompts. User modifications to default
+  prompts will be lost on upgrade
+- **`default`'s identity.yaml and `readonly` directory are never overwritten**
+  — protecting user's configuration changes
+- **If the `default` directory is deleted, it will be restored on init**
+- **User-created identity directories are unaffected by init**
+
+## Where prompt content comes from
+
+### Built-in prompts: compiled into binary, extracted to disk
+
+Built-in identity prompt content is **embedded in the binary** (via
+`//go:embed`) and written out to `~/.gen/identities/` on init.
+
+```
+Source (embedded in binary):               User directory (after init):
+internal/identity/builtin/                 ~/.gen/identities/
+├── default/                              ├── default/
+│   ├── identity.yaml                     │   ├── identity.yaml    ← extracted
+│   └── prompts/                          │   └── prompts/
+│       ├── output.txt                    │       ├── output.txt   ← extracted
+│       ├── engineering.txt               │       ├── engineering.txt
+│       ├── policy.txt                    │       ├── policy.txt
+│       ├── guidelines.txt                │       ├── guidelines.txt
+│       └── environment.txt               │       └── environment.txt
+└── readonly/                             ├── readonly/
+    └── identity.yaml                     │   └── identity.yaml    ← extracted
+                                          └── my-custom/           ← user-created
+                                              ├── identity.yaml
+                                              └── prompts/
+                                                  └── output.txt
+```
+
+### Resolution priority
+
+```
+Loading the "output" section for identity "my-custom":
+
+  my-custom/prompts/output.txt  exists? → use it
+                        doesn't? ↓
+  default/prompts/output.txt    exists? → use it
+                        doesn't? ↓
+                        don't inject this section
+
+Loading sections for identity "readonly":
+  sections: [environment]
+
+  → Load the environment section:
+    readonly/prompts/environment.txt  exists? → use it
+                             doesn't? ↓
+    default/prompts/environment.txt   exists? → use it
+                             doesn't? ↓
+                             don't inject
+
+  → output/engineering/policy/guidelines not declared → not loaded, not injected
+```
+
+## Final system prompt assembly
+
+```
+default identity → sections: [output, engineering, policy, guidelines, environment]
+
+  You are Gen Code, ...                                    ← preamble
+  <output>                                                 ← default/prompts/output.txt
+  ...
+  </output>
+  <engineering>                                            ← default/prompts/engineering.txt
+  ...
+  </engineering>
+  <policy>                                                 ← default/prompts/policy.txt
+  ...
+  </policy>
+  <guidelines name="tool-usage">...</guidelines>           ← default/prompts/guidelines.txt
+  <guidelines name="system-reminders">...</guidelines>
+  ...
+  <environment>                                            ← default/prompts/environment.txt
+  date: 2026-06-04  cwd: /project  platform: darwin/arm64
+  </environment>
+
+readonly identity → sections: [environment]
+
+  You are an AI assistant. ...                             ← preamble
+  <environment>                                            ← fallback to default/prompts/environment.txt
+  date: 2026-06-04  cwd: /project  platform: darwin/arm64
+  </environment>
+
+my-custom identity → sections: [output, engineering, policy, guidelines, environment]
+
+  You are a concise coding assistant. ...                  ← preamble
+  <output>                                                 ← my-custom/prompts/output.txt (its own)
+  Always concise. Use bullet points. Never apologize.
+  </output>
+  <engineering>                                            ← fallback to default
+  <policy>                                                 ← fallback to default
+  <guidelines>                                             ← fallback to default
+  <environment>                                            ← fallback to default
+```
+
+## User experience
+
+### Creating a custom identity
+
+```bash
+# 1. Create directory
+mkdir -p ~/.gen/identities/concise/prompts
+
+# 2. Write identity.yaml
+cat > ~/.gen/identities/concise/identity.yaml << 'EOF'
+name: concise
+description: Concise mode
+preamble: "You are a concise, direct coding assistant. Get to the point."
+sections:
+  - engineering
+  - policy
+  - environment
+tools: {}
+EOF
+
+# 3. (Optional) Override a section's prompt
+cat > ~/.gen/identities/concise/prompts/output.txt << 'EOF'
+<output>
+Answer directly. No small talk. No apologies.
+</output>
+EOF
+
+# 4. Switch to the identity
+gen> /identity concise
+✓ Identity switched: concise
+```
+
+### Modifying default prompts (affects all identities)
+
+```bash
+# Edit the default prompt files directly
+vim ~/.gen/identities/default/prompts/output.txt
+
+# All identities without their own output.txt (including readonly, my-custom, etc.)
+# will use the modified default prompt
+```
+
+### Deleting a custom identity
+
+```bash
+rm -rf ~/.gen/identities/my-custom
+# Completely removed; default and other identities unaffected
+```
+
+## Identity data structure
+
+```go
+type Identity struct {
+    Name        string   // Directory name, also the identity name
+    Description string   // One-liner
+    Preamble    string   // Identity declaration
+    Sections    []string // Section names to load, in order
+    AllowTools  []string // Tool allowlist (empty = all)
+    DenyTools   []string // Tool denylist
+    Dir         string   // Path to this identity's directory
+}
+```
+
+## Extensibility
+
+### Adding a new built-in identity
+
+1. Create a directory under `internal/identity/builtin/` with `identity.yaml`
+2. Optionally add `prompts/` files
+3. Add one line in `Initialize()`: `ensureIdentityDir("new-name", ...)`
+4. Done. On next `gen init`, it's written to disk
+
+### Adding a new section type
+
+1. Add a `.txt` file under `default/prompts/` (e.g. `testing.txt`)
+2. Add one line to the section→slot mapping table
+3. Existing identities that declare the new section in their list will
+   automatically load it
+4. Identities that don't declare it are unaffected
+
+### Community sharing
+
+```bash
+# Export an identity (directory tarball)
+tar -czf my-architect.tar.gz -C ~/.gen/identities architect/
+
+# Import
+tar -xzf my-architect.tar.gz -C ~/.gen/identities/
+gen> /identity architect
+```
+
+## Relationship with existing system
+
+| Existing concept | Change |
+|---|---|
+| `~/.gen/identities/*.md` | Single .md files replaced by directory structure |
+| `prompts/identity.txt` etc. | Content moves to `default/prompts/` files, written on init |
+| `applyDefaults()` | Hardcoded scope branches replaced by iterating over `Identity.Sections` |
+| `core.Scope` | Keep Main/Subagent concept, but section composition is identity-driven |
+| `/identity` | Auto-scans subdirectories under `~/.gen/identities/` |
+| `settings.json` | `"identity": "readonly"` points to the directory name |
+
+## Default prompts content
+
+Files under `default/prompts/` match the current `prompts/*.txt` content:
+
+| File | Corresponding Slot | Description |
+|---|---|---|
+| `output.txt` | SlotIdentity | Tone, updates, behavior |
+| `engineering.txt` | SlotIdentity | Restraint, code conventions, error handling |
+| `policy.txt` | SlotPolicy | Safety contract |
+| `guidelines.txt` | SlotGuidelines | Tool usage, system reminders, task workflow, when to ask |
+| `environment.txt` | SlotEnvironment | Environment template (with `{{.Date}}` etc. variables) |
+
+## Decided questions
+
+1. **Project-level identity directories?** → **Not supported.** Only use
+   `~/.gen/identities/`, no `.gen/identities/` project-level directory.
+   Keep it simple.
+
+2. **Can the default identity be deleted?** → **Not allowed.** If the user
+   deletes `~/.gen/identities/default/`, it will be restored on next init.
+   Other identities depend on default as fallback; deleting it would break
+   the system.
+
+3. **Should upgrades update default prompts?** → **Yes.** New Gen Code
+   versions will overwrite default prompt files on init. User modifications
+   to default prompts will be lost on upgrade. Users who want to persist
+   customizations should put them in their own identity directory.
+
+## References
+
+- [identity.go](../../internal/identity/identity.go) — Current Identity struct
+- [catalog.go](../../internal/core/system/catalog.go) — Current system prompt assembly
+- [section.go](../../internal/core/section.go) — Section and Slot types
+- [prompts/](../../internal/core/system/prompts/) — Currently embedded prompt files (will migrate to built-in default identity directory)

--- a/docs/design/decisions/minimal-default-identity.md
+++ b/docs/design/decisions/minimal-default-identity.md
@@ -2,41 +2,49 @@
 
 ## Summary
 
-Redesign Identity as a **directory structure** under `~/.gen/identities/`.
-Each identity is a directory containing:
-- `identity.yaml` — role configuration (name, preamble, section list, tool permissions)
-- `prompts/` — the prompt files used by this role
+Redesign Identity as a **directory structure** under `~/.gen/identities/` (user)
+and `.gen/identities/` (project). Each identity is a directory containing:
+- `identity.md` — role configuration (frontmatter + preamble), the common case
+- `prompts/` — **optional** persona-layer prompt overrides
+- `skills/` — **optional** bundled skills, active only while this identity is
 
-**Core mechanism: file-based fallback.** When an identity is missing a prompt
-file, the same-named file from the `default` identity is used automatically.
+**Core mechanism: embedded default + file-based override.** Default prompt
+content stays `//go:embed`'d in the binary. When an identity has a prompt file
+on disk, it overrides the embedded default. When it doesn't, the embedded
+default is used directly — no extraction to disk, no upgrade clobber.
+
 Custom identities only need to contain the **differences** from default.
 
 The first new built-in identity: **`readonly`**, with minimal prompts and
 read-only tools.
+
+**Locked layers.** Identity can change persona (preamble, output style, tool
+permissions, bundled skills), but policy and core guidelines are
+harness-enforced and **never droppable** — they are not listed in `sections:`
+and are always injected.
 
 ## Directory structure
 
 ```
 ~/.gen/identities/
 │
-├── default/                        ← default identity (built-in, written on init)
-│   ├── identity.yaml               ← role configuration
-│   └── prompts/                    ← full set of default prompts
-│       ├── output.txt
-│       ├── engineering.txt
-│       ├── policy.txt
-│       ├── guidelines.txt
-│       └── environment.txt
+├── default/                        ← default identity (built-in, embedded in binary)
+│   └── identity.md                 ← one file, common case
 │
-├── readonly/                       ← read-only identity (built-in, written on init)
-│   ├── identity.yaml
-│   └── prompts/                    ← mostly empty, everything falls back to default
-│       └── environment.txt         ← optional; can also be omitted (fallback)
+├── readonly/                       ← read-only identity (built-in, embedded in binary)
+│   └── identity.md
 │
-└── my-custom/                      ← user-defined identity
-    ├── identity.yaml
-    └── prompts/
-        └── output.txt              ← only overrides output; rest fall back to default
+└── code-reviewer/                  ← user-defined identity with overrides
+    ├── identity.md                 ← frontmatter + preamble
+    ├── prompts/                    ← OPTIONAL persona-layer overrides
+    │   └── output.txt              ← only overrides output; rest uses embedded default
+    └── skills/                     ← OPTIONAL bundled skills
+        └── lint-rules/
+            └── SKILL.md
+
+.gen/identities/                    ← project-level (overrides user-level on name collision)
+└── project-role/
+    └── identity.md
 ```
 
 ### Compared to current structure
@@ -45,162 +53,194 @@ read-only tools.
 Current:                                New:
 ~/.gen/identities/                      ~/.gen/identities/
 ├── README.md                           ├── default/
-└── ml-engineer.md    ← single .md file │   ├── identity.yaml
-                                        │   └── prompts/
-                                        │       ├── output.txt
-                                        │       ├── engineering.txt
-                                        │       ├── policy.txt
-                                        │       ├── guidelines.txt
-                                        │       └── environment.txt
+└── ml-engineer.md    ← single .md file │   └── identity.md       ← frontmatter + preamble
                                         ├── readonly/
-                                        │   ├── identity.yaml
-                                        │   └── prompts/
-                                        │       └── (empty, all fallback)
-                                        └── my-custom/
-                                            ├── identity.yaml
-                                            └── prompts/
-                                                └── output.txt
+                                        │   └── identity.md
+                                        ├── code-reviewer/
+                                        │   ├── identity.md
+                                        │   ├── prompts/
+                                        │   │   └── output.txt
+                                        │   └── skills/
+                                        │       └── lint-rules/SKILL.md
+                                        └── old-style.md          ← migrated, body→preamble
 ```
+
+## Identity resolution: global + project
+
+`identity/registry.go` already resolves both scopes today. Keep both —
+project wins on name collision:
+
+```
+/identity foo
+
+  1. .gen/identities/foo/     → found? use project
+  2. ~/.gen/identities/foo/   → found? use user
+  3. neither                  → use default
+```
+
+This preserves the existing behavior where project-level config can
+override user-level config.
 
 ## Fallback mechanism
 
-This is the core of the design. When loading a section prompt for an identity,
-the system searches in this order:
+This is the core of the design. **Defaults stay embedded** in the binary
+via `//go:embed`. The fallback chain is:
 
 ```
-Loading the "output" section for identity "readonly":
+Loading the "output" section for identity "code-reviewer":
 
-  1. ~/.gen/identities/readonly/prompts/output.txt   ← identity's own
-  2. ~/.gen/identities/default/prompts/output.txt    ← fallback to default
+  1. ~/.gen/identities/code-reviewer/prompts/output.txt   ← identity's override file
+                                        doesn't exist? ↓
+  2. embedded default output.txt                           ← go:embed default (always exists)
 
-If neither exists → section is empty, not injected
+No extraction to disk. No upgrade clobber.
 ```
 
 ```go
+// Default prompts are embedded in the binary, never extracted.
+// An identity only has files on disk for what it explicitly overrides.
+//
+//go:embed prompts/*
+var defaultPrompts embed.FS
+
 func resolvePrompt(identityDir string, sectionName string) string {
-    // 1. Look for the identity's own prompt file
+    // 1. Look for the identity's own override file on disk
     p := filepath.Join(identityDir, "prompts", sectionName+".txt")
     if content, ok := readFile(p); ok {
         return content
     }
-    // 2. Fall back to default identity's same-named file
-    p = filepath.Join(defaultIdentityDir, "prompts", sectionName+".txt")
-    if content, ok := readFile(p); ok {
-        return content
-    }
-    // 3. Neither exists → don't inject this section
-    return ""
+    // 2. Fall back to embedded default (always exists, no disk I/O needed)
+    content, _ := defaultPrompts.ReadFile("prompts/" + sectionName + ".txt")
+    return string(content)
 }
 ```
 
 ### What this means
 
-**default identity**: all prompt files exist → uses entirely its own content
-(equivalent to current behavior)
+**default identity**: no `prompts/` directory on disk → all sections use
+embedded defaults directly (equivalent to current behavior, no disk copy)
 
-**readonly identity**: `prompts/` directory is basically empty → all sections
-would fall back to default's prompt files. But `identity.yaml` only declares
-the `environment` section, so only environment is loaded.
+**readonly identity**: `identity.md` declares only `environment` in sections
+→ only environment is loaded; policy and core guidelines are always injected
+by the harness regardless
 
 **Custom identity**: only needs prompt files that **differ from default**.
 For example, to just change the output style:
 
 ```
-my-custom/
-├── identity.yaml         ← declares sections: [output, engineering, policy, guidelines, environment]
+code-reviewer/
+├── identity.md             ← frontmatter: sections, tools
+│                             body: preamble
 └── prompts/
-    └── output.txt        ← its own output; other four fall back to default
+    └── output.txt          ← its own output; all else uses embedded default
 ```
 
-## identity.yaml format
+## Locked layers vs persona layers
 
-### default/identity.yaml
+Identity changes are scoped to the **persona layer**. Policy and core
+guidelines are harness-enforced and cannot be dropped:
 
-```yaml
+```
+┌─────────────────────────────────────────────┐
+│ IDENTITY CAN CHANGE (persona layer)         │
+│                                             │
+│  • preamble (identity declaration)          │
+│  • output / engineering style               │
+│  • tool permissions (integrated with        │
+│    existing permission layer)               │
+│  • bundled skills                           │
+└─────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────┐
+│ HARNESS-ENFORCED — NEVER DROPPABLE          │
+│                                             │
+│  • policy (safety contract)                 │
+│  • core guidelines (tool usage, reminders,  │
+│    task workflow)                           │
+└─────────────────────────────────────────────┘
+```
+
+This means:
+- `sections:` in identity config only lists **persona-layer** sections
+  (`output`, `engineering`, `environment`)
+- `policy` and `guidelines` are never in `sections:` — they are always
+  injected by the harness after persona sections
+- An identity cannot accidentally (or intentionally) remove the safety
+  contract
+
+## identity.md format
+
+Single file with YAML frontmatter + markdown body. The body is the preamble.
+
+### default/identity.md
+
+```markdown
+---
 name: default
 description: Built-in Gen Code persona — software engineering generalist
-
-preamble: |
-  You are Gen Code, an interactive AI assistant for software
-  engineering tasks running in a terminal.
-
-# Declares which sections to load.
-# Each section's prompt content is loaded from prompts/<name>.txt.
-# If the file doesn't exist, falls back to default identity's same-named file.
 sections:
   - output
   - engineering
-  - policy
-  - guidelines
   - environment
+---
 
-# Tool permissions
-tools:
-  # empty = all available
+You are Gen Code, an interactive AI assistant for software
+engineering tasks running in a terminal.
 ```
 
-### readonly/identity.yaml
+### readonly/identity.md
 
-```yaml
+```markdown
+---
 name: readonly
 description: Read-only assistant — search, analyze, answer questions
-
-preamble: |
-  You are an AI assistant. You can read files, search code, and answer
-  questions. You cannot modify files or execute commands.
-
 sections:
   - environment
+---
 
-tools:
-  allow:
-    - Read
-    - Grep
-    - Glob
-    - WebSearch
-    - WebFetch
-    - Task
+You are an AI assistant. You can read files, search code, and answer
+questions. You cannot modify files or execute commands.
 ```
 
-### code-reviewer/identity.yaml
+### code-reviewer/identity.md (user-defined with overrides)
 
-```yaml
+```markdown
+---
 name: code-reviewer
 description: Code review specialist — read-only, focused on logic and style
-
-preamble: |
-  You are a code review specialist. Carefully read code to find bugs,
-  security vulnerabilities, performance issues, and style inconsistencies.
-
 sections:
   - engineering
-  - policy
   - environment
+---
 
-tools:
-  allow:
-    - Read
-    - Grep
-    - Glob
+You are a code review specialist. Carefully read code to find bugs,
+security vulnerabilities, performance issues, and style inconsistencies.
 ```
 
-### my-custom/identity.yaml (user-defined, overrides output)
+Together with `code-reviewer/prompts/output.txt`:
 
-```yaml
+```
+<output>
+Be thorough. Cite file paths and line numbers. Suggest fixes.
+</output>
+```
+
+Other sections (`engineering`, `environment`) use embedded defaults.
+`policy` and `guidelines` are always injected by the harness.
+
+### my-custom/identity.md (user-defined, overrides output)
+
+```markdown
+---
 name: my-custom
 description: My custom role — concise output + engineering standards
-
-preamble: |
-  You are a concise coding assistant. One sentence per response, max.
-
 sections:
   - output
   - engineering
-  - policy
-  - guidelines
   - environment
+---
 
-tools: {}
+You are a concise coding assistant. One sentence per response, max.
 ```
 
 Together with `my-custom/prompts/output.txt`:
@@ -211,147 +251,182 @@ Always concise. Use bullet points. Never apologize.
 </output>
 ```
 
-The other four sections (engineering, policy, guidelines, environment)
-automatically fall back to files in `default/prompts/`.
+## Bundling skills
+
+Skills are already directory-based, loaded by `skill/loader.go` with
+multiple search scopes. The active identity's `skills/` directory is
+added as an additional search root — live only while the identity is active:
+
+```
+Skill loader search paths (when identity "code-reviewer" is active):
+
+  1. identities/code-reviewer/skills/   ← NEW: identity-bundled, active only while this identity is
+  2. ~/.gen/skills/                     ← user-installed skills
+  3. .gen/skills/                       ← project skills
+  4. built-in skills                    ← shipped with the binary
+```
+
+This makes identities self-contained and shareable:
+
+```bash
+# Export an identity with its skills
+tar -czf code-reviewer.tar.gz -C ~/.gen/identities code-reviewer/
+
+# Import — everything comes along
+tar -xzf code-reviewer.tar.gz -C ~/.gen/identities/
+gen> /identity code-reviewer
+```
+
+Open choice: **bundle** skills (self-contained, shareable as a tarball)
+vs **reference** by name (`skills: [git:commit]`, no duplication).
+Default to bundle, allow reference.
+
+## Tool permissions
+
+Tools are scoped through the **existing permission layer**, not a parallel
+`tools: allow/deny` system. The identity's tool constraints are merged into
+the current permission configuration:
+
+```markdown
+---
+name: readonly
+description: Read-only assistant
+sections:
+  - environment
+tools:
+  allow:
+    - Read
+    - Grep
+    - Glob
+    - WebSearch
+    - WebFetch
+---
+```
+
+- Empty or omitted `tools:` → no restrictions (all tools available)
+- `tools.allow:` → only these tools are available
+- Tool permissions are **intersected** with the existing permission layer
+  (e.g. if the harness already blocks `Bash`, identity can't re-enable it)
+
+## Migration: flat `<name>.md` → directory
+
+Existing flat `~/.gen/identities/<name>.md` files are migrated
+non-breakingly:
+
+```
+Before:                                After:
+~/.gen/identities/                     ~/.gen/identities/
+└── ml-engineer.md                     └── ml-engineer/
+    (frontmatter: name, sections           └── identity.md
+     body: preamble)                           (same file, body → preamble)
+```
+
+Migration logic:
+1. Scan `~/.gen/identities/` for `.md` files that are NOT inside
+   subdirectories
+2. For each: create `<name>/` directory, move file to `<name>/identity.md`
+3. Body of original `.md` becomes the preamble (markdown body of
+   `identity.md`)
+
+This is run automatically on first startup after the upgrade.
+
+## Final system prompt assembly
+
+```
+default identity → sections: [output, engineering, environment]
+  + harness-injected: policy, guidelines
+
+  You are Gen Code, ...                                    ← preamble (from identity.md body)
+  <output>                                                 ← embedded default (go:embed)
+  ...
+  </output>
+  <engineering>                                            ← embedded default
+  ...
+  </engineering>
+  <environment>                                            ← embedded default
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+  <guidelines name="tool-usage">...</guidelines>           ← HARNESS: always injected
+  <guidelines name="system-reminders">...</guidelines>
+  ...
+
+readonly identity → sections: [environment]
+  + harness-injected: policy, guidelines
+
+  You are an AI assistant. ...                             ← preamble
+  <environment>                                            ← embedded default
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+  <guidelines>                                             ← HARNESS: always injected
+  ...
+  </guidelines>
+
+code-reviewer identity → sections: [engineering, environment]
+  + harness-injected: policy, guidelines
+
+  You are a code review specialist. ...                    ← preamble
+  <output>                                                 ← code-reviewer/prompts/output.txt (override)
+  Be thorough. Cite file paths and line numbers.
+  </output>
+  <engineering>                                            ← embedded default (no override file)
+  ...
+  </engineering>
+  <environment>                                            ← embedded default
+  ...
+  </environment>
+  <policy>                                                 ← HARNESS: always injected
+  ...
+  </policy>
+  <guidelines>                                             ← HARNESS: always injected
+  ...
+  </guidelines>
+```
 
 ## Initialization
 
-On `gen init` or first run, built-in identities are written to
-`~/.gen/identities/`:
+No disk extraction needed for built-in identities. Defaults stay embedded.
+Only user-created identities exist on disk:
 
 ```go
 func Initialize(cwd string) {
-    ensureIdentityDir("default", builtin.DefaultIdentityConfig, builtin.DefaultPrompts)
-    ensureIdentityDir("readonly", builtin.ReadonlyIdentityConfig, builtin.ReadonlyPrompts)
-    // More built-in identities can be added in the future
+    // Migrate flat .md files to directory structure (one-time)
+    migrateFlatIdentityFiles()
+
+    // Ensure identity directories exist
+    os.MkdirAll(filepath.Join(userIdentitiesDir), 0755)
+    // Note: default & readonly are embedded, no disk extraction needed
 }
 
-// ensureIdentityDir writes identity.yaml and prompts/ directory.
-// default identity: prompt files can be overwritten on upgrade (user changes will be lost).
-// Other identities: existing files are NOT overwritten (respecting user modifications).
-func ensureIdentityDir(name string, config []byte, prompts map[string][]byte) {
-    dir := filepath.Join(identitiesDir, name)
-    os.MkdirAll(filepath.Join(dir, "prompts"), 0755)
-
-    // identity.yaml — write only if doesn't exist (all identities)
-    configPath := filepath.Join(dir, "identity.yaml")
-    if _, err := os.Stat(configPath); os.IsNotExist(err) {
-        os.WriteFile(configPath, config, 0644)
-    }
-
-    // prompts/ — default always updates; others write only if doesn't exist
-    for filename, content := range prompts {
-        p := filepath.Join(dir, "prompts", filename)
-        if name == "default" {
-            // Default identity: upgrades can overwrite prompt files
-            os.WriteFile(p, content, 0644)
-        } else if _, err := os.Stat(p); os.IsNotExist(err) {
-            os.WriteFile(p, content, 0644)
+// migrateFlatIdentityFiles migrates existing ~/.gen/identities/<name>.md
+// files into ~/.gen/identities/<name>/identity.md directories.
+func migrateFlatIdentityFiles() {
+    entries, _ := os.ReadDir(userIdentitiesDir)
+    for _, e := range entries {
+        if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+            continue
         }
+        name := strings.TrimSuffix(e.Name(), ".md")
+        dir := filepath.Join(userIdentitiesDir, name)
+        os.MkdirAll(dir, 0755)
+        os.Rename(
+            filepath.Join(userIdentitiesDir, e.Name()),
+            filepath.Join(dir, "identity.md"),
+        )
     }
 }
 ```
 
 Key behaviors:
-- **`default` and `readonly` directories are auto-created on first init**
-- **`default` prompt files are overwritten on upgrade** — new Gen Code
-  versions will update the default prompts. User modifications to default
-  prompts will be lost on upgrade
-- **`default`'s identity.yaml and `readonly` directory are never overwritten**
-  — protecting user's configuration changes
-- **If the `default` directory is deleted, it will be restored on init**
-- **User-created identity directories are unaffected by init**
-
-## Where prompt content comes from
-
-### Built-in prompts: compiled into binary, extracted to disk
-
-Built-in identity prompt content is **embedded in the binary** (via
-`//go:embed`) and written out to `~/.gen/identities/` on init.
-
-```
-Source (embedded in binary):               User directory (after init):
-internal/identity/builtin/                 ~/.gen/identities/
-├── default/                              ├── default/
-│   ├── identity.yaml                     │   ├── identity.yaml    ← extracted
-│   └── prompts/                          │   └── prompts/
-│       ├── output.txt                    │       ├── output.txt   ← extracted
-│       ├── engineering.txt               │       ├── engineering.txt
-│       ├── policy.txt                    │       ├── policy.txt
-│       ├── guidelines.txt                │       ├── guidelines.txt
-│       └── environment.txt               │       └── environment.txt
-└── readonly/                             ├── readonly/
-    └── identity.yaml                     │   └── identity.yaml    ← extracted
-                                          └── my-custom/           ← user-created
-                                              ├── identity.yaml
-                                              └── prompts/
-                                                  └── output.txt
-```
-
-### Resolution priority
-
-```
-Loading the "output" section for identity "my-custom":
-
-  my-custom/prompts/output.txt  exists? → use it
-                        doesn't? ↓
-  default/prompts/output.txt    exists? → use it
-                        doesn't? ↓
-                        don't inject this section
-
-Loading sections for identity "readonly":
-  sections: [environment]
-
-  → Load the environment section:
-    readonly/prompts/environment.txt  exists? → use it
-                             doesn't? ↓
-    default/prompts/environment.txt   exists? → use it
-                             doesn't? ↓
-                             don't inject
-
-  → output/engineering/policy/guidelines not declared → not loaded, not injected
-```
-
-## Final system prompt assembly
-
-```
-default identity → sections: [output, engineering, policy, guidelines, environment]
-
-  You are Gen Code, ...                                    ← preamble
-  <output>                                                 ← default/prompts/output.txt
-  ...
-  </output>
-  <engineering>                                            ← default/prompts/engineering.txt
-  ...
-  </engineering>
-  <policy>                                                 ← default/prompts/policy.txt
-  ...
-  </policy>
-  <guidelines name="tool-usage">...</guidelines>           ← default/prompts/guidelines.txt
-  <guidelines name="system-reminders">...</guidelines>
-  ...
-  <environment>                                            ← default/prompts/environment.txt
-  date: 2026-06-04  cwd: /project  platform: darwin/arm64
-  </environment>
-
-readonly identity → sections: [environment]
-
-  You are an AI assistant. ...                             ← preamble
-  <environment>                                            ← fallback to default/prompts/environment.txt
-  date: 2026-06-04  cwd: /project  platform: darwin/arm64
-  </environment>
-
-my-custom identity → sections: [output, engineering, policy, guidelines, environment]
-
-  You are a concise coding assistant. ...                  ← preamble
-  <output>                                                 ← my-custom/prompts/output.txt (its own)
-  Always concise. Use bullet points. Never apologize.
-  </output>
-  <engineering>                                            ← fallback to default
-  <policy>                                                 ← fallback to default
-  <guidelines>                                             ← fallback to default
-  <environment>                                            ← fallback to default
-```
+- **Embedded defaults are never extracted to disk** — no upgrade clobber
+- **User overrides only exist on disk when explicitly created**
+- **Flat `.md` files are migrated one-time** on first startup after upgrade
+- **User-created identity directories are unaffected by init/upgrade**
 
 ## User experience
 
@@ -359,47 +434,65 @@ my-custom identity → sections: [output, engineering, policy, guidelines, envir
 
 ```bash
 # 1. Create directory
-mkdir -p ~/.gen/identities/concise/prompts
+mkdir -p ~/.gen/identities/concise
 
-# 2. Write identity.yaml
-cat > ~/.gen/identities/concise/identity.yaml << 'EOF'
+# 2. Write identity.md
+cat > ~/.gen/identities/concise/identity.md << 'EOF'
+---
 name: concise
 description: Concise mode
-preamble: "You are a concise, direct coding assistant. Get to the point."
 sections:
   - engineering
-  - policy
   - environment
-tools: {}
+---
+
+You are a concise, direct coding assistant. Get to the point.
 EOF
 
 # 3. (Optional) Override a section's prompt
+mkdir -p ~/.gen/identities/concise/prompts
 cat > ~/.gen/identities/concise/prompts/output.txt << 'EOF'
 <output>
 Answer directly. No small talk. No apologies.
 </output>
 EOF
 
-# 4. Switch to the identity
+# 4. (Optional) Bundle skills
+mkdir -p ~/.gen/identities/concise/skills/short-answers
+cat > ~/.gen/identities/concise/skills/short-answers/SKILL.md << 'EOF'
+# Short Answers
+Always answer in 3 lines or fewer.
+EOF
+
+# 5. Switch to the identity
 gen> /identity concise
 ✓ Identity switched: concise
 ```
 
-### Modifying default prompts (affects all identities)
+### Creating a project-level identity
 
 ```bash
-# Edit the default prompt files directly
-vim ~/.gen/identities/default/prompts/output.txt
+# Lives in the repo, can be committed
+mkdir -p .gen/identities/project-role
 
-# All identities without their own output.txt (including readonly, my-custom, etc.)
-# will use the modified default prompt
+cat > .gen/identities/project-role/identity.md << 'EOF'
+---
+name: project-role
+description: Project-specific conventions
+sections:
+  - engineering
+  - environment
+---
+
+You are working on the Gen Code project. Follow Go conventions.
+EOF
 ```
 
 ### Deleting a custom identity
 
 ```bash
 rm -rf ~/.gen/identities/my-custom
-# Completely removed; default and other identities unaffected
+# Completely removed; other identities unaffected
 ```
 
 ## Identity data structure
@@ -408,11 +501,11 @@ rm -rf ~/.gen/identities/my-custom
 type Identity struct {
     Name        string   // Directory name, also the identity name
     Description string   // One-liner
-    Preamble    string   // Identity declaration
-    Sections    []string // Section names to load, in order
-    AllowTools  []string // Tool allowlist (empty = all)
-    DenyTools   []string // Tool denylist
-    Dir         string   // Path to this identity's directory
+    Preamble    string   // Identity declaration (body of identity.md)
+    Sections    []string // Persona-layer section names to load, in order
+    Tools       ToolPolicy // Tool restrictions (merged with permission layer)
+    Dir         string   // Path to this identity's directory (empty for embedded default)
+    SkillsDir   string   // Path to bundled skills/ (empty if none)
 }
 ```
 
@@ -420,14 +513,13 @@ type Identity struct {
 
 ### Adding a new built-in identity
 
-1. Create a directory under `internal/identity/builtin/` with `identity.yaml`
-2. Optionally add `prompts/` files
-3. Add one line in `Initialize()`: `ensureIdentityDir("new-name", ...)`
-4. Done. On next `gen init`, it's written to disk
+1. Add `identity.md` content to embedded FS (`internal/identity/builtin/`)
+2. Register in the built-in identity list
+3. Done. No disk extraction needed
 
-### Adding a new section type
+### Adding a new persona-layer section type
 
-1. Add a `.txt` file under `default/prompts/` (e.g. `testing.txt`)
+1. Add a `.txt` file to the embedded default prompts
 2. Add one line to the section→slot mapping table
 3. Existing identities that declare the new section in their list will
    automatically load it
@@ -436,7 +528,7 @@ type Identity struct {
 ### Community sharing
 
 ```bash
-# Export an identity (directory tarball)
+# Export an identity (directory tarball — includes skills if bundled)
 tar -czf my-architect.tar.gz -C ~/.gen/identities architect/
 
 # Import
@@ -448,44 +540,56 @@ gen> /identity architect
 
 | Existing concept | Change |
 |---|---|
-| `~/.gen/identities/*.md` | Single .md files replaced by directory structure |
-| `prompts/identity.txt` etc. | Content moves to `default/prompts/` files, written on init |
+| `~/.gen/identities/*.md` | Flat `.md` files migrated to `<name>/identity.md` directories |
+| `prompts/*.txt` (embedded) | Default prompts stay `//go:embed`'d, never extracted |
+| `.gen/identities/` (project) | **Kept** — project wins on name collision |
 | `applyDefaults()` | Hardcoded scope branches replaced by iterating over `Identity.Sections` |
-| `core.Scope` | Keep Main/Subagent concept, but section composition is identity-driven |
-| `/identity` | Auto-scans subdirectories under `~/.gen/identities/` |
+| `core.Scope` | Keep Main/Subagent concept, but persona-layer composition is identity-driven |
+| Policy & guidelines | **Harness-enforced** — always injected, never droppable |
+| `/identity` | Scans both `.gen/identities/` and `~/.gen/identities/` |
 | `settings.json` | `"identity": "readonly"` points to the directory name |
+| Skill loader | Active identity's `skills/` added as a search root |
+| Tool permissions | Merged into existing permission layer, not a parallel system |
 
 ## Default prompts content
 
-Files under `default/prompts/` match the current `prompts/*.txt` content:
+Files embedded in the binary under `prompts/` match the current
+`prompts/*.txt` content:
 
-| File | Corresponding Slot | Description |
-|---|---|---|
-| `output.txt` | SlotIdentity | Tone, updates, behavior |
-| `engineering.txt` | SlotIdentity | Restraint, code conventions, error handling |
-| `policy.txt` | SlotPolicy | Safety contract |
-| `guidelines.txt` | SlotGuidelines | Tool usage, system reminders, task workflow, when to ask |
-| `environment.txt` | SlotEnvironment | Environment template (with `{{.Date}}` etc. variables) |
+| File | Corresponding Slot | Layer | Description |
+|---|---|---|---|
+| `output.txt` | SlotIdentity | Persona | Tone, updates, behavior |
+| `engineering.txt` | SlotIdentity | Persona | Restraint, code conventions, error handling |
+| `environment.txt` | SlotEnvironment | Persona | Environment template (with `{{.Date}}` etc. variables) |
+| `policy.txt` | SlotPolicy | **Locked** | Safety contract (harness-enforced) |
+| `guidelines.txt` | SlotGuidelines | **Locked** | Tool usage, system reminders, task workflow (harness-enforced) |
 
 ## Decided questions
 
-1. **Project-level identity directories?** → **Not supported.** Only use
-   `~/.gen/identities/`, no `.gen/identities/` project-level directory.
-   Keep it simple.
+1. **Project-level identity directories?** → **Keep both.** `.gen/identities/`
+   (project) and `~/.gen/identities/` (user). Project wins on name collision.
+   `identity/registry.go` already resolves both today.
 
-2. **Can the default identity be deleted?** → **Not allowed.** If the user
-   deletes `~/.gen/identities/default/`, it will be restored on next init.
-   Other identities depend on default as fallback; deleting it would break
-   the system.
+2. **Can the default identity be deleted?** → **Not applicable.** Default
+   identity is embedded in the binary, not extracted to disk. There is no
+   `~/.gen/identities/default/` directory to delete.
 
-3. **Should upgrades update default prompts?** → **Yes.** New Gen Code
-   versions will overwrite default prompt files on init. User modifications
-   to default prompts will be lost on upgrade. Users who want to persist
-   customizations should put them in their own identity directory.
+3. **Should upgrades update default prompts?** → **Yes, automatically.**
+   Default prompts are `//go:embed`'d. Upgrading the binary upgrades the
+   defaults — no disk extraction, no clobber risk, no user data loss.
+   User overrides in custom identities are unaffected.
+
+4. **Can an identity remove the safety policy?** → **No.** `policy` and
+   `guidelines` are harness-enforced locked layers. They are never listed
+   in `sections:` and are always injected regardless of identity.
+
+5. **How are existing flat `.md` identities handled?** → **One-time migration.**
+   On first startup after upgrade, `~/.gen/identities/<name>.md` is moved to
+   `~/.gen/identities/<name>/identity.md`. Non-breaking.
 
 ## References
 
 - [identity.go](../../internal/identity/identity.go) — Current Identity struct
 - [catalog.go](../../internal/core/system/catalog.go) — Current system prompt assembly
 - [section.go](../../internal/core/section.go) — Section and Slot types
-- [prompts/](../../internal/core/system/prompts/) — Currently embedded prompt files (will migrate to built-in default identity directory)
+- [prompts/](../../internal/core/system/prompts/) — Currently embedded prompt files (stay embedded, not extracted)

--- a/docs/design/decisions/minimal-default-identity.zh.md
+++ b/docs/design/decisions/minimal-default-identity.zh.md
@@ -1,0 +1,910 @@
+# 提案：身份体系重构 — 基于目录的 Prompt 配置
+
+## 摘要
+
+将 Identity 重新设计为 **目录结构**，分别位于 `~/.gen/identities/`（用户级）
+和 `.gen/identities/`（项目级）。每个身份是一个目录，包含：
+- `identity.md` — 角色配置（frontmatter + 前言），最常见的情况
+- `prompts/` — **可选的** 角色层 prompt 覆盖
+- `skills/` — **可选的** 捆绑技能，仅在此身份激活时生效
+
+**核心机制：提取的默认值 + 基于文件的回退。** 默认 prompt 内容通过
+`//go:embed` 编译到二进制中，并在启动时**提取到磁盘上的 `default/prompts/`**。
+这些文件作为用户创建自定义身份时的**参考**。每次启动时，系统会验证其完整性——
+如果用户修改了它们，它们会被**覆盖**为规范版本。
+
+自定义身份只需要包含与默认值的**差异部分**。
+当某个身份缺少 prompt 文件时，系统回退到磁盘上的 `default/prompts/`。
+
+首个新内置身份：**`readonly`**，具有最小化的 prompt 和只读工具。
+
+**锁定层。** 策略由框架强制执行，**永远不可移除**——
+它不在 `sections:` 中列出，始终由框架注入。
+
+## `sections:` 与 `prompts/` —— 谁控制什么
+
+组装系统 prompt 时有两个关注点：
+
+1. 加载**哪些**节，以及以什么**顺序**
+2. 每个节使用**什么内容**
+
+这两者是分开的，设计上也显式地分开：
+
+| 关注点 | 由谁控制 | 描述 |
+|---|---|---|
+| 哪些节 + 顺序 | `identity.md` 中的 `sections:` | **唯一真相来源。** 此身份加载的角色层节的完整声明式列表，按顺序排列。 |
+| 每个节的内容 | `prompts/` 目录 | **覆盖机制。** 此处的文件为 `sections:` 中声明的节提供自定义内容。 |
+
+### 规则
+
+1. **`sections:` 是完整的清单。** 只有列在 `sections:` 中的节才会被加载。
+2. **`prompts/` 只影响已在 `sections:` 中的节。** `prompts/` 中属于未在 `sections:` 中声明的节的文件会被**忽略**（并产生警告）。
+3. **`sections:` 中每个节的内容解析：**
+   - 查找 `<identity>/prompts/<section>.txt` → 存在？使用它
+   - 不存在？→ 回退到 `default/prompts/<section>.txt`
+   - 两者都不存在？→ 该节为空，不注入
+4. **Policy 永远不在 `sections:` 中** — 它始终由框架在最后注入。
+
+### 为什么不用 `prompts/` 目录列表作为节列表？
+
+因为这样就无法表达"从默认值加载此节，但不需要为它创建文件"。每个身份
+都需要一份它想加载的每个节的完整副本。而且 `readonly` 无法表达"只加载
+environment"而不删除文件——但它根本没有文件可删，因为它使用的是回退。
+
+有了 `sections:` 作为显式列表，`readonly` 只需声明 `[environment]` 就能
+精确得到它想要的内容。自定义身份声明它想要的完整集合，只为有所不同的节
+创建覆盖文件。
+
+### 示例
+
+```
+# code-reviewer：加载 4 个节，覆盖 1 个
+sections: [output, engineering, guidelines, environment]
+prompts/
+  └── output.txt          ← 自定义 output 内容
+
+# readonly：加载 1 个节，无覆盖
+sections: [environment]
+prompts/                  ← 空或不存在；environment 回退到默认值
+
+# concise：加载 4 个节，覆盖 2 个
+sections: [output, engineering, guidelines, environment]
+prompts/
+  ├── output.txt          ← 自定义 output 内容
+  └── engineering.txt     ← 自定义 engineering 内容
+  # guidelines、environment → 回退到默认值
+
+# 反模式：guidelines.txt 存在但 guidelines 不在 sections 中
+sections: [output, engineering, environment]
+prompts/
+  └── guidelines.txt      ← 被忽略（带警告）：guidelines 不在 sections: 中
+```
+
+## 目录结构
+
+```
+~/.gen/identities/
+│
+├── default/                        ← 默认身份（内置，初始化时写入）
+│   ├── identity.md                 ← frontmatter + 前言
+│   └── prompts/                    ← 完整的默认 prompt 集合（参考用）
+│       ├── output.txt              ← 从二进制中提取；请勿修改
+│       ├── engineering.txt         ← 从二进制中提取；请勿修改
+│       ├── guidelines.txt          ← 从二进制中提取；请勿修改
+│       └── environment.txt         ← 从二进制中提取；请勿修改
+│
+├── readonly/                       ← 只读身份（内置，初始化时写入）
+│   ├── identity.md
+│   └── prompts/                    ← 大部分为空，全部回退到默认值
+│       └── environment.txt         ← 可选；也可以省略（回退）
+│
+└── code-reviewer/                  ← 用户自定义身份，带覆盖
+    ├── identity.md                 ← frontmatter + 前言
+    ├── prompts/                    ← 可选的角色层覆盖
+    │   └── output.txt              ← 自定义 output；其余回退到默认值
+    └── skills/                     ← 可选的捆绑技能
+        └── lint-rules/
+            └── SKILL.md
+
+.gen/identities/                    ← 项目级（名称冲突时覆盖用户级）
+└── project-role/
+    └── identity.md
+```
+
+### 与当前结构的对比
+
+```
+当前:                                    新:
+~/.gen/identities/                      ~/.gen/identities/
+├── README.md                           ├── default/
+└── ml-engineer.md    ← 单个 .md 文件    │   ├── identity.md       ← frontmatter + 前言
+                                        │   └── prompts/          ← 供用户参考的副本
+                                        │       ├── output.txt
+                                        │       ├── engineering.txt
+                                        │       ├── guidelines.txt
+                                        │       └── environment.txt
+                                        ├── readonly/
+                                        │   ├── identity.md
+                                        │   └── prompts/
+                                        │       └── （空，全部回退）
+                                        ├── code-reviewer/
+                                        │   ├── identity.md
+                                        │   ├── prompts/
+                                        │   │   └── output.txt
+                                        │   └── skills/
+                                        │       └── lint-rules/SKILL.md
+                                        └── old-style.md          ← 已迁移，正文→前言
+```
+
+## 为什么要把默认值放到磁盘上？
+
+将默认值提取到 `default/prompts/` 有一个关键目的：
+**用户需要一个参考来了解可以自定义什么。** 在创建自定义身份时，
+用户可以查看 `default/prompts/output.txt` 来了解当前的默认输出 prompt，
+然后决定要修改什么。
+
+没有这个，用户只能猜测有哪些节、默认内容是什么样的、以及使用什么格式。
+磁盘副本是用户可以阅读的真相来源——但不能修改。
+
+### 完整性强制
+
+**每次启动时**，系统验证 `default/prompts/` 的完整性：
+
+```go
+func verifyDefaultPrompts() error {
+    for _, filename := range builtin.PromptFiles {
+        diskPath := filepath.Join(defaultIdentityDir, "prompts", filename)
+        canonical := builtin.ReadPrompt(filename)
+        onDisk, err := os.ReadFile(diskPath)
+
+        if os.IsNotExist(err) {
+            // 缺失 — 恢复
+            os.WriteFile(diskPath, canonical, 0644)
+            continue
+        }
+
+        if bytes.Equal(onDisk, canonical) {
+            continue // 未更改，OK
+        }
+
+        // 用户修改了文件 — 用规范版本覆盖
+        log.Warn("default prompt modified, restoring: %s", filename)
+        os.WriteFile(diskPath, canonical, 0644)
+    }
+    return nil
+}
+```
+
+关键行为：
+- **每次启动**：运行完整性检查，而不仅仅在 init/upgrade 时
+- **被修改？覆盖。** 用户对 `default/prompts/` 的更改会被还原
+- **缺失？恢复。** 被删除的文件会被重新提取
+- **用户创建的身份永远不会被触及** — 仅 `default/prompts/`
+- **Policy 不在 `default/prompts/` 中** — 它由框架强制执行，由系统直接注入
+
+想要自定义 prompt 的用户应该创建自己的身份目录，而不是修改 `default/prompts/`。
+
+## 身份解析：全局 + 项目
+
+`identity/registry.go` 目前已同时解析两个作用域。保留两者——项目级在名称
+冲突时优先：
+
+```
+/identity foo
+
+  1. .gen/identities/foo/     → 找到？使用项目级
+  2. ~/.gen/identities/foo/   → 找到？使用用户级
+  3. 两者都没有                → 使用默认身份
+```
+
+这保留了现有行为，即项目级配置可以覆盖用户级配置。
+
+## 内容解析
+
+对于 `sections:` 中声明的每个节，按以下方式解析内容：
+
+```
+对于身份 "code-reviewer"，sections: [output, engineering, guidelines, environment]
+
+  output:
+    1. code-reviewer/prompts/output.txt     → 存在！使用它（自定义）
+
+  engineering:
+    1. code-reviewer/prompts/engineering.txt → 不存在
+    2. default/prompts/engineering.txt       → 存在！使用它（回退）
+
+  guidelines:
+    1. code-reviewer/prompts/guidelines.txt  → 不存在
+    2. default/prompts/guidelines.txt        → 存在！使用它（回退）
+
+  environment:
+    1. code-reviewer/prompts/environment.txt → 不存在
+    2. default/prompts/environment.txt       → 存在！使用它（回退）
+
+对于身份 "readonly"，sections: [environment]
+
+  environment:
+    1. readonly/prompts/environment.txt      → 不存在
+    2. default/prompts/environment.txt       → 存在！使用它（回退）
+
+  注意：output、engineering、guidelines 不在 sections: 中 → 完全不加载。
+  即使 readonly/prompts/output.txt 存在，也会被忽略。
+```
+
+```go
+func resolveSections(identity *Identity) []ResolvedSection {
+    var resolved []ResolvedSection
+
+    for _, sectionName := range identity.Sections {
+        content := ""
+
+        // 1. 查找身份自己的覆盖文件
+        p := filepath.Join(identity.Dir, "prompts", sectionName+".txt")
+        if c, ok := readFile(p); ok {
+            content = c
+        } else {
+            // 2. 回退到默认身份在磁盘上的同名文件
+            p = filepath.Join(defaultIdentityDir, "prompts", sectionName+".txt")
+            if c, ok := readFile(p); ok {
+                content = c
+            }
+        }
+
+        if content != "" {
+            resolved = append(resolved, ResolvedSection{
+                Name:    sectionName,
+                Content: content,
+            })
+        }
+    }
+
+    // 3. 对 prompts/ 中未在 sections: 中声明的孤儿文件进行警告
+    warnOrphanFiles(identity.Dir, identity.Sections)
+
+    return resolved
+}
+
+// warnOrphanFiles 检查 prompts/ 中不在 sections: 中的文件并警告用户。
+// 这些文件会被忽略。
+func warnOrphanFiles(identityDir string, declaredSections []string) {
+    promptsDir := filepath.Join(identityDir, "prompts")
+    entries, _ := os.ReadDir(promptsDir)
+    declared := setOf(declaredSections)
+    for _, e := range entries {
+        name := strings.TrimSuffix(e.Name(), ".txt")
+        if !declared[name] {
+            log.Warn("identity %s: prompts/%s ignored — section \"%s\" not declared in sections:",
+                filepath.Base(identityDir), e.Name(), name)
+        }
+    }
+}
+```
+
+## 锁定层 vs 角色层
+
+身份更改的范围限定在**角色层**。策略由框架强制执行，不可移除：
+
+```
+┌─────────────────────────────────────────────┐
+│ 身份可以更改（角色层）                       │
+│                                             │
+│  • 前言（身份声明）                          │
+│  • output / engineering 风格                 │
+│  • guidelines（工具使用、提醒等）              │
+│  • environment（日期、cwd、平台）             │
+│  • 工具权限（与现有权限层集成）                │
+│  • 捆绑技能                                  │
+└─────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────┐
+│ 框架强制执行 — 永远不可移除                   │
+│                                             │
+│  • policy（安全契约）                         │
+└─────────────────────────────────────────────┘
+```
+
+这意味着：
+- 身份配置中的 `sections:` 是**完整的清单**，列出要加载的角色层节及其顺序
+- `prompts/` 文件只影响已在 `sections:` 中声明的节
+- `policy` 永远不会出现在 `sections:` 中——它始终由框架在角色节之后注入
+- 身份不能意外（或故意）移除安全契约
+- **所有**角色节的默认内容都在磁盘上 `default/prompts/` 中供参考
+
+## identity.md 格式
+
+单个文件，YAML frontmatter + markdown 正文。正文即为前言。
+
+**`sections:` 是必填项。** 它是此身份加载哪些节以及以什么顺序加载的
+完整声明式列表。
+
+### default/identity.md
+
+```markdown
+---
+name: default
+description: 内置 Gen Code 角色 — 软件工程通才
+sections:
+  - output
+  - engineering
+  - guidelines
+  - environment
+---
+
+你是 Gen Code，一个在终端中运行、用于软件工程任务的交互式 AI 助手。
+```
+
+### readonly/identity.md
+
+```markdown
+---
+name: readonly
+description: 只读助手 — 搜索、分析、回答问题
+sections:
+  - environment
+---
+
+你是一个 AI 助手。你可以读取文件、搜索代码和回答问题。你不能修改文件
+或执行命令。
+```
+
+### code-reviewer/identity.md（用户自定义，带覆盖）
+
+```markdown
+---
+name: code-reviewer
+description: 代码审查专家 — 只读，专注于逻辑和风格
+sections:
+  - output
+  - engineering
+  - guidelines
+  - environment
+---
+
+你是一名代码审查专家。仔细阅读代码，找出 bug、安全漏洞、性能问题和风格
+不一致之处。
+```
+
+配合 `code-reviewer/prompts/output.txt`：
+
+```
+<output>
+审查要彻底。引用文件路径和行号。提出修复建议。
+</output>
+```
+
+注意：`output` **必须在 `sections:` 中声明**，`prompts/output.txt` 才能生效。
+如果 `output` 被从 `sections:` 中省略，该文件将被忽略并产生警告。
+
+其他节（`engineering`、`guidelines`、`environment`）在 `sections:` 中但
+没有覆盖文件 → 回退到 `default/prompts/`。
+
+Policy 始终由框架注入。
+
+### my-custom/identity.md（用户自定义，覆盖 output）
+
+```markdown
+---
+name: my-custom
+description: 我的自定义角色 — 简洁输出 + 工程标准
+sections:
+  - output
+  - engineering
+  - guidelines
+  - environment
+---
+
+你是一个简洁的编程助手。每次回复最多一句话。
+```
+
+配合 `my-custom/prompts/output.txt`：
+
+```
+<output>
+始终保持简洁。使用要点列表。永远不要道歉。
+</output>
+```
+
+## 捆绑技能
+
+Skills 已经是基于目录的，由 `skill/loader.go` 加载，具有多个搜索作用域。
+当前激活身份的 `skills/` 目录被添加为一个额外的搜索根——仅在身份激活期间
+生效：
+
+```
+技能加载器搜索路径（当身份 "code-reviewer" 激活时）：
+
+  1. identities/code-reviewer/skills/   ← 新增：身份捆绑的技能，仅在此身份激活时生效
+  2. ~/.gen/skills/                     ← 用户安装的技能
+  3. .gen/skills/                       ← 项目技能
+  4. built-in skills                    ← 随二进制一起提供的技能
+```
+
+这使得身份变得自包含且可分享：
+
+```bash
+# 导出一个身份及其技能
+tar -czf code-reviewer.tar.gz -C ~/.gen/identities code-reviewer/
+
+# 导入 — 一切随之而来
+tar -xzf code-reviewer.tar.gz -C ~/.gen/identities/
+gen> /identity code-reviewer
+```
+
+待定选择：**捆绑**技能（自包含，可作为 tarball 分享）vs **按名称引用**
+（`skills: [git:commit]`，无重复）。默认使用捆绑，同时允许引用。
+
+## 工具权限
+
+工具通过**现有权限层**进行作用域控制，而不是并行 `tools: allow/deny` 系统。
+身份的工具约束被合并到当前权限配置中：
+
+```markdown
+---
+name: readonly
+description: 只读助手
+sections:
+  - environment
+tools:
+  allow:
+    - Read
+    - Grep
+    - Glob
+    - WebSearch
+    - WebFetch
+---
+```
+
+- `tools:` 为空或省略 → 无限制（所有工具可用）
+- `tools.allow:` → 仅这些工具可用
+- 工具权限与现有权限层进行**交集运算**
+  （例如，如果框架已禁止 `Bash`，身份无法重新启用它）
+
+## 迁移：扁平 `<name>.md` → 目录
+
+现有的扁平 `~/.gen/identities/<name>.md` 文件以非破坏性方式迁移：
+
+```
+迁移前:                               迁移后:
+~/.gen/identities/                     ~/.gen/identities/
+└── ml-engineer.md                     └── ml-engineer/
+    (frontmatter: name, sections           └── identity.md
+     body: 前言)                              (同一文件，body → 前言)
+```
+
+迁移逻辑：
+1. 扫描 `~/.gen/identities/` 中不在子目录内的 `.md` 文件
+2. 对每个文件：创建 `<name>/` 目录，将文件移动到 `<name>/identity.md`
+3. 原始 `.md` 的正文变成前言（`identity.md` 的 markdown 正文）
+
+此操作在升级后的首次启动时自动运行。
+
+## 初始化
+
+在 `gen init` 或首次运行时，内置身份内容被提取到
+`~/.gen/identities/`。每次启动时，验证完整性：
+
+```go
+func Initialize(cwd string) {
+    // 将扁平 .md 文件迁移到目录结构（一次性）
+    migrateFlatIdentityFiles()
+
+    // 将内置身份文件提取到磁盘（如果缺失）
+    ensureIdentityDir("default", builtin.DefaultConfig, builtin.DefaultPrompts)
+    ensureIdentityDir("readonly", builtin.ReadonlyConfig, builtin.ReadonlyPrompts)
+
+    // 验证默认 prompt 的完整性（每次启动）
+    verifyDefaultPrompts()
+}
+
+// ensureIdentityDir 写入 identity.md 和 prompts/ 目录。
+// 所有身份：已存在的文件不会被覆盖（尊重用户修改）。
+func ensureIdentityDir(name string, config []byte, prompts map[string][]byte) {
+    dir := filepath.Join(identitiesDir, name)
+    os.MkdirAll(filepath.Join(dir, "prompts"), 0755)
+
+    // identity.md — 仅当不存在时写入
+    configPath := filepath.Join(dir, "identity.md")
+    if _, err := os.Stat(configPath); os.IsNotExist(err) {
+        os.WriteFile(configPath, config, 0644)
+    }
+
+    // prompts/ — 仅当不存在时写入
+    for filename, content := range prompts {
+        p := filepath.Join(dir, "prompts", filename)
+        if _, err := os.Stat(p); os.IsNotExist(err) {
+            os.WriteFile(p, content, 0644)
+        }
+    }
+}
+
+// verifyDefaultPrompts 在每次启动时检查 default/prompts/ 的完整性。
+// 如果任何文件缺失或被修改，从规范版本恢复。
+func verifyDefaultPrompts() {
+    for _, filename := range builtin.DefaultPromptFiles {
+        diskPath := filepath.Join(defaultIdentityDir, "prompts", filename)
+        canonical := builtin.ReadDefaultPrompt(filename)
+
+        onDisk, err := os.ReadFile(diskPath)
+        if os.IsNotExist(err) {
+            log.Info("restoring missing default prompt: %s", filename)
+            os.WriteFile(diskPath, canonical, 0644)
+            continue
+        }
+        if err != nil {
+            log.Warn("cannot read default prompt, restoring: %s (%v)", filename, err)
+            os.WriteFile(diskPath, canonical, 0644)
+            continue
+        }
+        if !bytes.Equal(onDisk, canonical) {
+            log.Warn("default prompt was modified, restoring: %s", filename)
+            os.WriteFile(diskPath, canonical, 0644)
+        }
+    }
+}
+```
+
+关键行为：
+- **`default/` 和 `readonly/` 目录在首次 init 时自动创建**
+  — 仅当不存在时写入
+- **默认 prompt 每次启动时验证** — 被修改的文件会被规范版本覆盖
+- **`readonly/` 的 prompt 文件一旦存在，永远不会被覆盖**
+- **用户创建的身份目录不受影响**
+- **无静默升级** — 如果 prompt 跨版本发生变化，它会被覆盖
+  （二进制中的规范版本始终是真相来源）
+
+## Prompt 内容的来源
+
+### 内置 prompt：编译到二进制中，提取到磁盘
+
+内置身份的 prompt 内容**嵌入在二进制中**（通过 `//go:embed`），
+并在 init 时写出到 `~/.gen/identities/`。
+
+```
+源码（嵌入在二进制中）:                    用户目录（init 后）:
+internal/identity/builtin/                 ~/.gen/identities/
+├── default/                              ├── default/
+│   ├── identity.md                       │   ├── identity.md    ← init 时提取
+│   └── prompts/                          │   └── prompts/
+│       ├── output.txt                    │       ├── output.txt ← init 时提取
+│       ├── engineering.txt               │       ├── engineering.txt
+│       ├── guidelines.txt                │       ├── guidelines.txt
+│       └── environment.txt               │       └── environment.txt
+└── readonly/                             ├── readonly/
+    └── identity.md                       │   ├── identity.md    ← init 时提取
+                                          │   └── prompts/
+                                          │       └── （空或用户创建）
+                                          └── code-reviewer/     ← 用户创建
+                                              ├── identity.md
+                                              └── prompts/
+                                                  └── output.txt
+```
+
+### 解析流程
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 对于 identity.Sections 中的每个节名（按顺序）：                   │
+│                                                                 │
+│   <identity>/prompts/<section>.txt 存在？                       │
+│     ├── 是 → 使用它（覆盖）                                      │
+│     └── 否 → 回退到 default/prompts/<section>.txt               │
+│                 ├── 存在 → 使用它（回退）                        │
+│                 └── 不存在 → 跳过此节（不注入）                   │
+│                                                                 │
+│ 然后，始终追加：policy（框架注入）                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+```
+示例：code-reviewer，sections: [output, engineering, guidelines, environment]
+
+  output:
+    code-reviewer/prompts/output.txt     → 存在 → 使用它（自定义）
+  engineering:
+    code-reviewer/prompts/engineering.txt → 不存在
+    default/prompts/engineering.txt       → 存在 → 使用它（回退）
+  guidelines:
+    code-reviewer/prompts/guidelines.txt  → 不存在
+    default/prompts/guidelines.txt        → 存在 → 使用它（回退）
+  environment:
+    code-reviewer/prompts/environment.txt → 不存在
+    default/prompts/environment.txt       → 存在 → 使用它（回退）
+  + policy（框架注入）
+
+示例：readonly，sections: [environment]
+
+  environment:
+    readonly/prompts/environment.txt      → 不存在
+    default/prompts/environment.txt       → 存在 → 使用它（回退）
+  + policy（框架注入）
+  （output、engineering、guidelines 不在 sections: 中 → 不加载）
+```
+
+## 最终系统 prompt 组装
+
+```
+default 身份 → sections: [output, engineering, guidelines, environment]
+  + 框架注入: policy
+
+  你是 Gen Code，...                                       ← 前言（来自 identity.md 正文）
+  <output>                                                 ← default/prompts/output.txt
+  ...
+  </output>
+  <engineering>                                            ← default/prompts/engineering.txt
+  ...
+  </engineering>
+  <guidelines name="tool-usage">...</guidelines>           ← default/prompts/guidelines.txt
+  <guidelines name="system-reminders">...</guidelines>
+  ...
+  <environment>                                            ← default/prompts/environment.txt
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← 框架：始终注入
+  ...
+  </policy>
+
+readonly 身份 → sections: [environment]
+  + 框架注入: policy
+
+  你是一个 AI 助手。...                                     ← 前言
+  <environment>                                            ← 回退到 default/prompts/environment.txt
+  date: 2026-06-05  cwd: /project  platform: darwin/arm64
+  </environment>
+  <policy>                                                 ← 框架：始终注入
+  ...
+  </policy>
+
+code-reviewer 身份 → sections: [output, engineering, guidelines, environment]
+  + 框架注入: policy
+
+  你是一名代码审查专家。...                                 ← 前言
+  <output>                                                 ← code-reviewer/prompts/output.txt（覆盖）
+  审查要彻底。引用文件路径和行号。
+  </output>
+  <engineering>                                            ← 回退到 default/prompts/engineering.txt
+  ...
+  </engineering>
+  <guidelines>                                             ← 回退到 default/prompts/guidelines.txt
+  ...
+  </guidelines>
+  <environment>                                            ← 回退到 default/prompts/environment.txt
+  ...
+  </environment>
+  <policy>                                                 ← 框架：始终注入
+  ...
+  </policy>
+```
+
+## 用户体验
+
+### 创建自定义身份
+
+```bash
+# 0. 查看默认 prompt 作为参考
+ls ~/.gen/identities/default/prompts/
+# output.txt  engineering.txt  guidelines.txt  environment.txt
+cat ~/.gen/identities/default/prompts/output.txt
+# 显示默认 output prompt — 用作参考
+
+# 1. 创建目录
+mkdir -p ~/.gen/identities/concise
+
+# 2. 编写 identity.md（sections: 是完整的清单）
+cat > ~/.gen/identities/concise/identity.md << 'EOF'
+---
+name: concise
+description: 简洁模式
+sections:
+  - output
+  - engineering
+  - guidelines
+  - environment
+---
+
+你是一个简洁、直接的编程助手。直奔主题。
+EOF
+
+# 3.（可选）覆盖某个节的 prompt
+#    该节必须也在上面的 sections: 中声明
+mkdir -p ~/.gen/identities/concise/prompts
+cat > ~/.gen/identities/concise/prompts/output.txt << 'EOF'
+<output>
+直接回答。不说闲话。不道歉。
+</output>
+EOF
+
+# 4.（可选）捆绑技能
+mkdir -p ~/.gen/identities/concise/skills/short-answers
+cat > ~/.gen/identities/concise/skills/short-answers/SKILL.md << 'EOF'
+# 简短回答
+始终在三行以内回答。
+EOF
+
+# 5. 切换到该身份
+gen> /identity concise
+✓ 身份已切换: concise
+```
+
+### 反模式：有覆盖文件但没有声明节
+
+```bash
+# 错误：output.txt 存在但 output 不在 sections: 中
+cat > ~/.gen/identities/bad-identity/identity.md << 'EOF'
+---
+name: bad-identity
+description: 这不会按预期工作
+sections:
+  - engineering
+  - environment
+---
+
+我是一个错误示例。
+EOF
+
+cat > ~/.gen/identities/bad-identity/prompts/output.txt << 'EOF'
+<output>
+这永远不会被加载。节 "output" 不在 sections: 中
+</output>
+EOF
+
+# 启动时：
+# WARN: identity bad-identity: prompts/output.txt ignored — section "output" not declared in sections:
+```
+
+### 修改默认 prompt（不允许 — 会被还原）
+
+```bash
+# 这将在下次启动时被还原：
+vim ~/.gen/identities/default/prompts/output.txt
+
+# 下次启动时：
+# WARN: default prompt was modified, restoring: output.txt
+#
+# 要自定义 output，请创建自己的身份：
+# mkdir -p ~/.gen/identities/my-style/prompts
+# cp ~/.gen/identities/default/prompts/output.txt \
+#    ~/.gen/identities/my-style/prompts/output.txt
+# vim ~/.gen/identities/my-style/prompts/output.txt
+```
+
+### 创建项目级身份
+
+```bash
+# 存放在仓库中，可以提交
+mkdir -p .gen/identities/project-role
+
+cat > .gen/identities/project-role/identity.md << 'EOF'
+---
+name: project-role
+description: 项目特定约定
+sections:
+  - engineering
+  - guidelines
+  - environment
+---
+
+你正在 Gen Code 项目上工作。请遵循 Go 语言约定。
+EOF
+```
+
+### 删除自定义身份
+
+```bash
+rm -rf ~/.gen/identities/my-custom
+# 完全移除；其他身份不受影响
+```
+
+## 身份数据结构
+
+```go
+type Identity struct {
+    Name        string     // 目录名，也是身份名称
+    Description string     // 一行描述
+    Preamble    string     // 身份声明（identity.md 的正文）
+    Sections    []string   // 要加载的角色层节的完整列表，按顺序
+    Tools       ToolPolicy // 工具限制（与权限层合并）
+    Dir         string     // 此身份目录的路径
+    SkillsDir   string     // 捆绑 skills/ 的路径（没有则为空）
+}
+```
+
+## 可扩展性
+
+### 添加新的内置身份
+
+1. 在 `internal/identity/builtin/` 下创建一个包含 `identity.md` 的目录
+2. 可选添加 `prompts/` 文件
+3. 在 `Initialize()` 中添加一行：`ensureIdentityDir("new-name", ...)`
+4. 完成。下次 `gen init` 时，它会被写入磁盘
+
+### 添加新的角色层节类型
+
+1. 在内置默认 prompt 中添加一个 `.txt` 文件
+2. 在节→槽映射表中添加一行
+3. 在其 `sections:` 列表中声明新节的现有身份将自动加载它
+   （通过回退到 `default/prompts/`）
+4. 未声明该节的身份不受影响
+
+### 社区分享
+
+```bash
+# 导出一个身份（目录 tarball — 包含技能，如果已捆绑）
+tar -czf my-architect.tar.gz -C ~/.gen/identities architect/
+
+# 导入
+tar -xzf my-architect.tar.gz -C ~/.gen/identities/
+gen> /identity architect
+```
+
+## 与现有系统的关系
+
+| 现有概念 | 变更 |
+|---|---|
+| `~/.gen/identities/*.md` | 扁平 `.md` 文件迁移到 `<name>/identity.md` 目录 |
+| `prompts/*.txt`（嵌入式） | 默认 prompt 在 init 时提取到磁盘上的 `default/prompts/` |
+| `.gen/identities/`（项目级） | **保留** — 名称冲突时项目级优先 |
+| `applyDefaults()` | 硬编码的作用域分支替换为遍历 `Identity.Sections` |
+| `core.Scope` | 保留 Main/Subagent 概念，但角色层组合由身份驱动 |
+| Policy | **框架强制执行** — 始终注入，永远不可移除，永不在磁盘上 |
+| `/identity` | 扫描 `.gen/identities/` 和 `~/.gen/identities/` |
+| `settings.json` | `"identity": "readonly"` 指向目录名 |
+| 技能加载器 | 当前身份的 `skills/` 作为搜索根添加 |
+| 工具权限 | 合并到现有权限层，而非并行系统 |
+
+## 默认 prompt 内容
+
+`default/prompts/` 下的文件与当前 `prompts/*.txt` 内容一致。
+它们在 init 时从二进制中提取，并在每次启动时进行完整性验证：
+
+| 文件 | 对应槽位 | 描述 |
+|---|---|---|
+| `output.txt` | SlotIdentity | 语气、更新、行为 |
+| `engineering.txt` | SlotIdentity | 约束、代码约定、错误处理 |
+| `guidelines.txt` | SlotGuidelines | 工具使用、系统提醒、任务工作流、何时询问 |
+| `environment.txt` | SlotEnvironment | 环境模板（含 `{{.Date}}` 等变量） |
+
+`policy.txt` **不在**磁盘上——它由框架直接注入，
+用户无法查看、修改或删除。
+
+## 已确定的问题
+
+1. **项目级身份目录？** → **保留两者。** `.gen/identities/`
+   （项目级）和 `~/.gen/identities/`（用户级）。名称冲突时项目级优先。
+   `identity/registry.go` 目前已同时解析两者。
+
+2. **用户可以修改默认值吗？** → **不可以。** `default/prompts/` 文件在
+   每次启动时进行完整性验证。被修改的文件会被规范版本覆盖。需要自定义
+   的用户应该创建自己的身份目录。
+
+3. **如果用户删除了 `default/prompts/` 会怎样？** → **下次启动时恢复。**
+   缺失的文件会从二进制中重新提取。删除整个 `default/` 目录不会破坏系统——
+   它会在下次 init 时重建。
+
+4. **升级时是否应更新默认 prompt？** → **是，自动更新。**
+   默认 prompt 每次启动时与二进制中的规范版本进行验证。当新版本发布更新
+   的 prompt 时，它们会在下次启动时覆盖磁盘副本。在自身身份目录中自定义
+   了 prompt 的用户不受影响。
+
+5. **身份可以移除安全策略吗？** → **不可以。** Policy 不提取到磁盘、
+   不列在 `sections:` 中，始终由框架注入。没有任何身份可以移除或修改它。
+
+6. **如何处理现有的扁平 `.md` 身份文件？** → **一次性迁移。**
+   升级后首次启动时，`~/.gen/identities/<name>.md` 被移动到
+   `~/.gen/identities/<name>/identity.md`。非破坏性操作。
+
+7. **为什么把默认值提取到磁盘而不是保持纯嵌入式？**
+   → 用户需要一个参考来了解可以自定义什么。创建自定义身份时，
+   `default/prompts/` 下的文件可以准确展示有哪些节、使用什么格式、
+   以及当前的默认值是什么。没有这个，用户只能猜测。
+
+8. **`sections:` 与 `prompts/` —— 哪个控制要加载什么？**
+   → **`sections:` 是唯一真相来源。** 它是角色层节的完整声明式列表，
+   按顺序排列。`prompts/` 文件仅为已在 `sections:` 中声明的节提供覆盖内容。
+   属于未声明节的文件将被忽略并产生警告。
+
+## 参考资料
+
+- [identity.go](../../internal/identity/identity.go) — 当前 Identity 结构体
+- [catalog.go](../../internal/core/system/catalog.go) — 当前系统 prompt 组装
+- [section.go](../../internal/core/section.go) — Section 和 Slot 类型
+- [prompts/](../../internal/core/system/prompts/) — 当前嵌入的 prompt 文件（将迁移到 init 时提取的内置默认身份目录）

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -6,7 +6,8 @@ single pull request.
 ## Files
 
 - `principles.md` - engineering principles for structure and documentation.
-- `decisions/` - architecture decision records.
+- `decisions/` - architecture decision records and proposals.
+  - `decisions/minimal-default-identity.md` - Proposal: Read-only Minimal Identity (EN)
 
 ## Decision Record Template
 


### PR DESCRIPTION
## Summary

This PR adds a design proposal for redesigning the Identity system as a **directory structure** under `~/.gen/identities/`.

### Key ideas

- Each identity is a directory containing `identity.yaml` (role config) and `prompts/` (section prompt files)
- **File-based fallback**: when an identity is missing a prompt file, the same-named file from the `default` identity is used automatically
- Introduces a built-in **`readonly`** identity with minimal prompts and read-only tools
- Custom identities only need to contain the **differences** from default

### Files changed

- `docs/design/decisions/minimal-default-identity.md` — the full proposal
- `docs/design/index.md` — add reference to the new proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)