### PR TITLE
ci: upload coverage to Codecov + add quality badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,15 @@ jobs:
       - name: Build
         run: make build-all
       - name: Unit tests
-        run: go test -race ./internal/...
+        run: make cover
       - name: Integration tests
         run: go test -race ./tests/integration/...
       - name: Vet
         run: make lint
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        with:
+          files: ./coverage.out
+          slug: genai-io/san
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ san_*
 # Dependencies
 vendor/
 
+# Coverage
+coverage.out
+
 # Local config
 .san/*
 !.san/skills/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export CGO_ENABLED := 0
 GOFILES := $(shell find . -path './vendor' -prune -o -path './.git' -prune -o -name '*.go' -print)
 GOIMPORTS_VERSION := v0.43.0
 
-.PHONY: build build-all install clean release release-push test format format-check lint install-format-tools check-format-tools
+.PHONY: build build-all install clean release release-push test cover format format-check lint install-format-tools check-format-tools
 
 build: format
 	@mkdir -p $(BINDIR)
@@ -58,11 +58,17 @@ lint-layers:
 test:
 	go test ./...
 
+# cover runs the unit tests with the race detector and writes an atomic
+# coverage profile (coverage.out) for upload to Codecov. covermode=atomic
+# is required when -race is enabled.
+cover:
+	go test -race -covermode=atomic -coverprofile=coverage.out ./internal/...
+
 # ci runs everything the GitHub workflow runs, in the same order. Use
 # `make ci` before pushing to catch format / vet / layercheck / test
 # failures locally instead of round-tripping through Actions.
 ci: format-check build-all lint
-	go test ./internal/...
+	$(MAKE) cover
 	go test ./tests/integration/...
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ test:
 
 # cover runs the unit tests with the race detector and writes an atomic
 # coverage profile (coverage.out) for upload to Codecov. covermode=atomic
-# is required when -race is enabled.
+# is required when -race is enabled. The race detector needs cgo, so override
+# the global CGO_ENABLED=0 here; this only affects the ephemeral test binaries,
+# not the statically linked release builds.
 cover:
-	go test -race -covermode=atomic -coverprofile=coverage.out ./internal/...
+	CGO_ENABLED=1 go test -race -covermode=atomic -coverprofile=coverage.out ./internal/...
 
 # ci runs everything the GitHub workflow runs, in the same order. Use
 # `make ci` before pushing to catch format / vet / layercheck / test

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
   <p><strong>Open-source unified runtime for specialized AI agents — in the terminal</strong></p>
   <p>
     <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square" alt="Release"></a>
+    <a href="https://goreportcard.com/report/github.com/genai-io/san"><img src="https://goreportcard.com/badge/github.com/genai-io/san?style=flat-square" alt="Go Report Card"></a>
+    <a href="https://codecov.io/gh/genai-io/san"><img src="https://img.shields.io/codecov/c/github/genai-io/san?style=flat-square" alt="Coverage"></a>
     <a href="https://genai-io.github.io/san/"><img src="https://img.shields.io/badge/Website-0d9488?style=flat-square" alt="Website"></a>
     <a href="https://genai-io.github.io/san/getting-started.html"><img src="https://img.shields.io/badge/Getting%20Started-0d9488?style=flat-square" alt="Getting Started"></a>
     <a href="docs/index.md"><img src="https://img.shields.io/badge/Docs-0d9488?style=flat-square" alt="Docs"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,6 +3,8 @@
   <p><strong>面向终端的开源「专用 Agent 统一运行时」</strong></p>
   <p>
     <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square" alt="Release"></a>
+    <a href="https://goreportcard.com/report/github.com/genai-io/san"><img src="https://goreportcard.com/badge/github.com/genai-io/san?style=flat-square" alt="Go Report Card"></a>
+    <a href="https://codecov.io/gh/genai-io/san"><img src="https://img.shields.io/codecov/c/github/genai-io/san?style=flat-square" alt="Coverage"></a>
     <a href="https://genai-io.github.io/san/"><img src="https://img.shields.io/badge/%E5%AE%98%E7%BD%91-0d9488?style=flat-square" alt="官网"></a>
     <a href="https://genai-io.github.io/san/getting-started.html"><img src="https://img.shields.io/badge/%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B-0d9488?style=flat-square" alt="快速开始"></a>
     <a href="docs/index.md"><img src="https://img.shields.io/badge/%E6%96%87%E6%A1%A3-0d9488?style=flat-square" alt="文档"></a>


### PR DESCRIPTION
## What

- Add a `cover` make target: runs unit tests with `-race` and writes an atomic coverage profile (`coverage.out`).
- Wire `cover` into `make ci` and the CI workflow (the **Unit tests** step now runs `make cover`, keeping `-race`).
- Upload `coverage.out` to Codecov via `codecov/codecov-action` (SHA-pinned to v6), `fail_ci_if_error: false` so coverage never blocks CI.
- Add **Go Report Card** and **Codecov** badges to `README.md` / `README.zh.md`.
- Ignore `coverage.out`.

## Why

This re-applies the Codecov integration that was merged earlier but lost from `main` during a history rewrite. Coverage + a reachable coverage link are also a prerequisite for the awesome-go listing.

## Required manual setup (repo admin) for the badge to render

1. Enable the repo on https://codecov.io (org `genai-io`).
2. Copy the repo upload token from Codecov.
3. `gh secret set CODECOV_TOKEN --repo genai-io/san` (paste the token).

After merge + secret, the next CI run on `main` uploads coverage and the badge resolves. Verified locally: `make cover` passes, total coverage ~36%.

> Note: please avoid force-pushing/rebasing `main` over this merge — that's what dropped it last time.