### PR TITLE
fix: banner shows model display name, status bar shows model ID

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -37,7 +37,7 @@ func Run(opts setting.RunOptions) error {
 	// conversation immediately, so a splash would just be churn.
 	if len(m.conv.Messages) == 0 {
 		printWelcome(welcomeInfo{
-			Model: m.services.LLM.ModelID(),
+			Model: m.env.GetModelDisplayName(),
 			CWD:   m.env.CWD,
 		})
 	}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -223,7 +223,7 @@ func (m model) renderTrackerList() string {
 }
 
 func (m model) renderModeStatus() string {
-	modelName := m.env.GetModelDisplayName()
+	modelName := m.env.GetModelID()
 	thinkingEffort := m.env.EffectiveThinkingEffort()
 	showThinking := true
 	if m.env.CurrentModel != nil && m.env.CurrentModel.Provider == llm.OpenAI && thinkingEffort != "" {

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -250,24 +250,37 @@ func (s *Store) GetAllCachedModelsIncludeExpired() map[string][]ModelInfo {
 }
 
 // CachedModelDisplayName returns the display name for a model ID found in any
-// cached provider list, ignoring TTL, falling back to the model's Name. Returns
-// "" if the ID isn't cached. Unlike GetAllCachedModels*, it scans in place
-// without allocating a snapshot map, since it runs on every status-bar render.
+// cached provider list, ignoring TTL. Returns "" if the ID isn't cached.
+//
+// The same model can be cached under several provider/auth keys (e.g. a model
+// offered both directly and via an aggregator). One provider may list a real
+// display name ("DeepSeek V4 Pro") while another only echoes the raw ID
+// ("deepseek-v4-pro"). Returning whichever entry we hit first would make the
+// status bar flicker between the two, because Go randomizes map iteration
+// order between renders. So we prefer a real display name — one that differs
+// from the ID — and only fall back to the raw name/ID when no real name
+// exists. Scans in place without allocating, since it runs on every render.
 func (s *Store) CachedModelDisplayName(id string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	raw := "" // the raw ID echoed back as a name; used only if no real name is found
 	for _, cache := range s.data.Models {
 		for _, m := range cache.Models {
-			if m.ID == id {
-				if m.DisplayName != "" {
-					return m.DisplayName
-				}
-				return m.Name
+			if m.ID != id {
+				continue
 			}
+			name := m.DisplayName
+			if name == "" {
+				name = m.Name
+			}
+			if name != "" && name != id {
+				return name // a real, human-readable display name
+			}
+			raw = name // keep scanning in case another provider has a real name
 		}
 	}
-	return ""
+	return raw
 }
 
 // SetCurrentModel sets the current model with provider info

--- a/internal/llm/store_test.go
+++ b/internal/llm/store_test.go
@@ -85,3 +85,53 @@ func TestStore_SetTokenLimitUpdatesCachedModelCopy(t *testing.T) {
 		t.Fatalf("expected previously returned cached slice to remain unchanged, got %#v", cachedBefore[0])
 	}
 }
+
+// When the same model ID is cached under multiple provider/auth keys — one with
+// a real display name and another that only echoes the raw ID — the display
+// name must be stable across renders. Returning the first map match would
+// flicker because Go randomizes map iteration order; we must deterministically
+// prefer the real display name.
+func TestStore_CachedModelDisplayNamePrefersRealNameAndIsStable(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	store, err := NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	// alibaba echoes the raw ID as the display name; deepseek has a real one.
+	if err := store.CacheModels(Alibaba, AuthAPIKey, []ModelInfo{
+		{ID: "deepseek-v4-pro", Name: "deepseek-v4-pro", DisplayName: "deepseek-v4-pro"},
+	}); err != nil {
+		t.Fatalf("CacheModels(alibaba) error = %v", err)
+	}
+	if err := store.CacheModels(DeepSeek, AuthAPIKey, []ModelInfo{
+		{ID: "deepseek-v4-pro", Name: "DeepSeek V4 Pro", DisplayName: "DeepSeek V4 Pro"},
+	}); err != nil {
+		t.Fatalf("CacheModels(deepseek) error = %v", err)
+	}
+
+	// Call many times; with randomized map order an order-dependent
+	// implementation would return both values across iterations.
+	for i := range 100 {
+		if got := store.CachedModelDisplayName("deepseek-v4-pro"); got != "DeepSeek V4 Pro" {
+			t.Fatalf("CachedModelDisplayName() = %q, want %q (unstable/wrong on iteration %d)", got, "DeepSeek V4 Pro", i)
+		}
+	}
+
+	// A model that only ever echoes its ID still falls back to that ID.
+	if err := store.CacheModels(OpenAI, AuthAPIKey, []ModelInfo{
+		{ID: "raw-only", Name: "raw-only", DisplayName: "raw-only"},
+	}); err != nil {
+		t.Fatalf("CacheModels(openai) error = %v", err)
+	}
+	if got := store.CachedModelDisplayName("raw-only"); got != "raw-only" {
+		t.Fatalf("CachedModelDisplayName(raw-only) = %q, want %q", got, "raw-only")
+	}
+
+	// An uncached ID returns "".
+	if got := store.CachedModelDisplayName("missing"); got != "" {
+		t.Fatalf("CachedModelDisplayName(missing) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## What

Two places render the current model, and they had it backwards:

- The **startup banner** showed the raw model ID (`deepseek-v4-pro`).
- The **status bar** (bottom-right) showed the display name (`DeepSeek V4 Pro`) — and it *flickered* between the friendly name and the raw ID on every render.

This swaps them so each fits its job:

- **Banner** → human-friendly **display name** (`DeepSeek V4 Pro`)
- **Status bar** → exact **model ID** (`deepseek-v4-pro`), so you always see precisely what is running

## Why the status bar flickered

The same model can be cached under several provider/auth keys — e.g. `deepseek-v4-pro` is cached under both `alibaba:api_key` (display name = the raw ID) and `deepseek:api_key` (display name = `DeepSeek V4 Pro`). `CachedModelDisplayName` returned the **first** map match, and Go randomizes map iteration order, so each render landed on a different entry.

Routing the status bar to the model ID removes that path entirely. And `CachedModelDisplayName` — now used by the banner — is made **deterministic**: it prefers a real display name (one that differs from the ID) and only falls back to the raw name/ID when no real name exists.

## Tests

Added `TestStore_CachedModelDisplayNamePrefersRealNameAndIsStable`, covering:

- duplicate cache entries (real name vs raw-ID echo) → stable across 100 calls
- a model that only echoes its ID → falls back to the ID
- an uncached ID → returns `""`

`go build ./...`, `go vet`, and `go test ./internal/llm/ ./internal/app/` all pass.