### PR TITLE
ci: add PR commands, title lint, stale bot, dependabot, and harden CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:27"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    open-pull-requests-limit: 5

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,24 @@
+name: Auto Merge
+
+# Merge PRs that have the lgtm label and pass all required checks.
+# Runs on a cron schedule so branch-protection status checks have time to finish.
+
+on:
+  schedule:
+    # Every 30 minutes (avoids :00/:30).
+    - cron: '7,37 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          merge-method: squash

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # v4.2.0 — https://github.com/actions/checkout
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
-      # v5.4.0 — https://github.com/actions/setup-go
-      - uses: actions/setup-go@0a12ef9b5f0c5f44376d96529b5a38d7b29e5b8e  # v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.25.6'
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25.6'
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      # v4.2.0 — https://github.com/actions/checkout
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      # v5.4.0 — https://github.com/actions/setup-go
+      - uses: actions/setup-go@0a12ef9b5f0c5f44376d96529b5a38d7b29e5b8e  # v5
         with:
           go-version: '1.25.6'
+          cache: true
       - name: Install format tools
         run: make install-format-tools
       - name: Format check
@@ -21,8 +27,8 @@ jobs:
       - name: Build
         run: make build-all
       - name: Unit tests
-        run: go test ./internal/...
+        run: go test -race ./internal/...
       - name: Integration tests
-        run: go test ./tests/integration/...
+        run: go test -race ./tests/integration/...
       - name: Vet
         run: make lint

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,27 @@
+name: DCO
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dco_check:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+      - name: Get PR Commits
+        id: get-pr-commits
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: DCO Check
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21  # v1.1.0
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -19,8 +19,8 @@ jobs:
     if: github.event.issue.pull_request != null
     runs-on: ubuntu-latest
     steps:
-      # v2.0.0 — https://github.com/jpmcb/prow-github-actions
-      - uses: jpmcb/prow-github-actions@v2
+      # https://github.com/jpmcb/prow-github-actions
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           prow-commands: '/assign /unassign /approve /retitle /area /kind /priority /remove /lgtm /close /reopen /lock /milestone /hold /cc /uncc'
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,189 +1,26 @@
 name: PR Commands
 
-# Handle slash commands in PR comments:
-#   /cc @user [@user ...]  – request review from the mentioned user(s)
-#   /hold [reason]          – add do-not-merge/hold label
-#   /unhold                 – remove do-not-merge/hold label
-#
-# Only PR comments are processed; issue comments are ignored. Commands are
-# case-insensitive and must appear at the start of a line.
+# Prow-style chat-ops for GitHub Actions, powered by jpmcb/prow-github-actions.
+# Commands: /cc /uncc /assign /unassign /approve /lgtm /hold
+#           /retitle /area /kind /priority /remove /close /reopen /lock /milestone
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write      # needed for adding/removing labels
-
-concurrency:
-  group: pr-commands-${{ github.event.issue_comment.id }}
-  cancel-in-progress: true
+  issues: write
 
 jobs:
   execute:
-    # Only run on PR comments (not plain issues) and skip bot comments.
-    if: |
-      github.event.issue.pull_request != null &&
-      github.event.comment.user.type != 'Bot'
+    # Only run on PR comments (not plain issues).
+    if: github.event.issue.pull_request != null
     runs-on: ubuntu-latest
     steps:
