### PR TITLE
redesign(site): editorial-terminal landing fused with the animated intro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.0.0] - 2026-06-05
+
+### Added
+- Ollama as LLM provider ([@zhiweiyin](https://github.com/zhiweiyin) in [#90](https://github.com/genai-io/san/pull/90))
+- Blank model selection via blank input in TUI ([@hchenxa](https://github.com/hchenxa) in [#85](https://github.com/genai-io/san/pull/85))
+- Inspector user guide in English and Chinese ([@ldpliu](https://github.com/ldpliu) in [#86](https://github.com/genai-io/san/pull/86))
+
+### Changed
+- **Breaking:** Rename project from gen-code/gen to san (三) ([@yanmxa](https://github.com/yanmxa) in [#96](https://github.com/genai-io/san/pull/96))
+- Website: reposition as unified agent runtime, highlight small footprint and deploy-anywhere ([@yanmxa](https://github.com/yanmxa) in [#93](https://github.com/genai-io/san/pull/93))
+- Rename internal turn counter to "steps", reserve "turn" for Think→Act cycle ([@yanmxa](https://github.com/yanmxa) in [#94](https://github.com/genai-io/san/pull/94))
+
+### Fixed
+- Clean up gen-code/gen legacy references in code, docs, and assets ([@yanmxa](https://github.com/yanmxa) in [#97](https://github.com/genai-io/san/pull/97))
+- Drop gen backward compatibility, finish rebrand touches ([@yanmxa](https://github.com/yanmxa) in [#98](https://github.com/genai-io/san/pull/98))
+
 ## [v1.19.3] - 2026-06-03
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -27,7 +27,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/openai"
 )
 
-var version = "1.19.3"
+var version = "2.0.0"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {

--- a/site/docs.html
+++ b/site/docs.html
@@ -15,12 +15,16 @@
 </head>
 <body>
 
-<nav>
+<nav id="nav">
   <div class="wrap">
     <span class="logo"><a href="index.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
-    <div class="nav-links">
+    <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
+    <div class="nav-links" id="nav-links">
       <a href="index.html#features">Features</a>
+      <a href="index.html#deploy">Deploy</a>
       <a href="index.html#benchmark">Benchmark</a>
+      <span class="nav-sep" aria-hidden="true"></span>
+      <a href="intro.html">Intro</a>
       <a href="getting-started.html">Get Started</a>
       <a href="docs.html">Docs</a>
       <a class="nav-cta" href="https://github.com/genai-io/san">★ Star on GitHub</a>
@@ -125,6 +129,18 @@
 
 <script>
   document.getElementById('year').innerText = new Date().getFullYear();
+
+  function toggleNav(btn) {
+    const nav = document.getElementById('nav');
+    const open = nav.classList.toggle('open');
+    btn.setAttribute('aria-expanded', open);
+  }
+  document.querySelectorAll('#nav-links a').forEach(a =>
+    a.addEventListener('click', () => document.getElementById('nav').classList.remove('open')));
+  const nav = document.getElementById('nav');
+  const onScroll = () => nav.classList.toggle('scrolled', window.scrollY > 8);
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
 </script>
 </body>
 </html>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -15,12 +15,16 @@
 </head>
 <body>
 
-<nav>
+<nav id="nav">
   <div class="wrap">
     <span class="logo"><a href="index.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
-    <div class="nav-links">
+    <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
+    <div class="nav-links" id="nav-links">
       <a href="index.html#features">Features</a>
+      <a href="index.html#deploy">Deploy</a>
       <a href="index.html#benchmark">Benchmark</a>
+      <span class="nav-sep" aria-hidden="true"></span>
+      <a href="intro.html">Intro</a>
       <a href="getting-started.html">Get Started</a>
       <a href="docs.html">Docs</a>
       <a class="nav-cta" href="https://github.com/genai-io/san">★ Star on GitHub</a>
@@ -114,6 +118,18 @@
     });
   }
   document.getElementById('year').innerText = new Date().getFullYear();
+
+  function toggleNav(btn) {
+    const nav = document.getElementById('nav');
+    const open = nav.classList.toggle('open');
+    btn.setAttribute('aria-expanded', open);
+  }
+  document.querySelectorAll('#nav-links a').forEach(a =>
+    a.addEventListener('click', () => document.getElementById('nav').classList.remove('open')));
+  const nav = document.getElementById('nav');
+  const onScroll = () => nav.classList.toggle('scrolled', window.scrollY > 8);
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
 </script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -12,17 +12,21 @@
 <meta property="og:image" content="https://genai-io.github.io/san/san.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='monospace'>%E2%9C%A6</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-<nav>
+<nav id="nav">
   <div class="wrap">
-    <span class="logo">&lt; SAN <span class="spark">✦</span> /&gt;</span>
-    <div class="nav-links">
+    <span class="logo"><a href="#top">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
+    <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
+    <div class="nav-links" id="nav-links">
       <a href="#features">Features</a>
       <a href="#deploy">Deploy</a>
       <a href="#benchmark">Benchmark</a>
+      <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">Intro</a>
       <a href="getting-started.html">Get Started</a>
       <a href="docs.html">Docs</a>
@@ -31,70 +35,83 @@
   </div>
 </nav>
 
-<header class="hero">
+<header class="hero" id="top">
   <div class="wrap">
-    <h1>San — the unified agent<br>that <span class="grad">lives in your terminal</span></h1>
-    <p class="sub">One runtime, many agents — <strong>evolving as you work.</strong></p>
-
-    <div class="intro-embed">
-      <iframe src="intro.html" title="San — animated intro" loading="lazy" allow="fullscreen"></iframe>
-    </div>
-    <p class="intro-cap"><a href="intro.html" target="_blank" rel="noopener">Watch full screen ↗</a></p>
-
-    <div class="badges">
-      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square" alt="Release"></a>
-      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=5eead4" alt="Stars"></a>
-      <a href="https://goreportcard.com/report/github.com/genai-io/san"><img src="https://goreportcard.com/badge/github.com/genai-io/san?style=flat-square" alt="Go Report Card"></a>
-      <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License">
+    <div class="hero-head">
+      <span class="kicker load-up d1">Open-source agent runtime · Apache-2.0</span>
+      <h1 class="load-up d2">San — the unified agent<br>that <span class="grad">lives in your terminal</span></h1>
+      <p class="sub load-up d3">One runtime, many agents — <strong>evolving as you work.</strong></p>
     </div>
 
-    <div class="install">
-      <div class="cmd">
-        <span class="prompt">$</span>
-        <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
-        <button class="copy-btn" onclick="copyInstall(this)">Copy</button>
+    <div class="screen-frame load-up d4">
+      <div class="intro-embed">
+        <iframe src="intro.html?theme=dark" title="San — animated intro" loading="lazy" allow="fullscreen"></iframe>
       </div>
     </div>
+    <p class="intro-cap load-up d4"><a href="intro.html" target="_blank" rel="noopener">Watch full screen ↗</a></p>
 
-    <div class="hero-actions">
+    <div class="hero-actions load-up d5">
       <a class="btn btn-primary" href="getting-started.html">Get started →</a>
       <a class="btn btn-ghost" href="https://github.com/genai-io/san">View on GitHub</a>
+    </div>
+
+    <div class="install-bar load-up d6">
+      <span class="prompt">$</span>
+      <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
+      <button class="copy-btn" onclick="copyInstall(this)">Copy</button>
+    </div>
+
+    <div class="badges load-up d6">
+      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square&color=0d9488" alt="Release"></a>
+      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=14b8a6" alt="Stars"></a>
+      <a href="https://goreportcard.com/report/github.com/genai-io/san"><img src="https://goreportcard.com/badge/github.com/genai-io/san?style=flat-square" alt="Go Report Card"></a>
+      <img src="https://img.shields.io/badge/license-Apache%202.0-0b7d72?style=flat-square" alt="License">
     </div>
   </div>
 </header>
 
 <section id="features">
   <div class="wrap">
-    <h2 class="section-title">Open by design</h2>
-    <p class="section-sub">Every layer is swappable at runtime. No lock-in.</p>
+    <div class="section-head">
+      <span class="kicker">Features</span>
+      <h2 class="section-title">Open <em>by design</em></h2>
+      <p class="section-sub">Every layer is swappable at runtime. No lock-in.</p>
+    </div>
     <div class="grid">
-      <div class="card">
-        <h3><span class="ico">🔌</span> Any LLM provider</h3>
-        <p>Seven providers, from Anthropic to Z.ai. Switch with <code>/model</code>.</p>
+      <div class="card reveal">
+        <span class="idx">01</span>
+        <h3><span class="ico">🔌</span> Multi-LLM providers</h3>
+        <p>Bring any LLM — from Anthropic to Z.ai. Switch with <code>/model</code>.</p>
       </div>
-      <div class="card">
+      <div class="card reveal">
+        <span class="idx">02</span>
         <h3><span class="ico">🔍</span> Pluggable search</h3>
         <p>Exa, Tavily, Brave, or Serper. Switch with <code>/search</code>.</p>
       </div>
-      <div class="card">
+      <div class="card reveal">
+        <span class="idx">03</span>
         <h3><span class="ico">🧩</span> Skills &amp; extensions</h3>
         <p>Skills, plugins, MCP servers, and subagents — Claude Code compatible, run unmodified.</p>
       </div>
-      <div class="card">
+      <div class="card reveal">
+        <span class="idx">04</span>
         <h3><span class="ico">🎭</span> Personas</h3>
         <p>Markdown-defined agent identities, scoped per user or project, plus lifecycle hooks.</p>
       </div>
-      <div class="card">
+      <div class="card reveal">
+        <span class="idx">05</span>
         <h3><span class="ico">⚡</span> Native performance</h3>
         <p>A single Go binary. 12 MB, ~0.01s startup, no runtime.</p>
       </div>
-      <div class="card">
+      <div class="card reveal">
+        <span class="idx">06</span>
         <h3><span class="ico">💾</span> Session persistence</h3>
         <p>Sessions auto-save, resume, and fork, with automatic context compaction.</p>
       </div>
-      <div class="card wide">
+      <div class="card wide reveal">
+        <span class="idx">07</span>
         <div>
-          <h3><span class="ico">✦</span> Self-evolving &nbsp;<span class="soon">Level 1 · live</span></h3>
+          <h3><span class="ico">✦</span> Self-evolving <span class="soon">Level 1 · live</span></h3>
           <p>Every few turns, a background reviewer distills your recent work into durable memory and reusable skills — so the agent levels up as you work, no manual tuning. Level 1 is live today; deeper levels are on the way.</p>
         </div>
         <div class="levels">
@@ -113,8 +130,11 @@
 
 <section id="deploy" style="background: var(--bg-soft);">
   <div class="wrap">
-    <h2 class="section-title">One binary. Runs anywhere.</h2>
-    <p class="section-sub">A single ~12&nbsp;MB binary, zero runtime dependencies — the same file runs unchanged on a laptop, a cloud node, or a 256&nbsp;MB edge device.</p>
+    <div class="section-head">
+      <span class="kicker">Deploy anywhere</span>
+      <h2 class="section-title">One binary. <em>Runs anywhere.</em></h2>
+      <p class="section-sub">A single ~12&nbsp;MB binary, zero runtime dependencies — the same file runs unchanged on a laptop, a cloud node, or a 256&nbsp;MB edge device.</p>
+    </div>
     <div class="deploy-targets">
       <span class="pill">💻 macOS &amp; Linux laptops</span>
       <span class="pill">☁️ Cloud nodes &amp; VMs</span>
@@ -129,9 +149,12 @@
 
 <section id="benchmark">
   <div class="wrap">
-    <h2 class="section-title">Faster &amp; leaner than Claude Code</h2>
-    <p class="section-sub">Same model (<span class="mono">claude-sonnet-4-6</span>) on Apple Silicon, comparable feature set.</p>
-    <div class="bench-wrap">
+    <div class="section-head">
+      <span class="kicker">Benchmark</span>
+      <h2 class="section-title">Faster &amp; leaner than <em>Claude Code</em></h2>
+      <p class="section-sub">Same model (<span class="mono">claude-sonnet-4-6</span>) on Apple Silicon, comparable feature set.</p>
+    </div>
+    <div class="bench-wrap reveal">
       <table>
         <thead>
           <tr><th>Metric</th><th>San</th><th>Claude Code</th><th>Advantage</th></tr>
@@ -152,7 +175,8 @@
 
 <section style="background: var(--bg-soft);">
   <div class="wrap">
-    <div class="cta-box">
+    <div class="cta-box reveal">
+      <span class="kicker" style="justify-content:center;">Get started</span>
       <h2>Try it in 30 seconds</h2>
       <p>Open source under Apache 2.0. Star the repo if it's useful — it genuinely helps.</p>
       <div class="hero-actions">
@@ -165,7 +189,7 @@
 
 <footer>
   <div class="wrap">
-    <span>© <span id="year"></span> San · Apache 2.0</span>
+    <span class="brand">© <span id="year"></span> <span class="san">San 三</span> · Apache 2.0</span>
     <span>
       <a href="https://github.com/genai-io/san">GitHub</a> ·
       <a href="https://github.com/genai-io/san/tree/main/docs">Docs</a> ·
@@ -175,6 +199,7 @@
 </footer>
 
 <script>
+  // Copy install command
   function copyInstall(btn) {
     const text = document.getElementById('install-cmd').innerText;
     navigator.clipboard.writeText(text).then(() => {
@@ -184,6 +209,46 @@
     });
   }
   document.getElementById('year').innerText = new Date().getFullYear();
+
+  // Mobile nav toggle
+  function toggleNav(btn) {
+    const nav = document.getElementById('nav');
+    const open = nav.classList.toggle('open');
+    btn.setAttribute('aria-expanded', open);
+  }
+  // Close the mobile menu after tapping a link
+  document.querySelectorAll('#nav-links a').forEach(a =>
+    a.addEventListener('click', () => document.getElementById('nav').classList.remove('open')));
+
+  // Nav gains a solid background once the page scrolls
+  const nav = document.getElementById('nav');
+  const onScroll = () => nav.classList.toggle('scrolled', window.scrollY > 8);
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
+
+  // Scroll-triggered reveals
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+  document.querySelectorAll('.reveal').forEach((el, i) => {
+    el.style.transitionDelay = (i % 6) * 60 + 'ms';
+    io.observe(el);
+  });
+
+  // Scroll-spy: highlight the active in-page nav link
+  const spyLinks = [...document.querySelectorAll('#nav-links a[href^="#"]')];
+  const sections = spyLinks
+    .map(a => document.getElementById(a.getAttribute('href').slice(1)))
+    .filter(Boolean);
+  const spy = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        spyLinks.forEach(l => l.classList.toggle('active',
+          l.getAttribute('href') === '#' + e.target.id));
+      }
+    });
+  }, { rootMargin: '-45% 0px -50% 0px' });
+  sections.forEach(s => spy.observe(s));
 
   // The intro is a fixed 1280x720 page embedded as an iframe; scale the whole
   // iframe to the container width so the full animated stage is always shown.

--- a/site/intro.html
+++ b/site/intro.html
@@ -230,7 +230,7 @@
 </style>
 <script>
   (function(){ const p=new URLSearchParams(location.search);
-    document.documentElement.dataset.theme = p.get('theme') || 'dark'; })();   // dark by default; ?theme=light forces light
+    document.documentElement.dataset.theme = p.get('theme') || 'dark'; })();   // dark by default (cinematic); ?theme=light or ◐/T for the light/site theme
 </script>
 </head>
 <body>
@@ -416,7 +416,7 @@ const params = new URLSearchParams(location.search);
 const SEEK = params.has('t') ? parseFloat(params.get('t')) : null;   // ?t=<sec> freezes the timeline (screenshots)
 
 const mq = matchMedia('(prefers-color-scheme: dark)');
-let manualTheme = true;   // dark by default everywhere; ◐ / T toggles. ?theme=light forces light.
+let manualTheme = true;   // dark by default (cinematic); ◐ / T toggles. ?theme=light forces light.
 function applyAuto(){ if(!manualTheme) root.dataset.theme = mq.matches ? 'dark' : 'light'; }
 mq.addEventListener('change', applyAuto);
 function toggleTheme(){ manualTheme = true; root.dataset.theme = root.dataset.theme==='dark' ? 'light' : 'dark'; }

--- a/site/style.css
+++ b/site/style.css
@@ -1,238 +1,483 @@
+/* ============================================================
+   San — editorial-terminal design system
+   Type:  Newsreader (display / italic editorial)  ·
+          IBM Plex Mono (terminal voice: nav, code, data, labels) ·
+          Spline Sans (body)  — three families for 三.
+   Theme: warm parchment + deep teal, noise + radial glow,
+          terminal panels with traffic-light dots & a live cursor.
+   Shared by index.html, getting-started.html, docs.html.
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=Spline+Sans:wght@400;500;600;700&display=swap");
+
 :root {
-  --bg: #ffffff;
-  --bg-soft: #f6f8fa;
-  --card: #ffffff;
-  --border: #e3e7ec;
-  --text: #1a1f26;
-  --muted: #5b6573;
-  --accent: #0d9488;
-  --accent-2: #6366f1;
-  --green: #16a34a;
-  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  /* warm parchment surfaces — aligned 1:1 with intro.html's light theme
+     so the page and the embedded intro are the same material. */
+  --bg:        #f5f3ee;
+  --bg-soft:   #f1efe9;
+  --bg-warm:   #ece9e1;
+  --card:      #fffefb;
+  --card-2:    #f8f6f1;
+
+  /* ink */
+  --text:      #15181d;
+  --muted:     #586069;
+  --faint:     #a09c91;
+
+  /* warm hairlines */
+  --border:    #e4e0d6;
+  --border-2:  #d7d2c4;
+
+  /* teal accent family — matches intro.html exactly */
+  --accent:    #0d9488;   /* deep teal — primary */
+  --accent-2:  #0b7d72;   /* darker teal — text on light */
+  --accent-br: #14b8a6;   /* bright teal */
+  --mint:      #2dd4bf;
+  --accent-soft: rgba(13,148,136,.11);
+  --accent-line: rgba(13,148,136,.30);
+  --glow:      rgba(13,148,136,.12);
+
+  /* dark "screen" for terminals & embeds */
+  --screen:    #0a0c10;
+  --screen-2:  #11151b;
+  --screen-bar:#161b22;
+  --screen-fg: #e7efeb;
+  --screen-dim:#8b97a0;
+  --screen-border: #232b34;
+
+  --green:     #15803d;
+  --amber:     #c2740a;
+
+  --mono:  "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --serif: "Newsreader", Georgia, "Times New Roman", serif;
+  --sans:  "Spline Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  --maxw: 1080px;
+  --ease: cubic-bezier(.22,.61,.36,1);
 }
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; scroll-padding-top: 84px; -webkit-text-size-adjust: 100%; }
+
 body {
   background: var(--bg);
   color: var(--text);
   font-family: var(--sans);
-  line-height: 1.6;
+  font-size: 16px;
+  line-height: 1.62;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
 }
-a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-.wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+
+/* atmosphere: fixed teal glow + faint grain, behind all content */
+body::before {
+  content: ""; position: fixed; inset: 0; z-index: -2; pointer-events: none;
+  background:
+    radial-gradient(110% 70% at 50% -12%, var(--glow), transparent 56%),
+    radial-gradient(80% 60% at 100% 0%, rgba(13,148,136,.07), transparent 50%),
+    var(--bg);
+}
+body::after {
+  content: ""; position: fixed; inset: 0; z-index: -1; pointer-events: none;
+  opacity: .045; mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+::selection { background: var(--accent); color: #fff; }
+
+a { color: var(--accent-2); text-decoration: none; transition: color .18s ease; }
+a:hover { color: var(--accent-br); text-decoration: none; }
+
+.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
 .mono { font-family: var(--mono); }
 
-/* Nav */
-nav {
-  position: sticky; top: 0; z-index: 10;
-  background: rgba(255,255,255,.85);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--border);
+/* shared eyebrow / kicker */
+.kicker {
+  font-family: var(--mono); font-size: 12px; font-weight: 500;
+  letter-spacing: .22em; text-transform: uppercase; color: var(--accent-2);
+  display: inline-flex; align-items: center; gap: 9px;
 }
-nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 60px; }
-.logo { font-family: var(--mono); font-weight: 700; font-size: 18px; color: var(--text); }
-.logo a { color: var(--text); }
-.logo a:hover { text-decoration: none; }
-.logo .spark { color: var(--accent); }
-.nav-links { display: flex; gap: 24px; align-items: center; font-size: 14px; }
-.nav-links a { color: var(--muted); }
-.nav-links a:hover { color: var(--text); text-decoration: none; }
-.nav-cta {
-  background: var(--accent); color: #fff !important;
-  padding: 7px 16px; border-radius: 7px; font-weight: 600;
-}
-.nav-cta:hover { text-decoration: none; opacity: .9; }
+.kicker::before { content: "✦"; color: var(--accent); font-size: 13px; }
 
-/* Hero */
-.hero { text-align: center; padding: 90px 0 60px; }
-.hero h1 { font-size: clamp(38px, 6vw, 60px); line-height: 1.1; letter-spacing: -1.5px; font-weight: 800; }
+/* ============================================================ NAV */
+nav {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(245,242,234,.72);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+  border-bottom: 1px solid transparent;
+  transition: background .25s ease, border-color .25s ease, box-shadow .25s ease;
+}
+nav.scrolled {
+  background: rgba(245,242,234,.9);
+  border-bottom-color: var(--border);
+  box-shadow: 0 1px 0 rgba(0,0,0,.02), 0 14px 30px -26px rgba(27,32,31,.5);
+}
+nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 66px; gap: 18px; }
+
+.logo {
+  font-family: var(--mono); font-weight: 600; font-size: 16px; letter-spacing: -.01em;
+  color: var(--text); white-space: nowrap; display: inline-flex; align-items: center;
+}
+.logo a { color: var(--text); display: inline-flex; align-items: center; }
+.logo a:hover { color: var(--text); }
+.logo .spark { color: var(--accent); margin: 0 .12em; }
+.logo::after {
+  content: "▌"; color: var(--accent); margin-left: 2px;
+  animation: blink 1.05s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.nav-links { display: flex; gap: 6px; align-items: center; font-family: var(--mono); font-size: 13px; }
+.nav-links a {
+  color: var(--muted); padding: 7px 11px; border-radius: 7px; position: relative;
+  transition: color .18s ease, background .18s ease;
+}
+.nav-links a:not(.nav-cta):hover { color: var(--text); background: rgba(13,148,136,.07); }
+.nav-links a.active { color: var(--accent-2); }
+.nav-links a.active::before {
+  content: ""; position: absolute; left: 11px; right: 11px; bottom: 2px; height: 2px;
+  background: var(--accent); border-radius: 2px;
+}
+.nav-cta {
+  margin-left: 6px; color: var(--accent-2) !important;
+  border: 1px solid var(--accent-line); background: var(--accent-soft);
+  padding: 7px 15px !important; border-radius: 8px; font-weight: 500;
+  transition: background .18s ease, color .18s ease, border-color .18s ease, transform .18s ease;
+}
+.nav-cta:hover {
+  background: var(--accent); color: #fff !important; border-color: var(--accent);
+  transform: translateY(-1px);
+}
+/* divider between in-page section links and destination-page links */
+.nav-sep { width: 1px; height: 16px; background: var(--border-2); margin: 0 6px; align-self: center; }
+
+/* mobile toggle */
+.nav-toggle {
+  display: none; background: none; border: 1px solid var(--border-2); color: var(--text);
+  width: 40px; height: 38px; border-radius: 9px; cursor: pointer;
+  font-size: 19px; line-height: 1; align-items: center; justify-content: center;
+}
+.nav-toggle:hover { border-color: var(--accent); color: var(--accent-2); }
+
+/* ============================================================ BUTTONS */
+.btn {
+  padding: 12px 22px; border-radius: 10px; font-weight: 600; font-size: 14.5px;
+  font-family: var(--sans); display: inline-flex; align-items: center; gap: 9px;
+  transition: transform .18s var(--ease), box-shadow .2s ease, background .2s ease, border-color .2s ease;
+}
+.btn-primary {
+  background: var(--accent); color: #fff;
+  box-shadow: 0 12px 26px -14px rgba(13,148,136,.8);
+}
+.btn-primary:hover { color: #fff; transform: translateY(-2px); box-shadow: 0 18px 34px -14px rgba(13,148,136,.9); background: var(--accent-2); }
+.btn-ghost { border: 1px solid var(--border-2); color: var(--text); background: var(--card); }
+.btn-ghost:hover { color: var(--text); border-color: var(--accent); background: var(--card-2); transform: translateY(-2px); }
+.hero-actions { margin-top: 26px; display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+
+/* ============================================================ HERO (home) */
+.hero { padding: 92px 0 64px; position: relative; text-align: center; }
+.hero .wrap { position: relative; }
+
+.hero-head { max-width: 840px; margin: 0 auto; }
+.hero h1 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: clamp(34px, 6vw, 68px); line-height: 1.06; letter-spacing: -.015em;
+  margin-top: 22px; color: var(--text);
+}
 .hero h1 .grad {
-  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  font-style: italic; font-weight: 500; color: var(--accent-2);
+  background: linear-gradient(100deg, var(--accent-2), var(--accent-br));
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
-.hero p.sub { font-size: clamp(17px, 2.5vw, 21px); color: var(--muted); max-width: 640px; margin: 22px auto 0; }
-.hero p.sub strong { color: var(--text); }
-.badges { margin-top: 18px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
-.badges img { height: 20px; }
-
-/* Install / command box */
-.install { margin: 36px auto 0; max-width: 640px; }
-.cmd {
-  display: flex; align-items: center; gap: 12px;
-  background: var(--bg-soft); border: 1px solid var(--border);
-  border-radius: 10px; padding: 14px 16px;
-  font-family: var(--mono); font-size: 14px; text-align: left;
+.hero p.sub {
+  font-size: clamp(17px, 2.1vw, 20px); color: var(--muted); max-width: 600px; margin: 22px auto 0;
 }
-.cmd .prompt { color: var(--accent); user-select: none; }
-.cmd code { flex: 1; color: var(--text); overflow-x: auto; white-space: nowrap; }
+.hero p.sub strong { color: var(--text); font-weight: 600; }
+
+.badges { margin-top: 24px; display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+.badges img { height: 21px; }
+
+/* copy button (used by the install bar) */
 .copy-btn {
-  background: var(--border); color: var(--text); border: none;
-  padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;
-  font-family: var(--sans); white-space: nowrap;
+  background: rgba(255,255,255,.07); color: var(--screen-fg); border: 1px solid var(--screen-border);
+  padding: 6px 13px; border-radius: 7px; cursor: pointer; font-size: 12px;
+  font-family: var(--mono); white-space: nowrap; transition: background .18s ease, border-color .18s ease;
 }
-.copy-btn:hover { background: #d4dae1; }
-.hero-actions { margin-top: 22px; display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
-.btn {
-  padding: 12px 24px; border-radius: 9px; font-weight: 600; font-size: 15px;
-  display: inline-flex; align-items: center; gap: 8px;
-}
-.btn-primary { background: var(--accent); color: #fff; }
-.btn-primary:hover { text-decoration: none; opacity: .9; }
-.btn-ghost { border: 1px solid var(--border); color: var(--text); }
-.btn-ghost:hover { text-decoration: none; background: var(--bg-soft); }
+.copy-btn:hover { background: rgba(45,212,191,.16); border-color: var(--accent-br); }
 
-.screenshot { margin: 56px auto 0; max-width: 920px; }
-.screenshot img {
-  width: 100%; display: block; border-radius: 14px;
-  border: 1px solid var(--border);
-  box-shadow: 0 24px 50px -24px rgba(26,31,38,.25);
+/* slim one-line install (sits below the intro in the visual-led hero) */
+.install-bar {
+  margin: 26px auto 0; max-width: 620px;
+  display: flex; align-items: center; gap: 12px;
+  background: var(--screen); border: 1px solid var(--screen-border);
+  border-radius: 12px; padding: 13px 16px;
+  font-family: var(--mono); font-size: 13.5px; text-align: left;
+  box-shadow: 0 24px 50px -32px rgba(10,12,16,.55);
 }
+.install-bar .prompt { color: var(--mint); user-select: none; }
+.install-bar code { flex: 1; min-width: 0; color: var(--screen-fg); overflow-x: auto; white-space: nowrap; }
+.install-bar code::-webkit-scrollbar { height: 0; }
 
-/* Animated intro embedded in the hero (video-as-HTML, plays inline) */
+/* animated intro — a dark "screen" on warm paper (the hybrid hero shot).
+   A clean monitor bezel, NOT a terminal; the intro contains its own. */
+.screen-frame {
+  width: min(1000px, 100%); margin: 44px auto 0;
+  padding: 8px; background: var(--screen-bar);
+  border: 1px solid var(--screen-border); border-radius: 18px; overflow: hidden;
+  box-shadow: 0 44px 100px -46px rgba(10,12,16,.62), inset 0 1px 0 rgba(255,255,255,.05);
+}
 .intro-embed {
-  position: relative;
-  left: 50%; transform: translateX(-50%);   /* break out wider than the text column */
-  width: min(1100px, 92vw); margin: 56px 0 0;
-  aspect-ratio: 1280 / 720; overflow: hidden;
-  border-radius: 14px; border: 1px solid var(--border);
-  box-shadow: 0 24px 50px -24px rgba(26,31,38,.25);
-  background: #0a0c10;
+  position: relative; width: 100%; aspect-ratio: 1280 / 720; overflow: hidden;
+  background: var(--screen); border-radius: 11px;
 }
-/* The intro is a fixed 1280x720 page; the page script scales the whole iframe
-   to the box width so the full animated stage is always shown (no clipping). */
 .intro-embed iframe {
-  position: absolute; top: 0; left: 0;
-  width: 1280px; height: 720px; border: 0;
+  position: absolute; top: 0; left: 0; width: 1280px; height: 720px; border: 0;
   transform-origin: top left;
 }
-.intro-cap { text-align: center; margin-top: 14px; font-size: 14px; color: var(--muted); }
+.intro-cap { text-align: center; margin-top: 16px; font-family: var(--mono); font-size: 12.5px; color: var(--faint); }
+.intro-cap a { color: var(--accent-2); }
 
-/* Sections */
-section { padding: 64px 0; }
-.section-title { font-size: 30px; font-weight: 700; letter-spacing: -.5px; text-align: center; }
-.section-sub { color: var(--muted); text-align: center; margin-top: 8px; max-width: 600px; margin-left: auto; margin-right: auto; }
+/* legacy screenshot helper (kept for compatibility) */
+.screenshot { margin: 56px auto 0; max-width: 920px; }
+.screenshot img { width: 100%; display: block; border-radius: 14px; border: 1px solid var(--border); box-shadow: 0 24px 50px -24px rgba(27,32,31,.3); }
 
-/* Feature grid */
-.grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; margin-top: 40px; }
+/* ============================================================ SECTIONS */
+section { padding: 76px 0; position: relative; }
+.section-head { max-width: 620px; margin: 0 auto; text-align: center; }
+.section-head.left { margin: 0; text-align: left; }
+.section-title {
+  font-family: var(--serif); font-weight: 500; letter-spacing: -.01em;
+  font-size: clamp(28px, 3.8vw, 42px); line-height: 1.1; margin-top: 14px;
+}
+.section-title em { font-style: italic; color: var(--accent-2); }
+.section-sub { color: var(--muted); margin-top: 12px; font-size: 16.5px; }
+.section-sub code, .section-sub .mono {
+  font-family: var(--mono); font-size: 13.5px; background: var(--accent-soft);
+  padding: 1px 7px; border-radius: 5px; color: var(--accent-2);
+}
+
+/* ============================================================ FEATURE GRID */
+.grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 44px; }
 .card {
   background: var(--card); border: 1px solid var(--border);
-  border-radius: 12px; padding: 24px;
+  border-radius: 14px; padding: 26px; position: relative; overflow: hidden;
+  transition: transform .22s var(--ease), border-color .22s ease, box-shadow .22s ease;
 }
-.card h3 { font-size: 17px; display: flex; align-items: center; gap: 10px; }
-.card .ico { font-size: 20px; }
-.card p { color: var(--muted); font-size: 14px; margin-top: 8px; }
-.card code { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
+.card::after {
+  content: ""; position: absolute; inset: 0; border-radius: 14px; pointer-events: none;
+  box-shadow: inset 0 0 0 1px transparent; transition: box-shadow .22s ease;
+}
+.card:hover {
+  transform: translateY(-4px); border-color: var(--accent-line);
+  box-shadow: 0 24px 44px -28px rgba(13,148,136,.45);
+}
+.card .idx {
+  position: absolute; top: 20px; right: 22px;
+  font-family: var(--mono); font-size: 12px; color: var(--faint);
+  letter-spacing: .05em; transition: color .22s ease;
+}
+.card:hover .idx { color: var(--accent); }
+.card h3 { font-family: var(--sans); font-weight: 600; font-size: 17.5px; display: flex; align-items: center; gap: 12px; letter-spacing: -.01em; }
+.card .ico {
+  font-size: 19px; width: 38px; height: 38px; flex: 0 0 auto;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--bg-soft); border: 1px solid var(--border); border-radius: 10px;
+}
+.card p { color: var(--muted); font-size: 14.5px; margin-top: 12px; }
+.card code {
+  font-family: var(--mono); font-size: 12.5px; background: var(--accent-soft);
+  padding: 1px 6px; border-radius: 5px; color: var(--accent-2);
+}
 .card.wide {
   grid-column: 1 / -1;
-  background: linear-gradient(120deg, rgba(13,148,136,.06), rgba(99,102,241,.06));
-  display: flex; flex-direction: column; gap: 16px;
+  background:
+    radial-gradient(120% 140% at 100% 0%, rgba(20,184,166,.10), transparent 55%),
+    var(--card);
+  display: flex; flex-direction: column; gap: 18px;
 }
-.levels { display: flex; flex-wrap: wrap; gap: 10px; }
+.card.wide h3 { font-size: 18.5px; }
+
+/* self-evolving levels track */
+.levels { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
 .level {
-  display: flex; align-items: center; gap: 8px;
-  background: var(--bg); border: 1px solid var(--border);
-  border-radius: 999px; padding: 6px 14px; font-size: 13px;
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--card-2); border: 1px solid var(--border);
+  border-radius: 999px; padding: 7px 15px; font-family: var(--mono); font-size: 12.5px; color: var(--muted);
 }
-.level b { color: var(--accent); font-family: var(--mono); }
-.level .arrow { color: var(--muted); }
-.level.live { border-color: var(--accent); background: rgba(13,148,136,.08); }
+.level b { color: var(--accent-2); }
+.levels .arrow { color: var(--faint); font-family: var(--mono); }
+.level.live {
+  border-color: var(--accent); background: var(--accent-soft); color: var(--text);
+}
 .level.live::after {
-  content: "live"; font-size: 10px; font-weight: 700;
-  letter-spacing: .5px; text-transform: uppercase; color: var(--accent);
+  content: "live"; font-size: 9.5px; font-weight: 600; letter-spacing: .14em;
+  text-transform: uppercase; color: #fff; background: var(--accent);
+  padding: 2px 7px; border-radius: 999px;
 }
 .soon {
-  font-family: var(--sans); font-size: 11px; font-weight: 600;
-  letter-spacing: .5px; text-transform: uppercase;
-  color: var(--accent-2); background: rgba(99,102,241,.1);
-  border: 1px solid rgba(99,102,241,.25);
-  padding: 2px 9px; border-radius: 999px; vertical-align: middle;
+  font-family: var(--mono); font-size: 10.5px; font-weight: 500;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--amber);
+  background: rgba(194,116,10,.12); border: 1px solid rgba(194,116,10,.3);
+  padding: 3px 10px; border-radius: 999px; vertical-align: middle; margin-left: 4px;
 }
 
-/* Benchmark table */
-.bench-wrap { margin-top: 40px; overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-th, td { padding: 13px 18px; text-align: left; border-bottom: 1px solid var(--border); }
-th { background: var(--bg-soft); color: var(--muted); font-weight: 600; }
-tr:last-child td { border-bottom: none; }
-td.adv { color: var(--green); font-weight: 600; }
-.bench-note { color: var(--muted); font-size: 13px; text-align: center; margin-top: 16px; }
-
-/* Providers */
-.pills { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; margin-top: 36px; }
+/* ============================================================ DEPLOY / PILLS */
+.deploy-targets, .pills { display: flex; flex-wrap: wrap; gap: 11px; justify-content: center; margin-top: 40px; }
 .pill {
   background: var(--card); border: 1px solid var(--border);
-  padding: 8px 16px; border-radius: 999px; font-size: 14px; color: var(--text);
+  padding: 9px 16px; border-radius: 999px; font-size: 14px; color: var(--text);
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: border-color .18s ease, transform .18s ease, background .18s ease;
+}
+.pill:hover { border-color: var(--accent-line); transform: translateY(-2px); background: var(--card-2); }
+.deploy-targets .pill code, .pill code {
+  font-family: var(--mono); font-size: 12.5px; background: var(--accent-soft);
+  padding: 1px 6px; border-radius: 5px; color: var(--accent-2);
 }
 
-/* Deploy-anywhere targets */
-.deploy-targets { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 40px; }
-.deploy-targets .pill { display: inline-flex; align-items: center; gap: 8px; font-size: 14.5px; }
-.deploy-targets .pill code {
-  font-family: var(--mono); font-size: 12.5px;
-  background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent);
+/* ============================================================ BENCHMARK */
+.bench-wrap { margin-top: 44px; overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; background: var(--card); }
+table { width: 100%; border-collapse: collapse; font-size: 14px; }
+th, td { padding: 14px 20px; text-align: left; border-bottom: 1px solid var(--border); }
+th {
+  background: var(--bg-soft); color: var(--muted); font-weight: 500;
+  font-family: var(--mono); font-size: 12px; letter-spacing: .08em; text-transform: uppercase;
 }
-.section-sub code { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
+td { font-family: var(--mono); font-size: 13px; color: var(--text); }
+td:first-child { font-family: var(--sans); color: var(--muted); }
+tbody tr { transition: background .15s ease; }
+tbody tr:hover { background: var(--accent-soft); }
+tr:last-child td { border-bottom: none; }
+td.adv { color: var(--green); font-weight: 600; }
+.bench-note { color: var(--muted); font-size: 13px; text-align: center; margin-top: 18px; font-family: var(--mono); }
+.bench-note a { color: var(--accent-2); }
 
-/* CTA */
+/* ============================================================ CTA BOX */
 .cta-box {
-  background: linear-gradient(120deg, rgba(94,234,212,.08), rgba(129,140,248,.08));
-  border: 1px solid var(--border); border-radius: 16px;
-  padding: 50px 30px; text-align: center; margin-top: 20px;
+  background:
+    radial-gradient(120% 160% at 50% -30%, rgba(20,184,166,.16), transparent 60%),
+    var(--card);
+  border: 1px solid var(--border-2); border-radius: 20px;
+  padding: 60px 36px; text-align: center; margin-top: 20px; position: relative; overflow: hidden;
 }
-.cta-box h2 { font-size: 28px; }
-.cta-box p { color: var(--muted); margin-top: 10px; }
+.cta-box::before {
+  content: "三"; position: absolute; right: 24px; bottom: -28px;
+  font-family: var(--serif); font-size: 180px; line-height: 1; color: var(--accent);
+  opacity: .05; pointer-events: none;
+}
+.cta-box h2 { font-family: var(--serif); font-weight: 500; font-size: clamp(26px, 3.4vw, 36px); }
+.cta-box p { color: var(--muted); margin-top: 12px; max-width: 520px; margin-left: auto; margin-right: auto; }
+.cta-box .hero-actions { justify-content: center; }
 
-footer { border-top: 1px solid var(--border); padding: 36px 0; color: var(--muted); font-size: 14px; }
-footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px; }
+/* ============================================================ FOOTER */
+footer { border-top: 1px solid var(--border); padding: 40px 0; color: var(--muted); font-size: 13.5px; margin-top: 20px; }
+footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px; align-items: center; }
+footer .brand { font-family: var(--mono); color: var(--text); }
+footer .brand .san { color: var(--accent); }
 footer a { color: var(--muted); }
+footer a:hover { color: var(--accent-2); }
 
-/* ---- Getting Started page ---- */
-.page-hero { text-align: center; padding: 64px 0 8px; }
-.page-hero h1 { font-size: clamp(30px, 5vw, 44px); font-weight: 800; letter-spacing: -1px; }
-.page-hero p { color: var(--muted); margin-top: 12px; font-size: 18px; }
+/* ============================================================ GETTING STARTED */
+.page-hero { padding: 86px 0 10px; }
+.page-hero .wrap { max-width: 760px; }
+.page-hero h1 { font-family: var(--serif); font-weight: 500; font-size: clamp(34px, 5.2vw, 52px); letter-spacing: -.015em; margin-top: 14px; line-height: 1.06; }
+.page-hero h1 em { font-style: italic; color: var(--accent-2); }
+.page-hero p { color: var(--muted); margin-top: 14px; font-size: 18px; max-width: 560px; }
 
-.steps { counter-reset: step; max-width: 760px; margin: 48px auto 0; display: flex; flex-direction: column; gap: 28px; }
+.steps { counter-reset: step; max-width: 760px; margin: 50px auto 0; display: flex; flex-direction: column; gap: 26px; }
 .step { display: flex; gap: 22px; align-items: flex-start; }
 .step .num {
-  flex: 0 0 auto; width: 38px; height: 38px; border-radius: 50%;
-  background: var(--accent); color: #fff; font-weight: 700; font-family: var(--mono);
+  flex: 0 0 auto; width: 42px; height: 42px; border-radius: 12px;
+  background: var(--accent); color: #fff; font-weight: 600; font-family: var(--mono);
   display: flex; align-items: center; justify-content: center; font-size: 17px;
+  box-shadow: 0 12px 24px -12px rgba(13,148,136,.8);
 }
 .step-body { flex: 1; min-width: 0; }
-.step-body h3 { font-size: 20px; font-weight: 700; }
-.step-body > p { color: var(--muted); margin-top: 6px; }
+.step-body h3 { font-family: var(--sans); font-size: 20px; font-weight: 600; }
+.step-body > p { color: var(--muted); margin-top: 7px; }
 .step-body .cmd { margin-top: 14px; }
-.step-body code.inline { font-family: var(--mono); font-size: 13px; background: var(--bg-soft); padding: 1px 6px; border-radius: 4px; color: var(--accent); }
+.step-body code.inline,
+code.inline { font-family: var(--mono); font-size: 13px; background: var(--accent-soft); padding: 2px 7px; border-radius: 5px; color: var(--accent-2); }
+
+/* light inline command box (subpages) */
+.cmd {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--screen); border: 1px solid var(--screen-border);
+  border-radius: 11px; padding: 14px 16px;
+  font-family: var(--mono); font-size: 13.5px; text-align: left;
+}
+.cmd .prompt { color: var(--mint); user-select: none; }
+.cmd code { flex: 1; color: var(--screen-fg); overflow-x: auto; white-space: nowrap; }
+
 .substeps { margin: 16px 0 0; padding-left: 0; list-style: none; counter-reset: sub; display: flex; flex-direction: column; gap: 12px; }
 .substeps li {
-  position: relative; padding: 14px 16px 14px 46px;
-  background: var(--bg-soft); border: 1px solid var(--border); border-radius: 10px;
+  position: relative; padding: 14px 16px 14px 48px;
+  background: var(--card); border: 1px solid var(--border); border-radius: 11px;
   font-size: 14px; color: var(--text);
 }
 .substeps li::before {
   counter-increment: sub; content: counter(sub, lower-alpha);
   position: absolute; left: 14px; top: 13px;
-  width: 22px; height: 22px; border-radius: 50%;
-  background: var(--bg); border: 1px solid var(--accent); color: var(--accent);
-  font-family: var(--mono); font-size: 12px; font-weight: 700;
+  width: 24px; height: 24px; border-radius: 7px;
+  background: var(--bg); border: 1px solid var(--accent); color: var(--accent-2);
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
   display: flex; align-items: center; justify-content: center;
 }
 .substeps li b { color: var(--accent-2); }
 
-/* ---- Docs index page ---- */
-.doc-card h3 { font-size: 16px; display: flex; align-items: center; gap: 9px; }
-.doc-card ul { list-style: none; margin-top: 14px; display: flex; flex-direction: column; gap: 9px; }
+/* ============================================================ DOCS INDEX */
+.doc-card h3 { font-family: var(--sans); font-size: 16.5px; font-weight: 600; display: flex; align-items: center; gap: 11px; }
+.doc-card ul { list-style: none; margin-top: 16px; display: flex; flex-direction: column; gap: 10px; }
 .doc-card li a {
-  color: var(--text); font-size: 14px; display: inline-flex; align-items: baseline; gap: 7px;
+  color: var(--text); font-size: 14px; display: inline-flex; align-items: baseline; gap: 8px;
 }
-.doc-card li a::before { content: "›"; color: var(--accent); font-weight: 700; }
-.doc-card li a:hover { color: var(--accent); text-decoration: none; }
+.doc-card li a::before { content: "›"; color: var(--accent); font-weight: 700; font-family: var(--mono); }
+.doc-card li a:hover { color: var(--accent-2); }
 
-@media (max-width: 640px) {
+/* ============================================================ MOTION */
+.reveal { opacity: 0; transform: translateY(22px); transition: opacity .7s var(--ease), transform .7s var(--ease); }
+.reveal.in { opacity: 1; transform: none; }
+
+/* staggered hero load-in */
+.load-up { opacity: 0; transform: translateY(16px); animation: loadUp .8s var(--ease) forwards; }
+@keyframes loadUp { to { opacity: 1; transform: none; } }
+.d1 { animation-delay: .05s; } .d2 { animation-delay: .15s; } .d3 { animation-delay: .25s; }
+.d4 { animation-delay: .35s; } .d5 { animation-delay: .45s; } .d6 { animation-delay: .55s; }
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .reveal, .load-up { transition: none; animation: none; opacity: 1; transform: none; }
+  .logo::after { animation: none; }
+  * { transition: none !important; }
+}
+
+/* ============================================================ RESPONSIVE */
+@media (max-width: 860px) {
   .grid { grid-template-columns: 1fr; }
-  .nav-links a:not(.nav-cta) { display: none; }
-  .hero { padding: 56px 0 40px; }
+}
+@media (max-width: 760px) {
+  .nav-toggle { display: inline-flex; }
+  .nav-links {
+    position: absolute; top: 66px; left: 0; right: 0;
+    flex-direction: column; align-items: stretch; gap: 4px;
+    background: rgba(245,242,234,.97); backdrop-filter: blur(14px);
+    border-bottom: 1px solid var(--border); padding: 12px 18px 18px;
+    box-shadow: 0 20px 30px -20px rgba(27,32,31,.4);
+    transform: translateY(-8px); opacity: 0; pointer-events: none;
+    transition: opacity .2s ease, transform .2s ease;
+  }
+  nav.open .nav-links { transform: none; opacity: 1; pointer-events: auto; }
+  .nav-sep { display: none; }
+  .nav-links a { padding: 11px 12px; font-size: 14px; }
+  .nav-links a.active::before { display: none; }
+  .nav-cta { margin: 6px 0 0; text-align: center; justify-content: center; }
+}
+@media (max-width: 640px) {
+  .wrap { padding: 0 20px; }
+  .hero { padding: 64px 0 44px; }
+  section { padding: 56px 0; }
+  .step { gap: 16px; }
+  .cta-box { padding: 44px 24px; }
 }


### PR DESCRIPTION
Redesigns the marketing site to share one design language with the animated intro — **Newsreader** (italic serif) + **IBM Plex Mono** + **Spline Sans** on warm parchment with a single teal accent.

- **`index.html`** — visual-led hero (headline → dark intro "screen" → CTAs → one-line install → badges); grouped nav with scroll-spy + mobile menu; provider copy fixed to "Multi-LLM providers".
- **`style.css`** — rewritten as a shared design system; palette aligned 1:1 with `intro.html` so page and embed are the same material. Subpages restyled to match; reduced-motion + responsive included.
- **`intro.html`** — cinematic dark by default; embedded in the hero as a dark screen (no terminal chrome). Light theme via `T` / `◐`.
- **`getting-started.html` / `docs.html`** — nav aligned for consistency.

**Why hybrid (light page + dark hero screen):** the dark screen pops as the focal point while the page stays distinctive — avoiding the all-dark dev-tool cliché.

Verify by opening `site/index.html` in a browser.
