### PR TITLE
refactor(plugin): move install + marketplace-sync orchestration into internal/plugin

### DIFF
--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -284,20 +284,10 @@ func pluginInstallCmd(reg *coreplugin.Registry, cwd string, msg PluginInstallMsg
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		installer := coreplugin.NewInstaller(reg, cwd)
-		if err := installer.LoadMarketplaces(); err != nil {
+		ref := coreplugin.FormatPluginRef(msg.PluginName, msg.Marketplace)
+		if err := coreplugin.Install(ctx, reg, cwd, ref, msg.Scope); err != nil {
 			return PluginInstallResultMsg{PluginName: msg.PluginName, Success: false, Error: err}
 		}
-
-		pluginRef := msg.PluginName
-		if msg.Marketplace != "" {
-			pluginRef = msg.PluginName + "@" + msg.Marketplace
-		}
-
-		if err := installer.Install(ctx, pluginRef, msg.Scope); err != nil {
-			return PluginInstallResultMsg{PluginName: msg.PluginName, Success: false, Error: err}
-		}
-
 		return PluginInstallResultMsg{PluginName: msg.PluginName, Success: true}
 	}
 }

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -851,7 +851,7 @@ func (s *PluginSelector) syncMarketplace(id string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		if err := s.marketplaceManager.Sync(ctx, id); err != nil {
+		if err := s.marketplaceManager.SyncOrPrune(ctx, id); err != nil {
 			return PluginMarketplaceSyncResultMsg{ID: id, Success: false, Error: err}
 		}
 		return PluginMarketplaceSyncResultMsg{ID: id, Success: true}
@@ -923,12 +923,9 @@ func (s *PluginSelector) HandleMarketplaceSync(msg PluginMarketplaceSyncResultMs
 	s.isLoading = false
 	s.loadingMsg = ""
 	if !msg.Success {
+		// A broken GitHub source is pruned inside SyncOrPrune; here we just
+		// surface the failure and let the refresh reflect any pruning.
 		s.setError(fmt.Sprintf("Failed to sync %s: %v", msg.ID, msg.Error))
-		if entry, ok := s.marketplaceManager.Get(msg.ID); ok && entry.Source.Source == "github" {
-			if _, err := os.Stat(entry.InstallLocation); os.IsNotExist(err) {
-				_ = s.marketplaceManager.Remove(msg.ID)
-			}
-		}
 	} else {
 		s.setSuccess(fmt.Sprintf("Synced %s", msg.ID))
 	}

--- a/internal/app/input/on_plugin_command.go
+++ b/internal/app/input/on_plugin_command.go
@@ -256,13 +256,8 @@ func pluginHandleInstall(reg *coreplugin.Registry, ctx context.Context, cwd stri
 		}
 	}
 
-	installer := coreplugin.NewInstaller(reg, cwd)
-	if err := installer.LoadMarketplaces(); err != nil {
-		return fmt.Sprintf("Failed to load marketplaces: %v", err), nil
-	}
-
 	ref := args[0]
-	if err := installer.Install(ctx, ref, scope); err != nil {
+	if err := coreplugin.Install(ctx, reg, cwd, ref, scope); err != nil {
 		return fmt.Sprintf("Failed to install plugin '%s': %v", ref, err), nil
 	}
 

--- a/internal/app/input/on_plugin_command.go
+++ b/internal/app/input/on_plugin_command.go
@@ -414,7 +414,7 @@ func pluginHandleMarketplaceSync(ctx context.Context, cwd string, args []string)
 		return strings.TrimRight(sb.String(), "\n"), nil
 	}
 
-	if err := manager.Sync(ctx, target); err != nil {
+	if err := manager.SyncOrPrune(ctx, target); err != nil {
 		return fmt.Sprintf("Failed to sync marketplace '%s': %v", target, err), nil
 	}
 	return fmt.Sprintf("Synced marketplace '%s'.", target), nil

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -110,6 +110,28 @@ func ParsePluginRef(ref string) (name, marketplace string) {
 	return name, marketplace
 }
 
+// FormatPluginRef builds a plugin reference from a name and optional
+// marketplace. It is the inverse of ParsePluginRef: an empty marketplace
+// yields just the name, otherwise "name@marketplace".
+func FormatPluginRef(name, marketplace string) string {
+	if marketplace == "" {
+		return name
+	}
+	return name + "@" + marketplace
+}
+
+// Install wires a fresh installer to reg/cwd, loads known marketplaces, and
+// installs the plugin referenced by ref ("name@marketplace" or "name") into
+// scope. It bundles the marketplace-load step every caller needs so call sites
+// don't repeat the sequence; cancellation and timeout are the caller's via ctx.
+func Install(ctx context.Context, reg *Registry, cwd, ref string, scope Scope) error {
+	installer := NewInstaller(reg, cwd)
+	if err := installer.LoadMarketplaces(); err != nil {
+		return fmt.Errorf("load marketplaces: %w", err)
+	}
+	return installer.Install(ctx, ref, scope)
+}
+
 // Install installs a plugin from a reference.
 // Reference format: "plugin-name@marketplace" or "plugin-name" (uses default)
 func (i *Installer) Install(ctx context.Context, ref string, scope Scope) error {

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -261,6 +261,27 @@ func (m *MarketplaceManager) syncGitHub(ctx context.Context, id string, entry Ma
 	return m.Save()
 }
 
+// SyncOrPrune syncs the marketplace and self-heals a broken GitHub source: if
+// the sync fails and the marketplace's local clone no longer exists on disk,
+// the now-unusable entry is removed. It returns the sync error (if any)
+// regardless of whether a prune happened, so callers still surface the failure.
+// Pruning is best-effort; a failure to remove is ignored.
+//
+// Bulk SyncAll and install-time syncs intentionally stay on plain Sync — they
+// should not silently remove marketplaces out from under a wider operation.
+func (m *MarketplaceManager) SyncOrPrune(ctx context.Context, id string) error {
+	err := m.Sync(ctx, id)
+	if err == nil {
+		return nil
+	}
+	if entry, ok := m.Get(id); ok && entry.Source.Source == "github" {
+		if _, statErr := os.Stat(entry.InstallLocation); os.IsNotExist(statErr) {
+			_ = m.Remove(id)
+		}
+	}
+	return err
+}
+
 // SyncAll synchronizes all marketplaces.
 func (m *MarketplaceManager) SyncAll(ctx context.Context) []error {
 	var errors []error

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -480,6 +480,52 @@ func TestInstall_LoadsMarketplacesAndInstalls(t *testing.T) {
 	}
 }
 
+func TestSyncOrPrune(t *testing.T) {
+	t.Run("prunes a broken github source when the local clone is gone", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		m := NewMarketplaceManager(tmp)
+
+		if err := m.Add("ghost", MarketplaceEntry{
+			Source:          MarketplaceSourceInfo{Source: "github", Repo: "owner/repo"},
+			InstallLocation: filepath.Join(tmp, "ghost-clone"), // never created
+		}); err != nil {
+			t.Fatalf("Add() error: %v", err)
+		}
+
+		// A pre-cancelled context makes the git clone fail immediately with no
+		// network access, so the sync-failure path is deterministic.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if err := m.SyncOrPrune(ctx, "ghost"); err == nil {
+			t.Fatal("expected sync to fail")
+		}
+		if _, ok := m.Get("ghost"); ok {
+			t.Fatal("expected the broken github marketplace to be pruned")
+		}
+	})
+
+	t.Run("does not prune a non-github source on sync failure", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		m := NewMarketplaceManager(tmp)
+
+		if err := m.Add("weird", MarketplaceEntry{
+			Source: MarketplaceSourceInfo{Source: "mystery"},
+		}); err != nil {
+			t.Fatalf("Add() error: %v", err)
+		}
+
+		if err := m.SyncOrPrune(context.Background(), "weird"); err == nil {
+			t.Fatal("expected an unsupported-source error")
+		}
+		if _, ok := m.Get("weird"); !ok {
+			t.Fatal("a non-github marketplace must not be pruned")
+		}
+	})
+}
+
 func TestRegistry_LoadScopeMergePrefersLocalOverProjectOverUser(t *testing.T) {
 	tmpHome := t.TempDir()
 	cwd := t.TempDir()

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -432,6 +432,54 @@ func TestInstaller_InstallAndUninstall_FromMarketplaceDirectory(t *testing.T) {
 	}
 }
 
+func TestFormatPluginRef(t *testing.T) {
+	if got := FormatPluginRef("git", "my-market"); got != "git@my-market" {
+		t.Fatalf("FormatPluginRef with marketplace = %q, want git@my-market", got)
+	}
+	if got := FormatPluginRef("git", ""); got != "git" {
+		t.Fatalf("FormatPluginRef without marketplace = %q, want git", got)
+	}
+	// Round-trips with ParsePluginRef.
+	if name, market := ParsePluginRef(FormatPluginRef("deploy", "local-market")); name != "deploy" || market != "local-market" {
+		t.Fatalf("round-trip = (%q, %q), want (deploy, local-market)", name, market)
+	}
+}
+
+// TestInstall_LoadsMarketplacesAndInstalls covers the package-level Install
+// helper, which both the plugin overlay and the /plugin install command call.
+// It must load known marketplaces itself before installing.
+func TestInstall_LoadsMarketplacesAndInstalls(t *testing.T) {
+	tmpHome := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	marketRoot := filepath.Join(t.TempDir(), "market")
+	pluginRoot := filepath.Join(marketRoot, "deploy")
+	writeTestPlugin(t, pluginRoot, "deploy", "1.2.3", "Deploy plugin", map[string]string{
+		"skills/deploy/SKILL.md": "---\nname: deploy\ndescription: Deploy skill\n---\nship it\n",
+	})
+
+	// Persist the marketplace to disk so the installer that Install() builds
+	// internally rediscovers it through LoadMarketplaces.
+	mgr := NewMarketplaceManager(cwd)
+	if err := mgr.AddDirectory("local-market", marketRoot); err != nil {
+		t.Fatalf("AddDirectory() error: %v", err)
+	}
+
+	registry := NewRegistry()
+	if err := Install(context.Background(), registry, cwd, "deploy@local-market", ScopeProject); err != nil {
+		t.Fatalf("Install() error: %v", err)
+	}
+
+	installPath := filepath.Join(cwd, ".san", "plugins", "deploy")
+	if _, err := os.Stat(installPath); err != nil {
+		t.Fatalf("expected installed plugin dir: %v", err)
+	}
+	if _, ok := registry.Get("deploy@local-market"); !ok {
+		t.Fatal("expected installed plugin registered")
+	}
+}
+
 func TestRegistry_LoadScopeMergePrefersLocalOverProjectOverUser(t *testing.T) {
 	tmpHome := t.TempDir()
 	cwd := t.TempDir()


### PR DESCRIPTION
Moves plugin install / marketplace **orchestration** out of the `internal/app/input` UI layer and into the `internal/plugin` feature package, per the "Keep internal/app as composition, not feature behavior" principle. Two commits.

## 1. `plugin.Install` entry point + install dedup

The plugin overlay (`pluginInstallCmd`) and the `/plugin install` slash command each independently did `NewInstaller` + `LoadMarketplaces` + `Install` — the same sequence in two places, with the marketplace-load step being feature orchestration living in the UI.

Adds package-level `plugin.Install(ctx, reg, cwd, ref, scope)` (plus `FormatPluginRef`, the inverse of `ParsePluginRef`); both call sites delegate to it. Install timeouts stay at the call sites via the passed `ctx`.

## 2. Marketplace sync self-heal → `SyncOrPrune`

The overlay's sync result handler carried a business rule: when a github-sourced marketplace fails to sync and its local clone is gone from disk, remove the now-unusable entry. That self-heal lived in the UI and only ran for the overlay.

Moves it into `MarketplaceManager.SyncOrPrune`; both the overlay and `/plugin marketplace sync <id>` now route through it. Bulk `SyncAll` and the install-time sync intentionally stay on plain `Sync` — they should not silently remove marketplaces out from under a wider operation.

## Behavior changes

- On the rare marketplace-load failure, the slash install error now reads `Failed to install plugin 'x': load marketplaces: ...` (folds the load step into the single install error path — more informative).
- `/plugin marketplace sync <id>` now prunes a broken github marketplace on failure, matching the overlay.

## Test

Adds deterministic, offline unit tests for `Install`, `FormatPluginRef`, and `SyncOrPrune`. `go build ./...`, `go vet`, `go test -race`, and `tools/layercheck` all pass.