### PR TITLE
ci: merge integration coverage and exclude TUI from Codecov stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,8 @@ jobs:
         run: make format-check
       - name: Build
         run: make build-all
-      - name: Unit tests
+      - name: Unit + integration tests (merged coverage)
         run: make cover
-      - name: Integration tests
-        run: go test -race ./tests/integration/...
       - name: Vet
         run: make lint
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -58,20 +58,25 @@ lint-layers:
 test:
 	go test ./...
 
-# cover runs the unit tests with the race detector and writes an atomic
-# coverage profile (coverage.out) for upload to Codecov. covermode=atomic
-# is required when -race is enabled. The race detector needs cgo, so override
-# the global CGO_ENABLED=0 here; this only affects the ephemeral test binaries,
-# not the statically linked release builds.
+# cover runs the unit and integration tests with the race detector and writes a
+# single merged coverage profile (coverage.out) for upload to Codecov.
+# -coverpkg=./internal/... attributes coverage to the internal packages from
+# both suites, so end-to-end paths exercised only by the integration tests are
+# counted too (a plain `./internal/...` run drops ~6 points of real coverage).
+# covermode=atomic is required when -race is enabled. The race detector needs
+# cgo, so override the global CGO_ENABLED=0 here; this only affects the
+# ephemeral test binaries, not the statically linked release builds.
 cover:
-	CGO_ENABLED=1 go test -race -covermode=atomic -coverprofile=coverage.out ./internal/...
+	CGO_ENABLED=1 go test -race -covermode=atomic \
+		-coverpkg=./internal/... -coverprofile=coverage.out \
+		./internal/... ./tests/integration/...
 
 # ci runs everything the GitHub workflow runs, in the same order. Use
 # `make ci` before pushing to catch format / vet / layercheck / test
-# failures locally instead of round-tripping through Actions.
+# failures locally instead of round-tripping through Actions. `cover` already
+# runs the integration tests (with coverage), so they need no separate step.
 ci: format-check build-all lint
 	$(MAKE) cover
-	go test ./tests/integration/...
 
 clean:
 	rm -rf $(BINDIR)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# Codecov configuration.
+#
+# The Bubble Tea TUI (internal/app) is rendering/key-handling code that is
+# costly to unit-test and low-value to gate on, so it is excluded from the
+# coverage statistics via `ignore` below. The tests still RUN it — both the
+# internal/app unit tests and the integration suite drive the TUI; only its
+# line coverage is left out of the report, so the reported number reflects the
+# non-TUI business logic.
+
+coverage:
+  precision: 1
+  round: down
+  status:
+    project:
+      default:
+        # Ratchet against the parent commit; don't let business-logic coverage
+        # regress.
+        target: auto
+        threshold: 1%
+    patch:
+      # New code should come with tests; surface the number without hard-
+      # blocking for now.
+      default:
+        target: 60%
+        threshold: 5%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "**/*_test.go"
+  - "internal/llm/fake_llm.go"
+  # TUI (Bubble Tea): tests still run it, but skip it in coverage stats for now.
+  - "internal/app"


### PR DESCRIPTION
Coverage was measured from `go test ./internal/...` only, dropping the integration suite entirely — about 6 points of real coverage.

- `make cover` now runs unit + integration with `-coverpkg=./internal/...` into one merged profile; the redundant integration CI step is removed.
- New `codecov.yml` ignores the Bubble Tea TUI (`internal/app`) in the coverage report. The tests still **run** it — both the `internal/app` unit tests and the integration suite drive the TUI — so only its line coverage is left out, and the reported number reflects the non-TUI business logic.