-      - name: Parse and execute commands
-        uses: actions/github-script@v7
+      # v2.0.0 — https://github.com/jpmcb/prow-github-actions
+      - uses: jpmcb/prow-github-actions@v2
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.issue.number;
-            const commentId = context.payload.comment.id;
-            const commentBody = context.payload.comment.body;
-            const commentUser = context.payload.comment.user.login;
-
-            // ── helpers ──────────────────────────────────────────────
-
-            /** React to the comment. */
-            async function react(reaction) {
-              await github.rest.reactions.createForIssueComment({
-                owner, repo, comment_id: commentId, content: reaction,
-              });
-            }
-
-            /** Post a reply to the comment. */
-            async function reply(body) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber, body,
-              });
-            }
-
-            /** Ensure a label exists (idempotent). */
-            async function ensureLabel(name, color, description) {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name });
-              } catch (e) {
-                if (e.status !== 404) throw e;
-                await github.rest.issues.createLabel({ owner, repo, name, color, description });
-              }
-            }
-
-            /** Parse @mentions from a string. Returns deduplicated usernames without @. */
-            function parseMentions(text) {
-              const matches = text.match(/@([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})/g);
-              if (!matches) return [];
-              return [...new Set(matches.map(m => m.slice(1)))];
-            }
-
-            // ── command parser ───────────────────────────────────────
-
-            /** Return all commands found in the comment, each with {cmd, args, line}. */
-            function parseCommands(body) {
-              const cmds = [];
-              const lines = body.split('\n');
-              for (const line of lines) {
-                const m = line.trim().match(/^\/(cc|hold|unhold)\b\s*(.*)/i);
-                if (m) {
-                  cmds.push({ cmd: m[1].toLowerCase(), args: m[2].trim(), line: line.trim() });
-                }
-              }
-              return cmds;
-            }
-
-            // ── command handlers ─────────────────────────────────────
-
-            async function handleCC(users) {
-              if (users.length === 0) {
-                await react('confused');
-                await reply(`@${commentUser} Usage: \`/cc @username [@username ...]\``);
-                return;
-              }
-
-              // Validate each user exists on GitHub.
-              const valid = [];
-              const invalid = [];
-              for (const u of users) {
-                try {
-                  await github.rest.users.getByUsername({ username: u });
-                  valid.push(u);
-                } catch (e) {
-                  if (e.status === 404) invalid.push(u);
-                  else throw e;
-                }
-              }
-
-              if (valid.length > 0) {
-                await github.rest.pulls.requestReviewers({
-                  owner, repo, pull_number: prNumber, reviewers: valid,
-                });
-              }
-
-              await react('+1');
-
-              const parts = [];
-              if (valid.length) parts.push(`✅ Requested review from ${valid.map(u => `@${u}`).join(', ')}.`);
-              if (invalid.length) parts.push(`⚠️ ${invalid.map(u => `@${u}`).join(', ')} — not a valid GitHub user.`);
-              await reply(parts.join('\n'));
-            }
-
-            async function handleHold(reason) {
-              await ensureLabel('do-not-merge/hold', 'D93F0B',
-                'This PR is on hold and should not be merged');
-
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: prNumber, labels: ['do-not-merge/hold'],
-              });
-
-              await react('+1');
-
-              const reasonText = reason ? `\n\n**Reason:** ${reason}` : '';
-              await reply(
-                `🔴 **Hold** requested by @${commentUser}. ` +
-                `This PR must not be merged until the hold is lifted.${reasonText}\n\n` +
-                `To lift the hold, comment \`/unhold\`.`
-              );
-            }
-
-            async function handleUnhold() {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: prNumber, name: 'do-not-merge/hold',
-                });
-              } catch (e) {
-                if (e.status !== 404) throw e;
-              }
-
-              await react('+1');
-              await reply(`🟢 Hold lifted by @${commentUser}.`);
-            }
-
-            // ── main ─────────────────────────────────────────────────
-
-            const commands = parseCommands(commentBody);
-            if (commands.length === 0) {
-              core.info('No commands found in comment.');
-              return;
-            }
-
-            core.info(`Found ${commands.length} command(s): ${JSON.stringify(commands)}`);
-
-            for (const { cmd, args } of commands) {
-              try {
-                switch (cmd) {
-                  case 'cc': {
-                    const mentioned = parseMentions(args);
-                    await handleCC(mentioned);
-                    break;
-                  }
-                  case 'hold':
-                    await handleHold(args || '');
-                    break;
-                  case 'unhold':
-                    await handleUnhold();
-                    break;
-                  default:
-                    core.warning(`Unknown command: /${cmd}`);
-                }
-              } catch (err) {
-                core.error(`Error handling /${cmd}: ${err.message}`);
-                await react('-1');
-                await reply(`❌ Error processing \`/${cmd}\`: ${err.message}`);
-              }
-            }
+          prow-commands: '/assign /unassign /approve /retitle /area /kind /priority /remove /lgtm /close /reopen /lock /milestone /hold /cc /uncc'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,189 @@
+name: PR Commands
+
+# Handle slash commands in PR comments:
+#   /cc @user [@user ...]  – request review from the mentioned user(s)
+#   /hold [reason]          – add do-not-merge/hold label
+#   /unhold                 – remove do-not-merge/hold label
+#
+# Only PR comments are processed; issue comments are ignored. Commands are
+# case-insensitive and must appear at the start of a line.
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write      # needed for adding/removing labels
+
+concurrency:
+  group: pr-commands-${{ github.event.issue_comment.id }}
+  cancel-in-progress: true
+
+jobs:
+  execute:
+    # Only run on PR comments (not plain issues) and skip bot comments.
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse and execute commands
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.issue.number;
+            const commentId = context.payload.comment.id;
+            const commentBody = context.payload.comment.body;
+            const commentUser = context.payload.comment.user.login;
+
+            // ── helpers ──────────────────────────────────────────────
+
+            /** React to the comment. */
+            async function react(reaction) {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: commentId, content: reaction,
+              });
+            }
+
+            /** Post a reply to the comment. */
+            async function reply(body) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }
+
+            /** Ensure a label exists (idempotent). */
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+            /** Parse @mentions from a string. Returns deduplicated usernames without @. */
+            function parseMentions(text) {
+              const matches = text.match(/@([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})/g);
+              if (!matches) return [];
+              return [...new Set(matches.map(m => m.slice(1)))];
+            }
+
+            // ── command parser ───────────────────────────────────────
+
+            /** Return all commands found in the comment, each with {cmd, args, line}. */
+            function parseCommands(body) {
+              const cmds = [];
+              const lines = body.split('\n');
+              for (const line of lines) {
+                const m = line.trim().match(/^\/(cc|hold|unhold)\b\s*(.*)/i);
+                if (m) {
+                  cmds.push({ cmd: m[1].toLowerCase(), args: m[2].trim(), line: line.trim() });
+                }
+              }
+              return cmds;
+            }
+
+            // ── command handlers ─────────────────────────────────────
+
+            async function handleCC(users) {
+              if (users.length === 0) {
+                await react('confused');
+                await reply(`@${commentUser} Usage: \`/cc @username [@username ...]\``);
+                return;
+              }
+
+              // Validate each user exists on GitHub.
+              const valid = [];
+              const invalid = [];
+              for (const u of users) {
+                try {
+                  await github.rest.users.getByUsername({ username: u });
+                  valid.push(u);
+                } catch (e) {
+                  if (e.status === 404) invalid.push(u);
+                  else throw e;
+                }
+              }
+
+              if (valid.length > 0) {
+                await github.rest.pulls.requestReviewers({
+                  owner, repo, pull_number: prNumber, reviewers: valid,
+                });
+              }
+
+              await react('+1');
+
+              const parts = [];
+              if (valid.length) parts.push(`✅ Requested review from ${valid.map(u => `@${u}`).join(', ')}.`);
+              if (invalid.length) parts.push(`⚠️ ${invalid.map(u => `@${u}`).join(', ')} — not a valid GitHub user.`);
+              await reply(parts.join('\n'));
+            }
+
+            async function handleHold(reason) {
+              await ensureLabel('do-not-merge/hold', 'D93F0B',
+                'This PR is on hold and should not be merged');
+
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: ['do-not-merge/hold'],
+              });
+
+              await react('+1');
+
+              const reasonText = reason ? `\n\n**Reason:** ${reason}` : '';
+              await reply(
+                `🔴 **Hold** requested by @${commentUser}. ` +
+                `This PR must not be merged until the hold is lifted.${reasonText}\n\n` +
+                `To lift the hold, comment \`/unhold\`.`
+              );
+            }
+
+            async function handleUnhold() {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: 'do-not-merge/hold',
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+
+              await react('+1');
+              await reply(`🟢 Hold lifted by @${commentUser}.`);
+            }
+
+            // ── main ─────────────────────────────────────────────────
+
+            const commands = parseCommands(commentBody);
+            if (commands.length === 0) {
+              core.info('No commands found in comment.');
+              return;
+            }
+
+            core.info(`Found ${commands.length} command(s): ${JSON.stringify(commands)}`);
+
+            for (const { cmd, args } of commands) {
+              try {
+                switch (cmd) {
+                  case 'cc': {
+                    const mentioned = parseMentions(args);
+                    await handleCC(mentioned);
+                    break;
+                  }
+                  case 'hold':
+                    await handleHold(args || '');
+                    break;
+                  case 'unhold':
+                    await handleUnhold();
+                    break;
+                  default:
+                    core.warning(`Unknown command: /${cmd}`);
+                }
+              } catch (err) {
+                core.error(`Error handling /${cmd}: ${err.message}`);
+                await react('-1');
+                await reply(`❌ Error processing \`/${cmd}\`: ${err.message}`);
+              }
+            }

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -5,7 +5,7 @@ name: PR Title Lint
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
     branches: [main]
 
 permissions:
