### PR TITLE
chore: display the timestamps in a better format

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -90,7 +90,7 @@ func Init() error {
 		MessageKey:     "M",
 		StacktraceKey:  "",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeTime:     zapcore.TimeEncoderOfLayout("15:04:05"),
+		EncodeTime:     zapcore.RFC3339TimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
 	}
 


### PR DESCRIPTION
Set the time of log file to an RFC3339-formatted string.

Timestamps in the current debug logs only contain hours, minutes, and seconds:
```
$ cat ~/.san/debug.log 
20:12:26	Debug logging started
```
add the date for better differentiation.
