### PR TITLE
docs(site): highlight small footprint & reposition as a unified agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>&lt; GEN ✦ /&gt;</h1>
-  <p><strong>Open-source AI coding assistant for the terminal</strong></p>
+  <p><strong>Open-source unified runtime for specialized AI agents — in the terminal</strong></p>
   <p>
     <a href="https://github.com/genai-io/gen-code/releases"><img src="https://img.shields.io/github/v/release/genai-io/gen-code?style=flat-square" alt="Release"></a>
     <a href="https://genai-io.github.io/gen-code/"><img src="https://img.shields.io/badge/Website-0d9488?style=flat-square" alt="Website"></a>
@@ -19,7 +19,7 @@
   </p>
 </div>
 
-Gen Code is a terminal coding assistant built around five pluggable pillars — **LLMs**, **search backends**, **personas**, **skills & extensions** (skills, plugins, MCP servers, subagents), and a **self-evolving** agent that levels up as you work. Built in Go and shipped as a single binary — a unified runtime for specialized agents.
+Gen Code is a terminal-native **unified runtime for specialized agents** — coding and beyond — built on five pluggable pillars: **LLMs**, **search backends**, **personas**, **skills & extensions** (skills, plugins, MCP servers, subagents), and a **self-evolving** agent that levels up as you work. Written in Go.
 
 ## Features
 
@@ -33,7 +33,7 @@ Gen Code is a terminal coding assistant built around five pluggable pillars — 
 
 ### Engineering
 