@@ -16,13 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github/semantic.json
-          sparse-checkout-cone-mode: false
-
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -33,11 +33,11 @@ jobs:
             ci
             chore
             revert
-          # Require a scope (e.g. "feat(api): …").
+          # Scope is optional (e.g. "feat(api): …" or just "feat: …").
           requireScope: false
-          # Disallow uppercase-only subjects like "FIX BUG".
+          # Reject these scopes (e.g. block "feat(WIP): …").
           disallowScopes: |
             WIP
             wip
-          # Validate the subject line only (skip body).
+          # Lint the PR title only; don't also require a lone commit's message to match.
           validateSingleCommit: false

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,49 @@
+name: PR Title Lint
+
+# Enforce Conventional Commits format on PR titles.
+# See https://www.conventionalcommits.org/
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/semantic.json
+          sparse-checkout-cone-mode: false
+
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          # Allowed types (align with CONTRIBUTING.md).
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Require a scope (e.g. "feat(api): …").
+          requireScope: false
+          # Disallow uppercase-only subjects like "FIX BUG".
+          disallowScopes: |
+            WIP
+            wip
+          # Validate the subject line only (skip body).
+          validateSingleCommit: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           # ── PRs ──────────────────────────────────────────────────
           days-before-pr-stale: 21

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,70 @@
+name: Stale
+
+# Nudge and close abandoned PRs and issues.
+#
+# PRs:  warned after 21 days of inactivity, closed 7 days later.
+# Issues: warned after 90 days of inactivity, closed 30 days later.
+#
+# The stale label is applied on the first warning; it is removed if there is
+# any new activity. Labels and milestones are preserved on close.
+
+on:
+  schedule:
+    # Every day at 3:27 AM UTC (off-peak, avoids the :00 / :30 traffic spike).
+    - cron: '27 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # ── PRs ──────────────────────────────────────────────────
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          stale-pr-message: >
+            👋 This PR has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 7 days if no further activity occurs.
+
+
+            If you would like to keep it open, please comment or push new changes.
+            Thank you for your contribution!
+          close-pr-message: >
+            🔒 Closing this PR because it has been stale for 7 days with no activity.
+
+
+            Feel free to reopen if this is still relevant. Thanks!
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'do-not-merge/hold,superseded,security'
+
+          # ── Issues ───────────────────────────────────────────────
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-message: >
+            👋 This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 30 days if no further activity occurs.
+
+
+            If this is still relevant, please comment to keep it open.
+            Thank you!
+          close-issue-message: >
+            🔒 Closing this issue because it has been stale for 30 days with no activity.
+
+
+            Feel free to reopen if this is still relevant. Thanks!
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'good first issue,help wanted,security,bug'
+
+          # ── Housekeeping ─────────────────────────────────────────
+          # Operations-per-run limit protects against API abuse.
+          operations-per-run: 50
+          # Ascending order means oldest items are processed first.
+          ascending: true
+          # Remove the stale label when there is new activity.
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary

