### PR TITLE
refactor(core): dedupe and clarify message type definitions

### DIFF
--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -100,10 +100,10 @@ func (m *ConversationModel) AppendErrorToLast(err error) {
 func (m *ConversationModel) AppendCancelledToolResults(calls []core.ToolCall, contentFn func(core.ToolCall) string) {
 	for _, tc := range calls {
 		m.Append(core.ChatMessage{
-			Role:     core.RoleUser,
-			ToolName: tc.Name,
+			Role: core.RoleUser,
 			ToolResult: &core.ToolResult{
 				ToolCallID: tc.ID,
+				ToolName:   tc.Name,
 				Content:    contentFn(tc),
 				IsError:    true,
 			},
@@ -242,9 +242,6 @@ func (m ConversationModel) ConvertToProviderFrom(startIdx int) []core.Message {
 
 		if msg.ToolResult != nil {
 			tr := *msg.ToolResult
-			if msg.ToolName != "" {
-				tr.ToolName = msg.ToolName
-			}
 			providerMsg.ToolResult = &tr
 		}
 

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -239,7 +239,6 @@ func applyPostTool(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 	result := rt.OnToolResult(tr)
 	m.Append(core.ChatMessage{
 		Role:       core.RoleUser,
-		ToolName:   tr.ToolName,
 		ToolResult: result,
 	})
 	return nil

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -97,7 +97,7 @@ func PrecomputeInlinedResults(messages []core.ChatMessage) inlinedToolResults {
 				p.resultsForAssistant[i] = results
 			}
 			results[callID] = ToolResultData{
-				ToolName: next.ToolName,
+				ToolName: next.ToolResult.ToolName,
 				Content:  next.ToolResult.Content,
 				Error:    next.ToolResult.Content,
 				IsError:  next.ToolResult.IsError,
@@ -150,7 +150,7 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 		switch {
 		case msg.ToolResult != nil:
 			sb.WriteString(RenderToolResultInline(ToolResultData{
-				ToolName: msg.ToolName,
+				ToolName: msg.ToolResult.ToolName,
 				Content:  msg.ToolResult.Content,
 				Error:    msg.ToolResult.Content,
 				IsError:  msg.ToolResult.IsError,

--- a/internal/app/update_approval.go
+++ b/internal/app/update_approval.go
@@ -47,7 +47,7 @@ func (m *model) AbortToolWithError(errorMsg string, retry bool) tea.Cmd {
 		return tea.Batch(m.CommitMessages()...)
 	}
 	tc := m.conv.Tool.PendingCalls[m.conv.Tool.CurrentIdx]
-	m.conv.Append(core.ChatMessage{Role: core.RoleUser, ToolName: tc.Name, ToolResult: &core.ToolResult{ToolCallID: tc.ID, Content: errorMsg, IsError: true}})
+	m.conv.Append(core.ChatMessage{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: tc.ID, ToolName: tc.Name, Content: errorMsg, IsError: true}})
 	m.cancelRemainingToolCalls(m.conv.Tool.CurrentIdx + 1)
 	m.conv.Tool.Reset()
 	m.conv.Stream.Stop()

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// NewMessageID returns a fresh short hex identifier for a ChatMessage.
+// NewMessageID returns a fresh short hex identifier for a Message.
 // 8 bytes (16 hex chars) — collision space is large enough for the
 // per-session message volume we ever see; brevity matters because the
 // ID appears in every transcript record's id field.
@@ -26,12 +26,9 @@ type Role string
 const (
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
-	RoleTool      Role = "tool_result"
+	RoleTool      Role = "tool_result" // a tool-result turn; "tool_result" is its wire value
 	RoleNotice    Role = "notice"
 )
-
-// RoleToolResult is an alias for RoleTool.
-const RoleToolResult = RoleTool
 
 // Signal represents control signals sent through channels.
 type Signal string
@@ -44,7 +41,9 @@ const (
 	SigCompact Signal = "compact"
 )
 
-// Message is the canonical message type used across the codebase.
+// Message is the wire/agent-chain message: the unit the LLM provider and the
+// agent run loop exchange, append to history, and persist. It holds no
+// UI/display state — for the rendered TUI view-model, see ChatMessage.
 type Message struct {
 	ID                string         `json:"id,omitempty"`
 	Role              Role           `json:"role"`
@@ -60,7 +59,14 @@ type Message struct {
 	Meta              map[string]any `json:"meta,omitempty"`
 }
 
-// ChatMessage represents a UI-layer chat message with display state.
+// ChatMessage is the TUI view-model for one conversation entry: the same
+// content as Message plus transient display state (the expand/collapse
+// toggles). The app layer renders ChatMessages and converts them back to
+// Message before sending to the provider — see
+// conv.ConversationModel.ConvertToProvider.
+//
+// The tool's name lives on ToolResult.ToolName (the single source of truth),
+// not on the ChatMessage itself.
 type ChatMessage struct {
 	// ID is a stable per-message identifier assigned once at construction.
 	// The session.Save path uses it to dedupe appends, so it must not change
@@ -74,11 +80,9 @@ type ChatMessage struct {
 	ThinkingSignature string
 	Images            []Image
 	ToolCalls         []ToolCall
-	ToolCallsExpanded bool
 	ToolResult        *ToolResult
-	ToolName          string
-	Expanded          bool
-	RenderedInline    bool
+	ToolCallsExpanded bool // UI: the assistant's tool-call block is expanded
+	Expanded          bool // UI: the tool-result block is expanded
 }
 
 // Image represents an image attachment.

--- a/internal/session/convert.go
+++ b/internal/session/convert.go
@@ -92,7 +92,6 @@ func ConvertFromEntries(entries []Entry) []core.ChatMessage {
 		}
 		if m.ToolResult != nil {
 			chatMsg.ToolResult = m.ToolResult
-			chatMsg.ToolName = m.ToolResult.ToolName
 		}
 		messages = append(messages, chatMsg)
 	}


### PR DESCRIPTION
Tighten the two central message structs in `internal/core` to remove redundancy and sharpen their definitions. No behavior change.

- Drop the denormalized `ChatMessage.ToolName`; `ToolResult.ToolName` is now the single source of truth (set at construction, read at render, reconciliation branch in `ConvertToProvider` removed).
- Remove dead `ChatMessage.RenderedInline` field and the unused `RoleToolResult` alias.
- Fix the `NewMessageID` doc and document `Message` (wire/agent-chain) vs `ChatMessage` (TUI view-model).

Verified: `go build ./...`, `go vet`, affected package tests, and `tools/layercheck` all pass.