-- **Native performance** — Single Go binary; see [benchmark](#benchmark-gencode-vs-claude-code) for measured numbers.
+- **Runs anywhere** — A single ~12 MB binary with zero runtime dependencies (no Node.js, no Python). Native Go: ~0.01s cold start, ~32 MB baseline, and the same file runs unchanged on a laptop, an edge device, or in a `scratch` container ([footprint](docs/operations/footprint.md) · [benchmark](#benchmark-gencode-vs-claude-code)).
 - **Event-driven coordination** — Parallel subagent execution via a pub/sub hub ([architecture](docs/packages/subagent.md)).
 - **Session persistence** — Auto-save, resume, fork, and automatic context compaction.
 - **Prompt prediction** — Speculative completion of likely next prompts to reduce latency.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>&lt; GEN ✦ /&gt;</h1>
-  <p><strong>面向终端的开源 AI 编程助手</strong></p>
+  <p><strong>面向终端的开源「专用 Agent 统一运行时」</strong></p>
   <p>
     <a href="https://github.com/genai-io/gen-code/releases"><img src="https://img.shields.io/github/v/release/genai-io/gen-code?style=flat-square" alt="Release"></a>
     <a href="https://genai-io.github.io/gen-code/"><img src="https://img.shields.io/badge/%E5%AE%98%E7%BD%91-0d9488?style=flat-square" alt="官网"></a>
@@ -19,7 +19,7 @@
   </p>
 </div>
 
-Gen Code 是一款终端 AI 编程助手，围绕五大可插拔能力构建 —— **模型（LLM）**、**搜索引擎**、**人设（Personas）**、**技能与扩展**（skills、plugins、MCP servers、subagents），以及**随使用不断自我进化、逐级升级**的 Agent。使用 Go 实现，单二进制分发 —— 面向各类专用 Agent 的统一运行时。
+Gen Code 是面向终端的**专用 Agent 统一运行时**（Unified Specialized Agent Runtime）—— 不止于编程 —— 构建在五大可插拔能力之上：**模型（LLM）**、**搜索引擎**、**人设（Personas）**、**技能与扩展**（skills、plugins、MCP servers、subagents），以及**随使用不断自我进化、逐级升级**的 Agent。使用 Go 实现。
 
 ## 特性
 
@@ -33,7 +33,7 @@ Gen Code 是一款终端 AI 编程助手，围绕五大可插拔能力构建 —
 
 ### 工程实现
 
-- **原生性能** —— 单一 Go 二进制；实测数据见下方[基准测试](#基准测试gen-code-vs-claude-code)。
+- **随处运行** —— 单一约 12 MB 二进制，零运行时依赖（无需 Node.js、Python）。原生 Go：冷启动约 0.01s、基线内存约 32 MB，同一文件可在笔记本、边缘设备或 `scratch` 容器中直接运行（[体积](docs/operations/footprint.md) · [基准测试](#基准测试gen-code-vs-claude-code)）。
 - **事件驱动协同** —— 基于 pub/sub hub 的并行 subagent 执行（[架构说明](docs/packages/subagent.md)）。
 - **会话持久化** —— 自动保存、恢复、Fork 以及自动上下文压缩。
 - **Prompt 预测** —— 推测式地预生成可能的下一个 prompt 以降低延迟。

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -1,31 +1,8 @@
 # Gen Code 代码详解（中文文档）
 
-## 项目概述
+本目录是 **Gen Code** 的中文「代码详解」文档集，面向贡献者与想深入源码的读者，逐层讲解架构、核心接口、工具系统与扩展机制。
 
-**Gen Code** 是一个开源的终端 AI 编程助手，使用 Go 语言编写。它是 [Claude Code](https://claude.ai/code) 的 Go 重写版本，编译为单一二进制文件，跨平台运行。项目定位是更快、更轻量的 Claude Code 替代品：下载体积缩小 5 倍，启动速度快 20 倍，内存占用减少 6 倍，实际任务执行快 4-8 倍。
-
-### 核心特性
-
-- **多 LLM 提供商**：支持 Anthropic Claude、OpenAI GPT/o-series、Google Gemini、Moonshot/Kimi、阿里云 DashScope（Qwen/DeepSeek）、MiniMax、Z.ai/智谱 GLM、DeepSeek
-- **可插拔搜索后端**：Exa、Tavily、Brave、Serper
-- **可定制身份/人格**：通过 Markdown 定义的自定义系统提示词
-- **六大扩展机制**：Skills、Plugins、MCP Server、Hooks、Slash Commands、Subagents
-- **会话持久化**：自动保存、恢复、分叉、上下文自动压缩
-- **事件驱动架构**：基于 Bubble Tea TUI 框架的 MVU 循环
-- **发布/订阅事件总线**：支持并行子 Agent 执行
-
-### 性能对比
-
-与 Claude Code v2.1.112 对比（Apple Silicon, 同模型 `claude-sonnet-4-6`）：
-
-| 指标 | Gen Code | Claude Code | 优势 |
-|------|---------|-------------|------|
-| 下载体积 | 12 MB | 63 MB (+ Node.js 112 MB) | **5x 更小** |
-| 磁盘占用 | 38 MB | 175 MB | **4.6x 更小** |
-| 启动时间 | ~0.01s | ~0.20s | **20x 更快** |
-| 启动内存 | ~32 MB | ~189 MB | **5.8x 更少** |
-| 简单任务 | ~2.4s / 39 MB | ~10.4s / 286 MB | **4.3x 更快** |
-| 工具调用任务 | ~3.3s / 39 MB | ~26.0s / 285 MB | **7.9x 更快** |
+> 产品概述、安装、用法与性能对比请见根目录的 [README.zh.md](../../README.zh.md)。
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ explanations here.
 - `operations/release.md` — release process.
 - `operations/troubleshooting.md` — common development issues.
 - `operations/benchmark.md` — reproduce the benchmark numbers.
+- `operations/footprint.md` — why the single small binary is so portable.
 
 ### Know why a decision was made
 

--- a/docs/operations/benchmark.md
+++ b/docs/operations/benchmark.md
@@ -20,6 +20,8 @@ Comparison between **GenCode v1.13.2** (Go) and **Claude Code v2.1.112** (Node.j
 
 GenCode ships as a single static binary with zero runtime dependencies. Claude Code requires Node.js and installs ~63 MB of npm packages.
 
+For what this small, dependency-free footprint enables — Raspberry Pi, edge nodes, minimal containers, air-gapped hosts — see [footprint.md](footprint.md).
+
 ---
 
 ## 2. Startup Time (`version`)

--- a/docs/operations/footprint.md
+++ b/docs/operations/footprint.md
@@ -1,0 +1,98 @@
+# Small Footprint & Portability
+
+Gen Code ships as **one self-contained binary**. There is no Node.js runtime,
+no Python interpreter, no package manager, and no `node_modules` tree to
+install or keep in sync. You copy a single file, mark it executable, and run
+it — which is exactly what makes it portable enough for tiny, locked-down, and
+far-from-the-datacenter machines.
+
+This page explains *why small matters* and *where that lets you run*. For the
+raw measured numbers and methodology, see
+[benchmark.md](benchmark.md).
+
+## How small is it?
+
+| Dimension | Gen Code | Why it matters |
+|---|---|---|
+| Download (compressed `.tar.gz`) | **~12 MB** | Fits on metered, slow, or air-gapped links |
+| On-disk binary | **~40 MB** | One file, no surrounding directory tree |
+| File count | **1** | Nothing to unpack, link, or `npm install` |
+| Runtime dependencies | **0** | No Node.js, no Python, no shared libraries to provision |
+| Startup memory | **~32 MB** | Leaves headroom on 256–512 MB devices |
+| Cold start | **~0.01s** | Cheap to launch in short-lived shells, CI steps, and hooks |
+
+A typical Node.js-based assistant, by contrast, needs its own ~60 MB package
+*plus* a ~110 MB Node.js runtime on disk before it can do anything — and pays a
+heavier baseline in RAM and startup time. Gen Code carries its entire world
+inside the single executable.
+
+## Why a single static binary
+
+Gen Code is compiled with Go. On Linux the released binaries are **statically
+linked** — running `file` on one reports `statically linked ... stripped`,
+meaning there are no external `.so` dependencies to resolve at load time. The
+result:
+
+- **No interpreter, no VM.** Native machine code starts instantly; there is no
+  JIT warm-up, no garbage-collected runtime to spin up first.
+- **No dependency hell.** There is no lockfile to reconcile, no transitive
+  package CVE surface to patch, no global vs. project version skew. The binary
+  you tested is the binary you ship.
+- **Trivial install / uninstall.** Install is "put the file on `PATH`."
+  Uninstall is "delete the file." Nothing is scattered across the filesystem.
+- **Reproducible everywhere.** The same artifact behaves the same on a laptop,
+  a CI runner, and an edge box, because it brings its own runtime with it.
+
+## Where you can run it
+
+Because the binary is small and dependency-free, it fits places a heavier
+toolchain can't follow:
+
+- **Minimal containers** — copy the binary into a `scratch`, `distroless`, or
+  Alpine image. The image layer is tiny and there is no base runtime to carry,
+  which keeps pulls fast and the attack surface small.
+- **Edge nodes and IoT gateways** — drop one binary onto a constrained edge
+  device; no need to provision a language runtime alongside it.
+- **CI runners** — download and cache ~12 MB instead of installing Node.js and
+  resolving an `npm` tree on every job. The ~0.01s cold start keeps pipeline
+  steps cheap.
+- **Air-gapped / restricted hosts** — bastions, jump hosts, and offline
+  machines where you can copy a file in but cannot run a package-manager
+  install. One `scp` and you're done.
+- **Ephemeral and serverless environments** — short-lived VMs and functions
+  where a fast cold start and a small artifact matter more than anything.
+- **Raspberry Pi and other SBCs** — small enough that the `linux/arm64` build
+  even runs on a Pi 3/4/5 (64-bit OS) and similar ARM single-board computers:
+  ~12 MB to fetch, ~32 MB resident.
+
+## Try it on a Raspberry Pi (or any arm64 Linux)
+
+```bash
+# On a 64-bit Raspberry Pi OS / arm64 Linux box:
+curl -fsSL https://raw.githubusercontent.com/genai-io/gen-code/main/install.sh | bash
+gen --version
+```
+
+The installer fetches the matching `linux/arm64` archive (~12 MB), unpacks the
+single `gen` binary, and puts it on your `PATH`. Nothing else is installed.
+
+## Building for other targets
+
+The release matrix covers `darwin/{amd64,arm64}` and `linux/{amd64,arm64}` (see
+the `release` target in the [`Makefile`](../../Makefile)). Because it is plain
+Go, you can cross-compile for almost any other target Go supports — older 32-bit
+ARM Pis, Windows, FreeBSD, RISC-V, and more — by setting two environment
+variables, with no C toolchain required:
+
+```bash
+# Example: 32-bit ARM (older Pi / Pi Zero), fully static, stripped
+GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 \
+  go build -ldflags "-s -w" -o gen ./cmd/gen
+```
+
+## Summary
+
+Small is not just a vanity metric. A ~12 MB, zero-dependency, single-file binary
+is what lets Gen Code run on a Raspberry Pi, slip into a `scratch` container,
+land on an air-gapped host, and cold-start inside a CI step — all without first
+dragging along a Node.js or Python runtime. The footprint *is* the portability.

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gen Code — Open-source AI coding assistant for the terminal</title>
-<meta name="description" content="Gen Code is a terminal coding assistant: a single Go binary, pluggable LLM providers, fully compatible with Claude Code skills, plugins, and MCP. 20x faster startup, 5x smaller than Claude Code.">
-<meta property="og:title" content="Gen Code — AI coding assistant for the terminal">
+<title>Gen Code — Open-source unified agent runtime for the terminal</title>
+<meta name="description" content="Gen Code is a terminal-native unified runtime for specialized agents: a single Go binary, pluggable LLM providers, fully compatible with Claude Code skills, plugins, and MCP. 20x faster startup, 5x smaller than Claude Code.">
+<meta property="og:title" content="Gen Code — Unified agent runtime for the terminal">
 <meta property="og:description" content="Single Go binary. Pluggable LLM providers. Claude Code compatible. 20x faster startup.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://genai-io.github.io/gen-code/">

--- a/site/intro.html
+++ b/site/intro.html
@@ -16,7 +16,7 @@
   Open in a browser. Auto-loops; click to pause/play, R restart, T theme.
   Record at 1280x720.
 
-  Flow: boot → multi-model → multi-persona → fast interaction → self-improvement → outro.
+  Flow: boot → multi-model → multi-persona → fast interaction → self-improvement → deploy → outro.
 -->
 <html lang="en">
 <head>
@@ -75,10 +75,11 @@
   .cdesc{font-size:14px;color:var(--dim);margin-top:7px;letter-spacing:.2px}
 
   /* terminal */
-  .term{position:absolute;z-index:4;left:80px;top:112px;width:1120px;height:540px;
+  .term{position:absolute;z-index:4;left:80px;top:112px;width:1120px;height:540px;transform-origin:50% 0;
     background:var(--panel);border:1px solid var(--border);border-radius:14px;
     box-shadow:0 28px 70px var(--shadow-soft), inset 0 1px 0 var(--hairline);
-    overflow:hidden;display:flex;flex-direction:column;transition:background .4s ease,border-color .4s ease}
+    overflow:hidden;display:flex;flex-direction:column;transition:background .4s ease,border-color .4s ease,transform .6s var(--ease)}
+  .term.shrunk{transform:scale(.4)}
   .bar{height:40px;flex:0 0 40px;display:flex;align-items:center;gap:8px;padding:0 15px;
     background:var(--panel-bar);border-bottom:1px solid var(--border)}
   .dot{width:11px;height:11px;border-radius:50%;background:var(--faint);opacity:.7}
@@ -188,6 +189,31 @@
   .install .p{color:var(--accent)}
   .site{font-size:14px;color:var(--accent)}
 
+  /* deploy / fan-out — terminal shrinks, devices pop out on the stage */
+  .dlayer{position:absolute;inset:0;z-index:5;opacity:0;pointer-events:none;transition:opacity .5s ease}
+  .dlayer.on{opacity:1}
+  .dlines{position:absolute;inset:0;width:100%;height:100%;overflow:visible}
+  .dline{fill:none;stroke:var(--accent);stroke-width:1.4;stroke-dasharray:5 7;vector-effect:non-scaling-stroke;
+    opacity:0;transition:opacity .4s ease;animation:flow 1.05s linear infinite}
+  .dline.on{opacity:.5}
+  @keyframes flow{to{stroke-dashoffset:-24}}
+  .dgrid{position:absolute;left:0;right:0;top:430px;display:flex;justify-content:center;gap:20px}
+  .node{width:180px;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:14px 12px;
+    display:flex;flex-direction:column;align-items:center;gap:7px;box-shadow:0 16px 44px var(--shadow);
+    transition:border-color .35s ease,box-shadow .35s ease,opacity .4s var(--ease),transform .4s var(--ease)}
+  .node .nicon{color:var(--dim);line-height:0;transition:color .35s ease}
+  .node .nicon svg{width:30px;height:30px;display:block}
+  .node .nlabel{font-size:13px;color:var(--fg);letter-spacing:.2px}
+  .node .nrole{font-size:12px;color:var(--faint);transition:color .35s ease}
+  .node .nrole::before{content:'● ';color:var(--accent);opacity:0;transition:opacity .3s ease}
+  .node.run{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent-soft),0 18px 48px var(--shadow);transform:translateY(-3px)}
+  .node.run .nicon{color:var(--accent)}
+  .node.run .nrole{color:var(--accent)}
+  .node.run .nrole::before{opacity:1;animation:zap 1.1s ease-in-out infinite}
+  .dfoot{position:absolute;left:0;right:0;bottom:84px;text-align:center;font-family:var(--serif);font-style:italic;
+    font-size:23px;font-weight:500;color:var(--accent);
+    background:var(--title-grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+
   /* progress bar */
   .ticks{position:absolute;left:80px;right:80px;bottom:44px;z-index:6;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);height:14px}
   .ticks span{position:absolute;transform:translateX(-50%);white-space:nowrap}
@@ -218,7 +244,7 @@
     <div class="cdesc" id="cap-desc"></div>
   </div>
 
-  <div class="term">
+  <div class="term" id="term">
     <div class="bar">
       <span class="dot"></span><span class="dot"></span><span class="dot"></span>
       <span class="title">gen — ~/Workspace/app</span>
@@ -230,8 +256,8 @@
       <section class="scene" data-start="0" data-dur="4.4" id="boot">
         <div class="splash">
           <div class="logo reveal" id="b-logo">&lt; GEN <span class="sp">✦</span> /&gt;</div>
-          <div class="tag reveal" id="b-tag">An open-source AI coding assistant for the terminal</div>
-          <div class="sub reveal" id="b-sub">A unified runtime for specialized agents — shipped as a single, native Go binary</div>
+          <div class="tag reveal" id="b-tag">An open-source unified agent runtime</div>
+          <div class="sub reveal" id="b-sub">Specialized agents, coding and beyond — shipped as a single, native Go binary</div>
           <div class="pillars reveal" id="b-pil">Models · Search · Personas · Extensions · Evolution</div>
           <div class="bootline reveal" id="b-prompt"><span class="prompt">❭ </span><span class="cur"></span></div>
         </div>
@@ -294,7 +320,7 @@
       </section>
 
       <!-- ░░ SELF-IMPROVEMENT ░░ -->
-      <section class="scene" data-start="28.4" data-dur="10.6" id="learn">
+      <section class="scene" data-start="28.4" data-dur="8.0" id="learn">
         <div class="hist" id="l-hist">
           <div class="h-cmd"><span class="prompt">❭ </span>add a /healthz endpoint and a test</div>
           <div class="h-tool">⏺ <span class="tn">read</span> internal/server/router.go</div>
@@ -319,18 +345,60 @@
         <div class="rc-foot reveal" id="l-foot">↪ gen --resume app.selflearn-review.1780412141</div>
       </section>
 
+      <!-- ░░ DEPLOY / FAN-OUT ░░ -->
+      <section class="scene" data-start="36.4" data-dur="8.0" id="deploy">
+        <div class="splash">
+          <div class="logo reveal" id="d-logo">&lt; GEN <span class="sp">✦</span> /&gt;</div>
+          <div class="sub reveal" id="d-cap">one ~12 MB binary · zero deps</div>
+        </div>
+      </section>
+
       <!-- ░░ OUTRO ░░ -->
-      <section class="scene" data-start="39.0" data-dur="9.5" id="outro">
+      <section class="scene" data-start="44.4" data-dur="9.5" id="outro">
         <div class="outro">
           <div class="big reveal" id="o-logo">&lt; GEN <span class="sp">✦</span> /&gt;</div>
           <div class="ln reveal" id="o-cn">Models · Search · Personas · Extensions · Evolution</div>
-          <div class="en reveal" id="o-en">An open-source AI coding assistant for the terminal</div>
+          <div class="en reveal" id="o-en">One binary, many specialized agents — coding and beyond</div>
           <div class="install reveal" id="o-inst"><span class="p">$</span> curl -fsSL https://raw.githubusercontent.com/genai-io/gen-code/main/install.sh | bash</div>
           <div class="site reveal" id="o-site">genai-io.github.io/gen-code · ★ star it on GitHub</div>
         </div>
       </section>
 
     </div>
+  </div>
+
+  <!-- deploy fan-out: device nodes on the stage, around the shrunk terminal -->
+  <div class="dlayer" id="dlayer">
+    <svg class="dlines" viewBox="0 0 1280 720" preserveAspectRatio="none">
+      <path class="dline" id="d-l1" d="M640 330 L240 425"/>
+      <path class="dline" id="d-l2" d="M640 330 L440 425"/>
+      <path class="dline" id="d-l3" d="M640 330 L640 425"/>
+      <path class="dline" id="d-l4" d="M640 330 L840 425"/>
+      <path class="dline" id="d-l5" d="M640 330 L1040 425"/>
+    </svg>
+    <div class="dgrid">
+      <div class="node reveal" id="d-n1">
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><rect x="4" y="5" width="16" height="10" rx="1"/><path d="M2.5 18.5h19l-1.2-2H3.7z"/></svg></div>
+        <div class="nlabel">laptop</div><div class="nrole">coding</div>
+      </div>
+      <div class="node reveal" id="d-n2">
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="6" width="18" height="12" rx="1"/><path d="M8 6v12M12 6v12M16 6v12"/></svg></div>
+        <div class="nlabel">scratch container</div><div class="nrole">ci-runner</div>
+      </div>
+      <div class="node reveal" id="d-n3">
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="7" y="7" width="10" height="10" rx="1.2"/><path d="M10 7V4.2M14 7V4.2M10 19.8V17M14 19.8V17M7 10H4.2M7 14H4.2M19.8 10H17M19.8 14H17"/></svg></div>
+        <div class="nlabel">edge device</div><div class="nrole">log-triage</div>
+      </div>
+      <div class="node reveal" id="d-n4">
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M7 18h9.5a3.7 3.7 0 0 0 .4-7.4 5.2 5.2 0 0 0-10-1.4A3.6 3.6 0 0 0 7 18z"/></svg></div>
+        <div class="nlabel">cloud node</div><div class="nrole">api-review</div>
+      </div>
+      <div class="node reveal" id="d-n5">
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="5" r="2.3"/><circle cx="5" cy="18" r="2.3"/><circle cx="19" cy="18" r="2.3"/><path d="M10.5 6.8 6.5 16M13.5 6.8 17.5 16M7.3 18h9.4"/></svg></div>
+        <div class="nlabel">edge gateway</div><div class="nrole">automation</div>
+      </div>
+    </div>
+    <div class="dfoot reveal" id="d-foot">One runtime, shipped everywhere — a fleet of specialized agents</div>
   </div>
 
   <div class="ticks" id="ticks"></div>
@@ -357,7 +425,7 @@ $('themeBtn').addEventListener('click', e=>{ e.stopPropagation(); toggleTheme();
 const scenes = [...document.querySelectorAll('.scene')].map(el=>({ el, id:el.id, start:+el.dataset.start, dur:+el.dataset.dur }));
 const TOTAL = Math.max(...scenes.map(s=>s.start+s.dur));
 const HOLD = 1.4;
-const SPEED = 0.75;   // master playback speed — <1 slower, >1 faster
+const SPEED = 1.0;   // master playback speed — <1 slower, >1 faster
 
 function fit(){ $('stage').style.transform = `scale(${Math.min(innerWidth/1280, innerHeight/720)})`; }
 addEventListener('resize', fit); fit();
@@ -366,12 +434,13 @@ const CAPS = {
   model:   {k:'OPEN ARCHITECTURE', t:'Multi-model switching',   d:'Switch provider or model with one command — fetched live, never hard-coded'},
   ident:   {k:'OPEN ARCHITECTURE', t:'Multi-persona switching', d:'Same agent, many personas — Markdown identities scoped to user or project'},
   interact:{k:'NATIVE RUNTIME',    t:'Fast interaction',        d:'Native Go, single binary — read, edit, run the tests, stream back in seconds'},
-  learn:   {k:'SELF-EVOLVING',     t:'Self-improvement',        d:'A background reviewer studies each session — writing memory, tuning skills, leveling up'},
+  learn:   {k:'SELF-EVOLVING',     t:'Learns as you work',      d:'A background reviewer studies each session — writing memory, tuning skills, leveling up'},
+  deploy:  {k:'SMALL FOOTPRINT',   t:'Runs anywhere',           d:'One ~12 MB binary, zero deps — fan it out to edge devices, containers, and the cloud'},
 };
 
 const TICKS = [
   {t:0,label:'boot'},{t:4.4,label:'multi-model'},{t:12.2,label:'multi-persona'},
-  {t:19.4,label:'fast'},{t:28.4,label:'self-improve'},{t:39.0,label:'outro'},
+  {t:19.4,label:'fast'},{t:28.4,label:'self-evolve'},{t:36.4,label:'deploy'},{t:44.4,label:'outro'},
 ];
 TICKS.forEach(tk=>{ const sp=document.createElement('span'); sp.textContent=tk.label; sp.style.left=(tk.t/TOTAL*100)+'%'; sp.dataset.t=tk.t; $('ticks').appendChild(sp); });
 
@@ -391,6 +460,7 @@ function mFilter(q){
 }
 
 function boot(lt){
+  $('term').classList.remove('shrunk'); $('dlayer').classList.remove('on');   // reset deploy state on (re)start
   $('barpill').textContent = 'openai · GPT-5.5 · ◇ think';   // default model before any switch
   tog($('b-logo'),lt>0.2); tog($('b-tag'),lt>0.9); tog($('b-sub'),lt>1.5); tog($('b-pil'),lt>2.1); tog($('b-prompt'),lt>2.8);
 }
@@ -434,10 +504,21 @@ function learn(lt){
   tog($('l-recap'),show); tog($('l-gm'),show); tog($('l-gs'),show);
   tog($('l-foot'), lt>4.9);
 }
+function deploy(lt){
+  $('term').classList.toggle('shrunk', lt>0.35 && lt<7.5);   // the whole terminal shrinks into a hub
+  tog($('d-logo'), lt>0.4); tog($('d-cap'), lt>0.7);
+  $('dlayer').classList.toggle('on', lt>0.9 && lt<7.55);     // devices pop out around it, on the stage
+  const L=['d-l1','d-l2','d-l3','d-l4','d-l5'];
+  L.forEach((id,i)=>{ $(id).classList.toggle('on', lt > 1.2 + i*0.1); });    // fan-out beams light up
+  const N=['d-n1','d-n2','d-n3','d-n4','d-n5'];
+  N.forEach((id,i)=>{ tog($(id), lt > 1.35 + i*0.14); });     // nodes pop in, snappy stagger
+  N.forEach((id,i)=>{ $(id).classList.toggle('run', lt > 2.0 + i*0.16); });  // each boots its agent
+  tog($('d-foot'), lt>3.8);
+}
 function outro(lt){
   tog($('o-logo'),lt>0.2); tog($('o-cn'),lt>0.9); tog($('o-en'),lt>1.4); tog($('o-inst'),lt>2.1); tog($('o-site'),lt>2.8);
 }
-const RUN = {boot, model, ident, interact, learn, outro};
+const RUN = {boot, model, ident, interact, learn, deploy, outro};
 
 let base=null, paused=false, pausedAt=0, t=0, curCap=null;
 function frame(now){


### PR DESCRIPTION
## Summary

Positions Gen Code around its small, dependency-free footprint and broadens the framing from "AI coding assistant" to a **unified runtime for specialized agents — coding and beyond**.

## Changes

- **New doc — `docs/operations/footprint.md`**: why one ~12 MB, zero-dependency binary is so portable — edge devices, `scratch`/`distroless` containers, CI runners, air-gapped hosts, Raspberry Pi. Linked from the docs index and the benchmark page.
- **README / README.zh**: new **Runs anywhere** engineering bullet (single binary, no Node.js/Python; native Go: ~0.01s cold start, ~32 MB baseline); tagline + intro repositioned to a unified runtime for specialized agents.
- **`site/index.html`**: `<title>`, meta description, and `og:title` updated to the new positioning.
- **`site/intro.html`**: new **deploy / fan-out** scene — the terminal shrinks into a hub and device nodes (laptop, scratch container, edge device, cloud node, edge gateway) pop out across the stage with animated connector lines; fixed the duplicated self-evolving caption; tightened pacing (faster overall, shorter self-evolve hold); dropped the redundant "for the terminal" tagline.
- **`docs/cn/README.md`**: trimmed the overview/features/benchmark that duplicated `README.zh.md`; now links to it and stays focused as the Chinese deep-dive navigation index.

## Verification

- Benchmark/footprint numbers re-confirmed by building stripped release binaries: `linux/arm64` `.tar.gz` ≈ 12 MB; statically linked (no shared-library deps).
- Intro animation verified via headless-Chrome screenshots across the new deploy scene and the outro.

Docs / site only — no code changes.
