### PR TITLE
fix: disable cgo for static builds to support older glibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ BINDIR := bin
 SRCDIR := ./cmd/san
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
+
+# Disable cgo so binaries are statically linked, with no glibc version
+# dependency that would break on older distros.
+export CGO_ENABLED := 0
 GOFILES := $(shell find . -path './vendor' -prune -o -path './.git' -prune -o -name '*.go' -print)
 GOIMPORTS_VERSION := v0.43.0
 


### PR DESCRIPTION
## Problem

The released `linux/amd64` binary fails on older distros like Ubuntu 20.04:

```
san: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by san)
```

## Cause

The `linux/amd64` build runs natively on CI with cgo enabled by default, so it dynamically links the runner's newer glibc.

## Fix

The project uses no cgo, so set `CGO_ENABLED=0` for fully static binaries with no glibc dependency.

Fixes #102