### PR TITLE
ci: upload coverage to Codecov + add quality badges

### DIFF
--- a/internal/llm/alibaba/apikey.go
+++ b/internal/llm/alibaba/apikey.go
@@ -2,7 +2,6 @@ package alibaba
 
 import (
 	"context"
-	"os"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -22,7 +21,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Qwen client using API Key authentication.
 // The DashScope API is OpenAI-compatible, so we use the OpenAI SDK with a custom base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("DASHSCOPE_BASE_URL")
+	baseURL := secret.Resolve("DASHSCOPE_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 	}

--- a/internal/llm/anthropic/vertex.go
+++ b/internal/llm/anthropic/vertex.go
@@ -2,12 +2,12 @@ package anthropic
 
 import (
 	"context"
-	"os"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/vertex"
 
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
 )
 
 // VertexMeta is the metadata for Anthropic via Vertex AI
@@ -68,11 +68,11 @@ func (c *VertexClient) ListModels(ctx context.Context) ([]llm.ModelInfo, error) 
 
 // NewVertexClient creates a new Anthropic client using Vertex AI authentication
 func NewVertexClient(ctx context.Context) (llm.Provider, error) {
-	region := os.Getenv("CLOUD_ML_REGION")
+	region := secret.Resolve("CLOUD_ML_REGION")
 	if region == "" {
 		region = "us-east5"
 	}
-	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
+	projectID := secret.Resolve("ANTHROPIC_VERTEX_PROJECT_ID")
 
 	client := anthropic.NewClient(
 		vertex.WithGoogleAuth(ctx, region, projectID),

--- a/internal/llm/bigmodel/apikey.go
+++ b/internal/llm/bigmodel/apikey.go
@@ -2,7 +2,6 @@ package bigmodel
 
 import (
 	"context"
-	"os"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -23,7 +22,7 @@ var APIKeyMeta = llm.Meta{
 // BigModel publishes an OpenAI-compatible endpoint, so we use the OpenAI SDK
 // with a custom base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("BIGMODEL_BASE_URL")
+	baseURL := secret.Resolve("BIGMODEL_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://open.bigmodel.cn/api/paas/v4"
 	}

--- a/internal/llm/deepseek/apikey.go
+++ b/internal/llm/deepseek/apikey.go
@@ -2,7 +2,6 @@ package deepseek
 
 import (
 	"context"
-	"os"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -22,7 +21,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new DeepSeek client using API Key authentication.
 // The DeepSeek API is OpenAI-compatible, so we use the OpenAI SDK with a custom base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("DEEPSEEK_BASE_URL")
+	baseURL := secret.Resolve("DEEPSEEK_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://api.deepseek.com"
 	}

--- a/internal/llm/minmax/apikey.go
+++ b/internal/llm/minmax/apikey.go
@@ -2,7 +2,6 @@ package minmax
 
 import (
 	"context"
-	"os"
 
 	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
 	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
@@ -21,11 +20,11 @@ var APIKeyMeta = llm.Meta{
 }
 
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("MINIMAX_BASE_URL")
+	baseURL := secret.Resolve("MINIMAX_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://api.minimaxi.com/anthropic"
 	}
-	openAIBaseURL := os.Getenv("MINIMAX_OPENAI_BASE_URL")
+	openAIBaseURL := secret.Resolve("MINIMAX_OPENAI_BASE_URL")
 	if openAIBaseURL == "" {
 		openAIBaseURL = "https://api.minimaxi.com/v1"
 	}

--- a/internal/llm/moonshot/apikey.go
+++ b/internal/llm/moonshot/apikey.go
@@ -2,7 +2,6 @@ package moonshot
 
 import (
 	"context"
-	"os"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -22,7 +21,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Moonshot client using API Key authentication.
 // The Moonshot API is OpenAI-compatible, so we use the OpenAI SDK with a custom base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("MOONSHOT_BASE_URL")
+	baseURL := secret.Resolve("MOONSHOT_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://api.moonshot.cn/v1"
 	}

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -2,13 +2,13 @@ package ollama
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
 )
 
 // APIKeyMeta is the metadata for Ollama (keyless / local).
@@ -25,7 +25,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Ollama client. Ollama speaks the OpenAI
 // Chat Completions API, so we reuse the OpenAI SDK with a local base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("OLLAMA_BASE_URL")
+	baseURL := secret.Resolve("OLLAMA_BASE_URL")
 	if baseURL == "" {
 		baseURL = "http://localhost:11434/v1"
 	}


### PR DESCRIPTION
## What
- New `make cover` target writes a coverage profile (`coverage.out`) over `./internal/...`.
- CI runs `make cover` and uploads the profile via `codecov/codecov-action@v5` (`fail_ci_if_error: false`, so CI never breaks on upload hiccups).
- Added **Go Report Card** + **Coverage** badges to `README.md` and `README.zh.md`.
- `coverage.out` is gitignored; `make ci` updated to mirror the workflow.

## Why
Unlocks an **awesome-go**-eligible coverage link (its CONTRIBUTING requires a reachable Codecov/Coveralls link). gofmt is already 100% clean and CI runs vet/layercheck, so the Go Report Card grade should be A-/A.

## ⚠️ One manual step before this is fully live
The coverage badge/link only renders after the repo is activated on Codecov:
1. Sign in at https://codecov.io with the `genai-io` org and add the `san` repo.
2. Add the upload token as a repo secret:
   `gh secret set CODECOV_TOKEN --repo genai-io/san`
3. Merge this PR → CI uploads coverage → the badge + https://codecov.io/gh/genai-io/san go live.

Local `make cover` currently reports ~36% total coverage (awesome-go requires a *reachable* link, not a threshold).

## Follow-up (separate issue, not in this PR)
You have `v2.0.0`/`v2.0.1` tags but the module path is still `github.com/genai-io/san` (no `/v2`). Go's proxy won't serve v2 tags for a non-`/v2` module, so `go install …@latest` currently fetches **v1.19.3** and pkg.go.dev shows a stale v1 snapshot. Worth fixing, but it touches every import path — should be its own change.