### PR TITLE
refactor(input): unify selector list-filter method to updateFilter

### DIFF
--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -126,7 +126,7 @@ func (s *AgentSelector) EnterSelect(width, height int) error {
 	s.height = height
 	s.nav.Reset()
 	s.activeTab = s.firstNonEmptyTab()
-	s.applyFilters()
+	s.updateFilter()
 	return nil
 }
 
@@ -197,8 +197,8 @@ func (s *AgentSelector) firstNonEmptyTab() agentTab {
 	return agentTabProject
 }
 
-// applyFilters rebuilds filteredAgents from the active tab + search query.
-func (s *AgentSelector) applyFilters() {
+// updateFilter rebuilds filteredAgents from the active tab + search query.
+func (s *AgentSelector) updateFilter() {
 	query := strings.ToLower(s.nav.Search)
 	s.filteredAgents = s.filteredAgents[:0]
 	for _, a := range s.agents {
@@ -253,7 +253,7 @@ func (s *AgentSelector) cycleTab(delta int) {
 	n := len(tabs)
 	next := tabs[((idx+delta)%n+n)%n]
 	s.activeTab = next
-	s.applyFilters()
+	s.updateFilter()
 }
 
 func (s *AgentSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
@@ -269,7 +269,7 @@ func (s *AgentSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 	}
 	searchChanged, consumed := s.nav.HandleKey(key)
 	if searchChanged {
-		s.applyFilters()
+		s.updateFilter()
 	}
 	if consumed {
 		return nil

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -987,7 +987,7 @@ func (s *ProviderSelector) rebuildVisibleItems() {
 
 // rebuildModelsTab builds visible items for the Models tab.
 func (s *ProviderSelector) rebuildModelsTab() {
-	s.applyFilter()
+	s.updateFilter()
 
 	// Group filtered models by provider
 	providerModels := make(map[string][]providerModelItem)
@@ -1057,7 +1057,7 @@ func (s *ProviderSelector) rebuildProvidersTab() {
 	}
 }
 
-func (s *ProviderSelector) applyFilter() {
+func (s *ProviderSelector) updateFilter() {
 	if s.searchQuery == "" {
 		s.filteredModels = s.allModels
 		return

--- a/internal/app/input/on_skill.go
+++ b/internal/app/input/on_skill.go
@@ -153,7 +153,7 @@ func (s *SkillSelector) EnterSelect(width, height int) error {
 	s.height = height
 	s.nav.Reset()
 	s.activeTab = s.firstNonEmptyTab()
-	s.applyFilters()
+	s.updateFilter()
 	return nil
 }
 
@@ -212,8 +212,8 @@ func (s *SkillSelector) Cancel() {
 	s.nav.Total = 0
 }
 
-// applyFilters rebuilds filteredSkills from the active tab + search query.
-func (s *SkillSelector) applyFilters() {
+// updateFilter rebuilds filteredSkills from the active tab + search query.
+func (s *SkillSelector) updateFilter() {
 	query := strings.ToLower(s.nav.Search)
 	s.filteredSkills = s.filteredSkills[:0]
 	for _, sk := range s.skills {
@@ -248,7 +248,7 @@ func (s *SkillSelector) cycleTab(delta int) {
 	n := len(tabs)
 	next := tabs[((idx+delta)%n+n)%n]
 	s.activeTab = next
-	s.applyFilters()
+	s.updateFilter()
 }
 
 func (s *SkillSelector) CycleState() tea.Cmd {
@@ -295,7 +295,7 @@ func (s *SkillSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 
 	searchChanged, consumed := s.nav.HandleKey(key)
 	if searchChanged {
-		s.applyFilters()
+		s.updateFilter()
 	}
 	if consumed {
 		return nil


### PR DESCRIPTION
## What

Seven overlay selectors implemented the same "recompute the filtered list from the active tab + search query" operation under three different names:

- `applyFilters` (agent, skill)
- `applyFilter` (provider)
- `updateFilter` (mcp, plugin, session, tool)

Grepping one name silently missed half the implementations.

## Change

Rename `applyFilters` / `applyFilter` → `updateFilter` so the shared concept has one predictable name across the package. Pure rename, no behavior change.

## Test

`go build ./...`, `go vet`, the `internal/app/input` package tests, and `tools/layercheck` all pass.