### PR TITLE
fix(ci): make DCO check work under pull_request_target

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,7 +1,20 @@
 name: DCO
 
+# Verify every commit in a PR carries a `Signed-off-by` trailer that matches its
+# author. Runs on pull_request_target so it also covers fork PRs without waiting
+# on the first-time-contributor approval gate (see #121).
+#
+# We fetch the PR's commit list straight from the API: the upstream
+# tim-actions/get-pr-commits action only understands the `pull_request` event and
+# aborts on pull_request_target with "Invalid event", which then left the DCO
+# step parsing an empty commit list ("Unexpected end of JSON input").
+
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to check"
+        required: true
   pull_request_target:
     branches:
       - main
@@ -15,13 +28,35 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     name: DCO Check
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr }}
     steps:
-      - name: Get PR Commits
-        id: get-pr-commits
-        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21  # v1.1.0
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
+        run: |
+          set -euo pipefail
+
+          # One line per commit: "<sha>\t<true|false>\t<expected sign-off>".
+          # A commit passes when any line of its message is exactly the
+          # "Signed-off-by: <author name> <author email>" trailer for its author.
+          results="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/commits" --jq '
+            .[]
+            | ("Signed-off-by: " + .commit.author.name + " <" + .commit.author.email + ">") as $exp
+            | "\(.sha[0:8])\t\((.commit.message | split("\n") | index($exp)) != null)\t\($exp)"
+          ')"
+
+          echo "$results" | awk -F'\t' '{
+            if ($2 == "true") printf "  PASS  %s  %s\n", $1, $3
+            else              printf "  FAIL  %s  missing: %s\n", $1, $3
+          }'
+
+          if echo "$results" | awk -F'\t' '$2 == "false" { found = 1 } END { exit !found }'; then
+            echo ""
+            echo "DCO check failed: one or more commits lack a Signed-off-by trailer"
+            echo "matching their author. Sign off every commit, then force-push:"
+            echo "  git rebase --signoff origin/main && git push --force-with-lease"
+            exit 1
+          fi
+
+          echo "All commits are signed off."


### PR DESCRIPTION
## Problem

The DCO check fails on **every** PR to `main` (e.g. #124, #125) with `Unexpected end of JSON input` — even when commits are correctly signed off.

Root cause: #121 switched the DCO workflow to `pull_request_target` to bypass the fork-approval gate, but `tim-actions/get-pr-commits` only supports the `pull_request` event and aborts with `Invalid event: pull_request_target`. That leaves the commit list empty, so the downstream `tim-actions/dco` step fails parsing it.

## Fix

Drop both upstream actions and fetch the PR's commits straight from the API, verifying each carries a `Signed-off-by` trailer matching its author. This works under `pull_request_target` and keeps the fork-approval-bypass behaviour from #121. The required check name (`DCO Check`) is unchanged.

## Note on merging

Because `pull_request_target` evaluates the workflow from the **base branch**, this PR's own DCO check still runs the old (broken) workflow from `main` and will fail. Its commit is properly signed off — merge with admin override. Once on `main`, re-running DCO on #124/#125 (and all future PRs) will pass.