### PR TITLE
fix: need to update provider base URL for ollama

### DIFF
--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -36,6 +36,11 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 		baseURL += "/v1"
 	}
 
+	// Update the secrets file
+	if store := secret.Default(); store != nil {
+		_ = store.Set("OLLAMA_BASE_URL", baseURL)
+	}
+
 	// Ollama ignores the Authorization header; "ollama" is a placeholder.
 	client := openai.NewClient(
 		option.WithAPIKey("ollama"),

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -2,6 +2,7 @@ package ollama
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -25,7 +26,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Ollama client. Ollama speaks the OpenAI
 // Chat Completions API, so we reuse the OpenAI SDK with a local base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := secret.ResolveOsEnv("OLLAMA_BASE_URL")
+	baseURL := os.Getenv("OLLAMA_BASE_URL")
 	if store := secret.Default(); store != nil {
 		storedURL := store.Get("OLLAMA_BASE_URL")
 		if baseURL != "" {

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -25,7 +25,20 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Ollama client. Ollama speaks the OpenAI
 // Chat Completions API, so we reuse the OpenAI SDK with a local base URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := secret.Resolve("OLLAMA_BASE_URL")
+	baseURL := secret.ResolveOsEnv("OLLAMA_BASE_URL")
+	if store := secret.Default(); store != nil {
+		storedURL := store.Get("OLLAMA_BASE_URL")
+		if baseURL != "" {
+			if baseURL != storedURL {
+				// Update the value in secrets file with OsEnv's
+				_ = store.Set("OLLAMA_BASE_URL", baseURL)
+			}
+		} else if storedURL != "" {
+			// Use the stored URL
+			baseURL = storedURL
+		}
+	}
+	// If not set, fall back to the default
 	if baseURL == "" {
 		baseURL = "http://localhost:11434/v1"
 	}
@@ -35,12 +48,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	if !strings.HasSuffix(baseURL, "/v1") {
 		baseURL += "/v1"
 	}
-
-	// Update the secrets file
-	if store := secret.Default(); store != nil {
-		_ = store.Set("OLLAMA_BASE_URL", baseURL)
-	}
-
 	// Ollama ignores the Authorization header; "ollama" is a placeholder.
 	client := openai.NewClient(
 		option.WithAPIKey("ollama"),

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -109,11 +109,3 @@ func Resolve(envVar string) string {
 	}
 	return ""
 }
-
-// As a wrapper to merely read the values of environment variables.
-func ResolveOsEnv(envVar string) string {
-	if v := os.Getenv(envVar); v != "" {
-		return v
-	}
-	return ""
-}

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -109,3 +109,11 @@ func Resolve(envVar string) string {
 	}
 	return ""
 }
+
+// As a wrapper to merely read the values of environment variables.
+func ResolveOsEnv(envVar string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return ""
+}


### PR DESCRIPTION
In issue #105, we will be reading the value of OLLAMA_BASE_URL from secrets.json; however, we could potentially update the currently used value back into this file to ensure it can be re-read if the environment variable is missing next time.
