### PR TITLE
feat: add Xiaomi MiMo LLM provider

### DIFF
--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/bigmodel"
 	_ "github.com/genai-io/san/internal/llm/deepseek"
 	_ "github.com/genai-io/san/internal/llm/google"
+	_ "github.com/genai-io/san/internal/llm/mimo"
 	_ "github.com/genai-io/san/internal/llm/minmax"
 	_ "github.com/genai-io/san/internal/llm/moonshot"
 	_ "github.com/genai-io/san/internal/llm/ollama"

--- a/docs/cn/providers.md
+++ b/docs/cn/providers.md
@@ -45,6 +45,7 @@ import (
     _ "github.com/genai-io/san/internal/llm/moonshot"
     _ "github.com/genai-io/san/internal/llm/alibaba"
     _ "github.com/genai-io/san/internal/llm/minmax"
+    _ "github.com/genai-io/san/internal/llm/mimo"
     _ "github.com/genai-io/san/internal/llm/bigmodel"
     _ "github.com/genai-io/san/internal/llm/deepseek"
 )
@@ -158,6 +159,18 @@ off → low → medium → high → maximum
 
 - **包**：[`internal/llm/minmax/`](../../internal/llm/minmax/)
 - **API 变量**：`MINIMAX_API_KEY`
+
+---
+
+### 6.5 MiMo（小米）
+
+- **包**：[`internal/llm/mimo/`](../../internal/llm/mimo/)
+- **API 变量**：`MIMO_API_KEY`（可选 `MIMO_BASE_URL`，默认 `https://api.xiaomimimo.com/anthropic`）
+- **支持模型**：MiMo V2.5 Pro、MiMo V2.5、MiMo V2 Pro、MiMo V2 Flash、MiMo V2 Omni
+- **特性**：
+  - 兼容 Anthropic API 格式（复用 anthropic provider 的流式逻辑）
+  - 模型列表通过平台 API 获取，失败时回退到静态目录
+  - 支持成本估算
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -41,6 +41,7 @@ for Anthropic). Supported providers and the env var each one reads:
 | Moonshot | `MOONSHOT_API_KEY` |
 | Alibaba | `DASHSCOPE_API_KEY` |
 | MiniMax | `MINIMAX_API_KEY` |
+| MiMo | `MIMO_API_KEY` |
 | Z.ai (GLM) | `BIGMODEL_API_KEY` |
 | DeepSeek | `DEEPSEEK_API_KEY` |
 

--- a/docs/packages/llm.md
+++ b/docs/packages/llm.md
@@ -61,7 +61,7 @@ func ResetDefaultConn()       // test-only
   `~/.san/providers.json`; tracks current model.
 - `stream/` — provider-side helpers for SSE parsing.
 - Provider subpackages: `anthropic/`, `openai/`, `google/`, `moonshot/`,