This PR adds CI workflows addressing the simple tasks from [#88](https://github.com/genai-io/san/issues/88).

---

### New workflows

#### 🤖 PR Commands ([pr-commands.yml](.github/workflows/pr-commands.yml))
Powered by [prow-github-actions](https://github.com/jpmcb/prow-github-actions), supports Prow-style slash commands on PR comments:

| Command | Action |
|---------|--------|
| `/cc @user` `/uncc @user` | Request / remove reviewers |
| `/approve` | Approve the PR |
| `/lgtm` | Looks good to me → auto squash-merge |
| `/hold` | Add `do-not-merge/hold` label to block merge |
| `/assign @user` `/unassign @user` | Assign / unassign users |
| `/retitle <title>` | Change PR title |
| `/area` `/kind` `/priority` | Apply category labels |
| `/close` `/reopen` `/lock` | Close / reopen / lock |

> ⚠️ **Known limitation**: `issue_comment` triggers only work after the workflow is merged to the default branch (main). The `/hold` `/cc` commands cannot be tested on this PR itself.

#### 🔀 Auto Merge ([auto-merge.yml](.github/workflows/auto-merge.yml))
Every 30 minutes, squash-merges PRs that have the `lgtm` label and pass all required checks.

#### 📝 PR Title Lint ([pr-title-lint.yml](.github/workflows/pr-title-lint.yml))
Enforces [Conventional Commits](https://www.conventionalcommits.org/) format on PR titles (`feat:`, `fix:`, `ci:`, `docs:`, `chore:`, etc.). Triggered on open, edit, reopen, and new pushes.

#### ✅ DCO Check ([dco.yml](.github/workflows/dco.yml))
Requires `Signed-off-by` trailer on every commit. Pattern copied from [open-cluster-management-io/ocm](https://github.com/open-cluster-management-io/ocm).

#### 🧹 Stale Bot ([stale.yml](.github/workflows/stale.yml))
- **PRs**: 21 days inactive → warning, 7 more days → auto-close
- **Issues**: 90 days inactive → warning, 30 more days → auto-close
- Exempts `do-not-merge/hold`, `security`, `good first issue`, `help wanted`, `bug` labels

#### 📦 Dependabot ([dependabot.yml](.github/dependabot.yml))
Weekly auto-updates for `github-actions` ecosystem.

---

### Updated workflows

#### 🔧 CI ([ci.yml](.github/workflows/ci.yml))
- Added `go test -race` for data race detection
- Enabled Go module caching (`cache: true` on `setup-go`)

---

### Why not Prow?

Repos like [stolostron/multicluster-global-hub](https://github.com/stolostron/multicluster-global-hub), [open-cluster-management-io/ocm](https://github.com/open-cluster-management-io/ocm), and [k3s-io/k3s](https://github.com/k3s-io/k3s) all use OpenShift Prow for `/cc` `/approve` `/lgtm` `/hold`. We don't have Prow, so we use `jpmcb/prow-github-actions@v2` to replicate the same chat-ops experience in pure GitHub Actions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)