### PR TITLE
fix(ci): repair DCO check under pull_request_target

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -16,12 +16,39 @@ jobs:
     runs-on: ubuntu-latest
     name: DCO Check
     steps:
-      - name: Get PR Commits
-        id: get-pr-commits
-        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # tim-actions/get-pr-commits rejects the pull_request_target event
+      # ("Invalid event"), so we fetch the PR commits directly and verify each
+      # carries a Signed-off-by trailer matching its author. Read-only: no
+      # secrets beyond the read-scoped GITHUB_TOKEN and no untrusted checkout.
       - name: DCO Check
-        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21  # v1.1.0
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          commits=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+            --jq '.[] | [.sha, .commit.author.email, (.commit.message | @base64)] | @tsv')
+          if [ -z "${commits}" ]; then
+            echo "::error::No commits found for PR #${PR_NUMBER}"
+            exit 1
+          fi
+
+          fail=0
+          while IFS=$'\t' read -r sha email msg_b64; do
+            [ -z "${sha}" ] && continue
+            if printf '%s' "${msg_b64}" | base64 -d \
+                 | grep -iE '^Signed-off-by:' | grep -qiF "<${email}>"; then
+              echo "ok: ${sha} signed off by <${email}>"
+            else
+              echo "::error::Commit ${sha} is missing a Signed-off-by trailer matching author <${email}>"
+              fail=1
+            fi
+          done <<< "${commits}"
+
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error::DCO check failed. Sign off each commit with 'git commit -s' (Signed-off-by: Your Name <your@email>)."
+            exit 1
+          fi
+          echo "All commits are signed off."


### PR DESCRIPTION
## Problem

DCO is failing on **every** PR to `main` since #121 switched `dco.yml` to the `pull_request_target` event. `tim-actions/get-pr-commits` does not support that event — it logs `##[error]Invalid event: pull_request_target` and emits no `commits` output, so the downstream `tim-actions/dco` step parses an empty string and dies with `Unexpected end of JSON input`.

Evidence: every `pull_request_target` DCO run fails; the earlier `pull_request` runs pass.

## Fix

Replace the two `tim-actions/*` steps with a single read-only step that:

- fetches the PR commits directly via `gh api --paginate repos/{repo}/pulls/{n}/commits`, and
- verifies each commit carries a `Signed-off-by:` trailer matching its **author** email.

This works under `pull_request_target` (preserving #121's fork-approval-bypass intent), needs only the read-scoped `GITHUB_TOKEN`, does no untrusted checkout, keeps the `DCO Check` job name, and drops the now-deprecated Node 20 actions.

## Validation

Dry-ran the verification logic against synthetic commits: a signed commit passes; an unsigned commit and a commit whose author email ≠ sign-off email both fail. YAML validated.

## Note on merging

Because `pull_request_target` runs the workflow from the **base** branch, this PR's own DCO check still runs the old (broken) workflow until it merges — so its DCO check will be red and needs an admin merge. Once merged, DCO passes for all PRs (including #124 and #125, whose commits are already signed off).