-  `alibaba/`, `bigmodel/`, `minmax/`, `deepseek/`, `ollama/`, `openaicompat/`.
+  `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `openaicompat/`.
 
 ## Lifecycle
 

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/llm/deepseek"
+	"github.com/genai-io/san/internal/llm/mimo"
 	"github.com/genai-io/san/internal/llm/minmax"
 	"github.com/genai-io/san/internal/log"
 )
@@ -60,6 +61,16 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 			}
 		case llm.DeepSeek:
 			cost, ok := deepseek.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
+				InputTokens:              resp.TokensIn,
+				OutputTokens:             resp.TokensOut,
+				CacheCreationInputTokens: resp.CacheCreateTokens,
+				CacheReadInputTokens:     resp.CacheReadTokens,
+			})
+			if ok {
+				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
+			}
+		case llm.Mimo:
+			cost, ok := mimo.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
 				InputTokens:              resp.TokensIn,
 				OutputTokens:             resp.TokensOut,
 				CacheCreationInputTokens: resp.CacheCreateTokens,

--- a/internal/llm/mimo/apikey.go
+++ b/internal/llm/mimo/apikey.go
@@ -1,0 +1,40 @@
+package mimo
+
+import (
+	"context"
+	"os"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+// APIKeyMeta is the metadata for Mimo via API Key
+var APIKeyMeta = llm.Meta{
+	Provider:    llm.Mimo,
+	AuthMethod:  llm.AuthAPIKey,
+	EnvVars:     []string{"MIMO_API_KEY"},
+	DisplayName: "Direct API",
+}
+
+// NewAPIKeyClient creates a new Mimo client using API Key authentication.
+// The Mimo API is Anthropic-compatible. Base URL is read from MIMO_BASE_URL.
+func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
+	baseURL := os.Getenv("MIMO_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.xiaomimimo.com/anthropic"
+	}
+
+	client := anthropicsdk.NewClient(
+		anthropicoption.WithAPIKey(secret.Resolve("MIMO_API_KEY")),
+		anthropicoption.WithBaseURL(baseURL),
+	)
+	return NewClient(client, "mimo:api_key"), nil
+}
+
+// init registers the API Key provider
+func init() {
+	llm.Register(APIKeyMeta, NewAPIKeyClient)
+}

--- a/internal/llm/mimo/catalog.go
+++ b/internal/llm/mimo/catalog.go
@@ -1,0 +1,98 @@
+package mimo
+
+import "github.com/genai-io/san/internal/llm"
+
+type pricing struct {
+	inputPerMTokens     float64
+	outputPerMTokens    float64
+	cacheReadPerMTokens float64
+}
+
+type modelCatalogEntry struct {
+	info    llm.ModelInfo
+	pricing pricing
+}
+
+var catalog = []modelCatalogEntry{
+	{
+		info: llm.ModelInfo{
+			ID:               "xiaomi/mimo-v2.5-pro",
+			Name:             "MiMo V2.5 Pro",
+			DisplayName:      "MiMo V2.5 Pro",
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 131072,
+		},
+		pricing: pricing{inputPerMTokens: 0.435, outputPerMTokens: 0.87, cacheReadPerMTokens: 0.0036},
+	},
+	{
+		info: llm.ModelInfo{
+			ID:               "xiaomi/mimo-v2.5",
+			Name:             "MiMo V2.5",
+			DisplayName:      "MiMo V2.5 (Multimodal)",
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 131072,
+		},
+		pricing: pricing{inputPerMTokens: 0.14, outputPerMTokens: 0.28, cacheReadPerMTokens: 0.0028},
+	},
+	{
+		info: llm.ModelInfo{
+			ID:               "xiaomi/mimo-v2-pro",
+			Name:             "MiMo V2 Pro",
+			DisplayName:      "MiMo V2 Pro",
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 131072,
+		},
+		pricing: pricing{inputPerMTokens: 1.0, outputPerMTokens: 3.0, cacheReadPerMTokens: 0.2},
+	},
+	{
+		info: llm.ModelInfo{
+			ID:               "xiaomi/mimo-v2-flash",
+			Name:             "MiMo V2 Flash",
+			DisplayName:      "MiMo V2 Flash",
+			InputTokenLimit:  262144,
+			OutputTokenLimit: 65536,
+		},
+		pricing: pricing{inputPerMTokens: 0.1, outputPerMTokens: 0.3, cacheReadPerMTokens: 0.01},
+	},
+	{
+		info: llm.ModelInfo{
+			ID:               "xiaomi/mimo-v2-omni",
+			Name:             "MiMo V2 Omni",
+			DisplayName:      "MiMo V2 Omni (Multimodal)",
+			InputTokenLimit:  262144,
+			OutputTokenLimit: 65536,
+		},
+		pricing: pricing{inputPerMTokens: 0.4, outputPerMTokens: 2.0, cacheReadPerMTokens: 0.08},
+	},
+}
+
+func StaticModels() []llm.ModelInfo {
+	models := make([]llm.ModelInfo, len(catalog))
+	for i, entry := range catalog {
+		models[i] = entry.info
+	}
+	return models
+}
+
+func CatalogModel(modelID string) (llm.ModelInfo, bool) {
+	for _, entry := range catalog {
+		if entry.info.ID == modelID {
+			return entry.info, true
+		}
+	}
+	return llm.ModelInfo{}, false
+}
+
+func EstimateCost(modelID string, usage llm.Usage) (llm.Money, bool) {
+	for _, entry := range catalog {
+		if entry.info.ID != modelID {
+			continue
+		}
+		const perMillion = 1_000_000.0
+		cost := (float64(usage.InputTokens) / perMillion) * entry.pricing.inputPerMTokens
+		cost += (float64(usage.OutputTokens) / perMillion) * entry.pricing.outputPerMTokens
+		cost += (float64(usage.CacheReadInputTokens) / perMillion) * entry.pricing.cacheReadPerMTokens
+		return llm.Money{Amount: cost, Currency: llm.CurrencyUSD}, true
+	}
+	return llm.Money{}, false
+}

--- a/internal/llm/mimo/client.go
+++ b/internal/llm/mimo/client.go
@@ -1,0 +1,99 @@
+// Package mimo implements the Provider interface using the Mimo API.
+// Mimo's API is Anthropic-compatible, so we delegate streaming to the
+// anthropic provider and only override ListModels for the platform API.
+package mimo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/genai-io/san/internal/llm"
+	anthropicprovider "github.com/genai-io/san/internal/llm/anthropic"
+	"github.com/genai-io/san/internal/secret"
+)
+
+const modelsURL = "https://platform.xiaomimimo.com/api/v1/models"
+
+var modelsClient = &http.Client{Timeout: 10 * time.Second}
+
+// Client implements the Provider interface for Mimo.
+// Streaming is delegated to the anthropic provider; ListModels uses the platform API.
+type Client struct {
+	inner *anthropicprovider.Client
+}
+
+// NewClient creates a new Mimo client wrapping an anthropic provider client.
+func NewClient(client anthropicsdk.Client, name string) *Client {
+	return &Client{inner: anthropicprovider.NewClient(client, name)}
+}
+
+// Name returns the provider name.
+func (c *Client) Name() string { return c.inner.Name() }
+
+// Stream delegates to the anthropic provider for full API compatibility.
+func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	return c.inner.Stream(ctx, opts)
+}
+
+// modelsResponse is the OpenRouter-style response from the Mimo models API.
+type modelsResponse struct {
+	Data []struct {
+		ID              string `json:"id"`
+		Name            string `json:"name"`
+		ContextLength   int    `json:"context_length"`
+		MaxOutputLength int    `json:"max_output_length"`
+	} `json:"data"`
+}
+
+// ListModels fetches available models from the Mimo platform API,
+// falling back to the static catalog on failure.
+func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", modelsURL, nil)
+	if err != nil {
+		return StaticModels(), nil
+	}
+	req.Header.Set("Authorization", "Bearer "+secret.Resolve("MIMO_API_KEY"))
+
+	resp, err := modelsClient.Do(req)
+	if err != nil {
+		return StaticModels(), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return StaticModels(), nil
+	}
+
+	var result modelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return StaticModels(), nil
+	}
+
+	models := make([]llm.ModelInfo, 0, len(result.Data))
+	for _, m := range result.Data {
+		if info, ok := CatalogModel(m.ID); ok {
+			models = append(models, info)
+			continue
+		}
+		models = append(models, llm.ModelInfo{
+			ID:               m.ID,
+			Name:             m.Name,
+			DisplayName:      m.Name,
+			InputTokenLimit:  m.ContextLength,
+			OutputTokenLimit: m.MaxOutputLength,
+		})
+	}
+
+	if len(models) == 0 {
+		return StaticModels(), nil
+	}
+
+	return models, nil
+}
+
+// Ensure Client implements Provider
+var _ llm.Provider = (*Client)(nil)

--- a/internal/llm/mimo/client_test.go
+++ b/internal/llm/mimo/client_test.go
@@ -1,0 +1,269 @@
+package mimo
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
+)
+
+// modelsTransport returns a mock models API response.
+type modelsTransport struct {
+	body string
+	code int
+}
+
+func (t *modelsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	code := t.code
+	if code == 0 {
+		code = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: code,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Request:    req,
+	}, nil
+}
+
+func withMockModelsClient(transport http.RoundTripper, fn func()) {
+	orig := modelsClient
+	modelsClient = &http.Client{Transport: transport}
+	defer func() { modelsClient = orig }()
+	fn()
+}
+
+func TestListModels_FromAPI(t *testing.T) {
+	body := `{"data":[
+		{"id":"xiaomi/mimo-v2.5-pro","name":"MiMo V2.5 Pro","context_length":1048576,"max_output_length":131072},
+		{"id":"xiaomi/mimo-v2-flash","name":"MiMo V2 Flash","context_length":262144,"max_output_length":65536}
+	]}`
+	withMockModelsClient(&modelsTransport{body: body}, func() {
+		c := NewClient(anthropicsdk.NewClient(), "mimo:test")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(models) != 2 {
+			t.Fatalf("expected 2 models, got %d", len(models))
+		}
+		if models[0].ID != "xiaomi/mimo-v2.5-pro" {
+			t.Errorf("expected first model xiaomi/mimo-v2.5-pro, got %s", models[0].ID)
+		}
+		if models[0].InputTokenLimit != 1048576 {
+			t.Errorf("expected input limit 1048576, got %d", models[0].InputTokenLimit)
+		}
+	})
+}
+
+func TestListModels_FallbackOnError(t *testing.T) {
+	withMockModelsClient(&modelsTransport{code: http.StatusUnauthorized}, func() {
+		c := NewClient(anthropicsdk.NewClient(), "mimo:test")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(models) == 0 {
+			t.Fatal("expected static fallback models, got 0")
+		}
+		found := false
+		for _, m := range models {
+			if m.ID == "xiaomi/mimo-v2.5-pro" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected xiaomi/mimo-v2.5-pro in fallback models")
+		}
+	})
+}
+
+func TestListModels_FallbackOnNetworkError(t *testing.T) {
+	withMockModelsClient(&modelsTransport{code: http.StatusInternalServerError}, func() {
+		c := NewClient(anthropicsdk.NewClient(), "mimo:test")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(models) != len(catalog) {
+			t.Fatalf("expected %d fallback models, got %d", len(catalog), len(models))
+		}
+	})
+}
+
+func TestListModels_CatalogLookup(t *testing.T) {
+	body := `{"data":[{"id":"xiaomi/mimo-v2.5-pro","name":"API Name","context_length":999,"max_output_length":999}]}`
+	withMockModelsClient(&modelsTransport{body: body}, func() {
+		c := NewClient(anthropicsdk.NewClient(), "mimo:test")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(models) != 1 {
+			t.Fatalf("expected 1 model, got %d", len(models))
+		}
+		if models[0].InputTokenLimit != 1048576 {
+			t.Errorf("expected catalog input limit 1048576, got %d", models[0].InputTokenLimit)
+		}
+		if models[0].DisplayName != "MiMo V2.5 Pro" {
+			t.Errorf("expected catalog display name 'MiMo V2.5 Pro', got %s", models[0].DisplayName)
+		}
+	})
+}
+
+func TestEstimateCost(t *testing.T) {
+	cost, ok := EstimateCost("xiaomi/mimo-v2.5-pro", llm.Usage{
+		InputTokens:  1000000,
+		OutputTokens: 1000000,
+	})
+	if !ok {
+		t.Fatal("expected pricing lookup to succeed")
+	}
+	if cost.Amount < 1.304 || cost.Amount > 1.306 {
+		t.Fatalf("expected ~1.305, got %.6f", cost.Amount)
+	}
+	if cost.Currency != llm.CurrencyUSD {
+		t.Fatalf("expected USD, got %s", cost.Currency)
+	}
+}
+
+func TestEstimateCost_UnknownModel(t *testing.T) {
+	_, ok := EstimateCost("unknown-model", llm.Usage{InputTokens: 1000, OutputTokens: 1000})
+	if ok {
+		t.Fatal("expected false for unknown model")
+	}
+}
+
+func TestStaticModels(t *testing.T) {
+	models := StaticModels()
+	if len(models) != len(catalog) {
+		t.Fatalf("expected %d static models, got %d", len(catalog), len(models))
+	}
+}
+
+func TestCatalogModel(t *testing.T) {
+	info, ok := CatalogModel("xiaomi/mimo-v2.5-pro")
+	if !ok {
+		t.Fatal("expected to find xiaomi/mimo-v2.5-pro in catalog")
+	}
+	if info.InputTokenLimit != 1048576 {
+		t.Errorf("expected 1048576, got %d", info.InputTokenLimit)
+	}
+}
+
+func TestCatalogModel_NotFound(t *testing.T) {
+	_, ok := CatalogModel("nonexistent")
+	if ok {
+		t.Fatal("expected false for nonexistent model")
+	}
+}
+
+// captureStreamTransport captures the request body and returns a minimal SSE stream.
+type captureStreamTransport struct {
+	body []byte
+}
+
+func (t *captureStreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		t.body = b
+	}
+
+	streamBody := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"xiaomi/mimo-v2.5-pro","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(streamBody)),
+		Request:    req,
+	}, nil
+}
+
+func TestStreamSendsRequest(t *testing.T) {
+	transport := &captureStreamTransport{}
+	client := anthropicsdk.NewClient(
+		anthropicoption.WithAPIKey("test"),
+		anthropicoption.WithBaseURL("https://example.com"),
+		anthropicoption.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+
+	c := NewClient(client, "mimo:test")
+	ch := c.Stream(context.Background(), llm.CompletionOptions{
+		Model:    "xiaomi/mimo-v2.5-pro",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	for range ch {
+	}
+
+	if len(transport.body) == 0 {
+		t.Fatal("no request body captured")
+	}
+	if !strings.Contains(string(transport.body), "xiaomi/mimo-v2.5-pro") {
+		t.Errorf("expected model in request body, got: %s", string(transport.body))
+	}
+}
+
+func TestStreamReceivesText(t *testing.T) {
+	transport := &captureStreamTransport{}
+	client := anthropicsdk.NewClient(
+		anthropicoption.WithAPIKey("test"),
+		anthropicoption.WithBaseURL("https://example.com"),
+		anthropicoption.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+
+	c := NewClient(client, "mimo:test")
+	ch := c.Stream(context.Background(), llm.CompletionOptions{
+		Model:    "xiaomi/mimo-v2.5-pro",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+
+	var textChunks []string
+	var done *llm.CompletionResponse
+	for chunk := range ch {
+		switch chunk.Type {
+		case llm.ChunkTypeText:
+			textChunks = append(textChunks, chunk.Text)
+		case llm.ChunkTypeDone:
+			done = chunk.Response
+		}
+	}
+
+	if len(textChunks) == 0 {
+		t.Fatal("expected text chunks")
+	}
+	if textChunks[0] != "hello" {
+		t.Errorf("expected 'hello', got %q", textChunks[0])
+	}
+	if done == nil {
+		t.Fatal("expected done chunk")
+	}
+	if done.StopReason != "end_turn" {
+		t.Errorf("expected stop_reason 'end_turn', got %q", done.StopReason)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -21,6 +21,7 @@ const (
 	BigModel  Name = "bigmodel"
 	DeepSeek  Name = "deepseek"
 	Ollama    Name = "ollama"
+	Mimo      Name = "mimo"
 )
 
 // AuthMethod represents an authentication method for an LLM provider.


### PR DESCRIPTION
## What & why

Add Xiaomi MiMo as a new LLM provider. MiMo offers an Anthropic-compatible API with 5 models ranging from 262K to 1M context windows. The provider fetches model metadata from the platform API with automatic fallback to a static catalog.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

Unit tests cover model listing (API + fallback), cost estimation, catalog lookup, and streaming.

```bash
go test -v ./internal/llm/mimo/
```

## Checklist

- [x] Follows Conventional Commits (`feat:`)
- [x] Tests pass locally
- [x] Docs updated (if behavior or config changed)
- [ ] Read and follow the Code of Conduct