### PR TITLE
fix(ci): use pull_request_target for safe workflows to bypass fork-approval gate

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,7 @@ name: DCO
 
 on:
   workflow_dispatch: {}
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -4,7 +4,7 @@ name: PR Title Lint
 # See https://www.conventionalcommits.org/
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
     branches: [main]
 


### PR DESCRIPTION
## Problem

All CI workflows on fork PRs require manual approval before running. This is because:
1. The repo is public and all PRs come from external contributors' forks
2. The repository setting "Fork pull request workflows from outside collaborators" is set to "Require approval for all outside collaborators"

## Fix

### Workflow changes (this PR)

- **[dco.yml](.github/workflows/dco.yml)**: Changed `pull_request` → `pull_request_target`. Safe because the DCO action only reads commit metadata via the GitHub API — it never checks out or executes PR code.
- **[pr-title-lint.yml](.github/workflows/pr-title-lint.yml)**: Changed `pull_request` → `pull_request_target`. Safe because the semantic PR title action only reads the PR title.

These two workflows will now run automatically without requiring approval. `pull_request_target` runs in the trusted base-repo context, bypassing the fork-approval gate.

### Repository settings change (needs admin, manual)

**ci.yml** intentionally stays on `pull_request` because it checks out and runs PR code (build, test, lint). For this workflow to run without approval, a repo admin needs to:

1. Go to **Settings → Actions → General**
2. Change "Fork pull request workflows from outside collaborators" from **"Require approval for all outside collaborators"** to **"Require approval for first-time contributors only"**

This way, repeat contributors won't need re-approval for every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)