### PR TITLE
refactor(llm): unify duplicated tool-message sanitization

### DIFF
--- a/internal/llm/google/client.go
+++ b/internal/llm/google/client.go
@@ -52,7 +52,7 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 		// Strip orphan function_call / function_response pairs left by a
 		// mid-stream cancel. Gemini rejects requests where a function_call
 		// is not followed by a matching function_response.
-		sanitized := sanitizeToolMessages(opts.Messages)
+		sanitized := llm.SanitizeToolMessages(opts.Messages)
 
 		// Convert messages to Google format
 		contents := make([]*genai.Content, 0, len(sanitized))
@@ -355,68 +355,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	}
 
 	return NewClient(client, "google:api_key"), nil
-}
-
-// sanitizeToolMessages drops orphan function_call / function_response pairs.
-// Mirrors openaicompat.SanitizeToolMessages and anthropic.sanitizeToolResults:
-// Gemini's API rejects requests where an assistant function_call is not
-// followed by a matching function_response (the user-initiated cancel path
-// can leave such orphans in agent.messages).
-func sanitizeToolMessages(msgs []core.Message) []core.Message {
-	result := make([]core.Message, 0, len(msgs))
-
-	for i := 0; i < len(msgs); i++ {
-		msg := msgs[i]
-
-		if msg.ToolResult != nil {
-			// Tool results are only valid immediately after their assistant call.
-			continue
-		}
-
-		if msg.Role != core.RoleAssistant || len(msg.ToolCalls) == 0 {
-			result = append(result, msg)
-			continue
-		}
-
-		j := i + 1
-		var followingResults []core.Message
-		for j < len(msgs) && msgs[j].ToolResult != nil {
-			followingResults = append(followingResults, msgs[j])
-			j++
-		}
-
-		resultIDs := make(map[string]bool, len(followingResults))
-		for _, r := range followingResults {
-			resultIDs[r.ToolResult.ToolCallID] = true
-		}
-
-		filteredCalls := make([]core.ToolCall, 0, len(msg.ToolCalls))
-		callIDs := make(map[string]bool, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			if resultIDs[tc.ID] {
-				filteredCalls = append(filteredCalls, tc)
-				callIDs[tc.ID] = true
-			}
-		}
-
-		msg.ToolCalls = filteredCalls
-		if len(msg.ToolCalls) > 0 || msg.Content != "" {
-			result = append(result, msg)
-		}
-
-		seenResults := make(map[string]bool, len(followingResults))
-		for _, r := range followingResults {
-			id := r.ToolResult.ToolCallID
-			if callIDs[id] && !seenResults[id] {
-				result = append(result, r)
-				seenResults[id] = true
-			}
-		}
-
-		i = j - 1
-	}
-
-	return result
 }
 
 func googleThinkingBudget(effort string) *int32 {

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -57,7 +57,7 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 		// Convert messages to Responses API input items
 		var inputItems responses.ResponseInputParam = make([]responses.ResponseInputItemUnionParam, 0, len(opts.Messages)+1)
 
-		for _, msg := range openaicompat.DropEmptyMessages(openaicompat.SanitizeToolMessages(opts.Messages)) {
+		for _, msg := range openaicompat.DropEmptyMessages(llm.SanitizeToolMessages(opts.Messages)) {
 			if msg.ToolResult != nil {
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{

--- a/internal/llm/openaicompat/convert.go
+++ b/internal/llm/openaicompat/convert.go
@@ -24,7 +24,7 @@ func ConvertMessages(
 	systemPrompt string,
 	convertAssistant func(msg core.Message) openai.ChatCompletionMessageParamUnion,
 ) []openai.ChatCompletionMessageParamUnion {
-	msgs = SanitizeToolMessages(msgs)
+	msgs = llm.SanitizeToolMessages(msgs)
 	msgs = DropEmptyMessages(msgs)
 	out := make([]openai.ChatCompletionMessageParamUnion, 0, len(msgs)+1)
 
@@ -51,67 +51,6 @@ func ConvertMessages(
 		}
 	}
 	return out
-}
-
-// SanitizeToolMessages ensures Chat Completions tool-call adjacency:
-// an assistant message with tool_calls must be followed immediately by tool
-// result messages for those calls. Interrupted runs and restored sessions can
-// leave orphaned tool calls/results in history; strip those before sending.
-func SanitizeToolMessages(msgs []core.Message) []core.Message {
-	result := make([]core.Message, 0, len(msgs))
-
-	for i := 0; i < len(msgs); i++ {
-		msg := msgs[i]
-
-		if msg.ToolResult != nil {
-			// Tool results are only valid immediately after their assistant call.
-			continue
-		}
-
-		if msg.Role != core.RoleAssistant || len(msg.ToolCalls) == 0 {
-			result = append(result, msg)
-			continue
-		}
-
-		j := i + 1
-		var followingResults []core.Message
-		for j < len(msgs) && msgs[j].ToolResult != nil {
-			followingResults = append(followingResults, msgs[j])
-			j++
-		}
-
-		resultIDs := make(map[string]bool, len(followingResults))
-		for _, r := range followingResults {
-			resultIDs[r.ToolResult.ToolCallID] = true
-		}
-
-		filteredCalls := make([]core.ToolCall, 0, len(msg.ToolCalls))
-		callIDs := make(map[string]bool, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			if resultIDs[tc.ID] {
-				filteredCalls = append(filteredCalls, tc)
-				callIDs[tc.ID] = true
-			}
-		}
-
-		msg.ToolCalls = filteredCalls
-		if len(msg.ToolCalls) > 0 || msg.Content != "" {
-			result = append(result, msg)
-		}
-
-		seenResults := make(map[string]bool, len(followingResults))
-		for _, r := range followingResults {
-			id := r.ToolResult.ToolCallID
-			if callIDs[id] && !seenResults[id] {
-				result = append(result, r)
-				seenResults[id] = true
-			}
-		}
-
-		i = j - 1
-	}
-
-	return result
 }
 
 // DropEmptyMessages removes text-only messages that cannot carry provider

--- a/internal/llm/openaicompat/convert_test.go
+++ b/internal/llm/openaicompat/convert_test.go
@@ -52,60 +52,6 @@ func TestConvertMessagesConvertsRoleToolResultToToolMessage(t *testing.T) {
 	}
 }
 
-func TestSanitizeToolMessagesStripsOrphanedAssistantToolCall(t *testing.T) {
-	msgs := []core.Message{
-		{
-			Role: core.RoleAssistant,
-			ToolCalls: []core.ToolCall{{
-				ID:    "call_orphan",
-				Name:  "Read",
-				Input: `{}`,
-			}},
-		},
-		{Role: core.RoleUser, Content: "continue"},
-	}
-
-	sanitized := SanitizeToolMessages(msgs)
-	if len(sanitized) != 1 {
-		t.Fatalf("expected orphaned empty assistant tool call to be dropped, got %d messages", len(sanitized))
-	}
-	if sanitized[0].Role != core.RoleUser || sanitized[0].Content != "continue" {
-		t.Fatalf("unexpected sanitized messages: %#v", sanitized)
-	}
-}
-
-func TestSanitizeToolMessagesKeepsOnlyImmediatelyAnsweredToolCalls(t *testing.T) {
-	msgs := []core.Message{
-		{
-			Role:    core.RoleAssistant,
-			Content: "checking",
-			ToolCalls: []core.ToolCall{
-				{ID: "call_1", Name: "Read", Input: `{}`},
-				{ID: "call_2", Name: "Glob", Input: `{}`},
-			},
-		},
-		{
-			Role:       core.RoleTool,
-			ToolResult: &core.ToolResult{ToolCallID: "call_1", ToolName: "Read", Content: "ok"},
-		},
-		{Role: core.RoleUser, Content: "next"},
-	}
-
-	sanitized := SanitizeToolMessages(msgs)
-	if len(sanitized) != 3 {
-		t.Fatalf("expected assistant, one tool result, and user message; got %d", len(sanitized))
-	}
-	if len(sanitized[0].ToolCalls) != 1 || sanitized[0].ToolCalls[0].ID != "call_1" {
-		t.Fatalf("unexpected filtered tool calls: %#v", sanitized[0].ToolCalls)
-	}
-	if sanitized[1].ToolResult == nil || sanitized[1].ToolResult.ToolCallID != "call_1" {
-		t.Fatalf("unexpected filtered tool result: %#v", sanitized[1])
-	}
-	if sanitized[2].Content != "next" {
-		t.Fatalf("expected trailing user message to remain, got %#v", sanitized[2])
-	}
-}
-
 func TestDropEmptyMessagesRemovesTextOnlyEmptyUserMessages(t *testing.T) {
 	msgs := []core.Message{
 		{Role: core.RoleUser, Content: "hello"},

--- a/internal/llm/sanitize.go
+++ b/internal/llm/sanitize.go
@@ -1,0 +1,76 @@
+package llm
+
+import "github.com/genai-io/san/internal/core"
+
+// SanitizeToolMessages enforces tool-call/tool-result adjacency: an assistant
+// message carrying tool calls must be followed immediately by the tool-result
+// messages for those calls. It drops orphaned calls and results, which
+// interrupted runs (mid-stream cancel) and restored sessions can leave behind.
+//
+// The rule is strict adjacency: for each assistant message, only the run of
+// tool-result messages directly after it counts. A tool call with no matching
+// following result is stripped; a tool result with no matching kept call is
+// dropped. This is what the OpenAI Chat Completions / Responses APIs and the
+// Gemini API both require, so the OpenAI-compatible and Google providers share
+// this single implementation.
+//
+// Anthropic deliberately does NOT use this. Its client applies a broader
+// variant (sanitizeToolResults) that matches results against any preceding
+// tool_use in the chain rather than only the immediately adjacent assistant
+// message; the two policies are not interchangeable, so keep them separate.
+func SanitizeToolMessages(msgs []core.Message) []core.Message {
+	result := make([]core.Message, 0, len(msgs))
+
+	for i := 0; i < len(msgs); i++ {
+		msg := msgs[i]
+
+		if msg.ToolResult != nil {
+			// Tool results are only valid immediately after their assistant call.
+			continue
+		}
+
+		if msg.Role != core.RoleAssistant || len(msg.ToolCalls) == 0 {
+			result = append(result, msg)
+			continue
+		}
+
+		j := i + 1
+		var followingResults []core.Message
+		for j < len(msgs) && msgs[j].ToolResult != nil {
+			followingResults = append(followingResults, msgs[j])
+			j++
+		}
+
+		resultIDs := make(map[string]bool, len(followingResults))
+		for _, r := range followingResults {
+			resultIDs[r.ToolResult.ToolCallID] = true
+		}
+
+		filteredCalls := make([]core.ToolCall, 0, len(msg.ToolCalls))
+		callIDs := make(map[string]bool, len(msg.ToolCalls))
+		for _, tc := range msg.ToolCalls {
+			if resultIDs[tc.ID] {
+				filteredCalls = append(filteredCalls, tc)
+				callIDs[tc.ID] = true
+			}
+		}
+
+		msg.ToolCalls = filteredCalls
+		if len(msg.ToolCalls) > 0 || msg.Content != "" {
+			result = append(result, msg)
+		}
+
+		seenResults := make(map[string]bool, len(followingResults))
+		for _, r := range followingResults {
+			id := r.ToolResult.ToolCallID
+			if callIDs[id] && !seenResults[id] {
+				result = append(result, r)
+				seenResults[id] = true
+			}
+		}
+
+		i = j - 1
+	}
+
+	return result
+}

--- a/internal/llm/sanitize_test.go
+++ b/internal/llm/sanitize_test.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+func TestSanitizeToolMessagesStripsOrphanedAssistantToolCall(t *testing.T) {
+	msgs := []core.Message{
+		{
+			Role: core.RoleAssistant,
+			ToolCalls: []core.ToolCall{{
+				ID:    "call_orphan",
+				Name:  "Read",
+				Input: `{}`,
+			}},
+		},
+		{Role: core.RoleUser, Content: "continue"},
+	}
+
+	sanitized := SanitizeToolMessages(msgs)
+	if len(sanitized) != 1 {
+		t.Fatalf("expected orphaned empty assistant tool call to be dropped, got %d messages", len(sanitized))
+	}
+	if sanitized[0].Role != core.RoleUser || sanitized[0].Content != "continue" {
+		t.Fatalf("unexpected sanitized messages: %#v", sanitized)
+	}
+}
+
+func TestSanitizeToolMessagesKeepsOnlyImmediatelyAnsweredToolCalls(t *testing.T) {
+	msgs := []core.Message{
+		{
+			Role:    core.RoleAssistant,
+			Content: "checking",
+			ToolCalls: []core.ToolCall{
+				{ID: "call_1", Name: "Read", Input: `{}`},
+				{ID: "call_2", Name: "Glob", Input: `{}`},
+			},
+		},
+		{
+			Role:       core.RoleTool,
+			ToolResult: &core.ToolResult{ToolCallID: "call_1", ToolName: "Read", Content: "ok"},
+		},
+		{Role: core.RoleUser, Content: "next"},
+	}
+
+	sanitized := SanitizeToolMessages(msgs)
+	if len(sanitized) != 3 {
+		t.Fatalf("expected assistant, one tool result, and user message; got %d", len(sanitized))
+	}
+	if len(sanitized[0].ToolCalls) != 1 || sanitized[0].ToolCalls[0].ID != "call_1" {
+		t.Fatalf("unexpected filtered tool calls: %#v", sanitized[0].ToolCalls)
+	}
+	if sanitized[1].ToolResult == nil || sanitized[1].ToolResult.ToolCallID != "call_1" {
+		t.Fatalf("unexpected filtered tool result: %#v", sanitized[1])
+	}
+	if sanitized[2].Content != "next" {
+		t.Fatalf("expected trailing user message to remain, got %#v", sanitized[2])
+	}
+}


### PR DESCRIPTION
Hoist the byte-identical tool-call/result adjacency sanitizer out of the OpenAI-compatible and Google providers into a single provider-agnostic `llm.SanitizeToolMessages`, and have both call it. Removes ~40 net lines and three divergent names for one operation.

- Anthropic intentionally keeps its own `sanitizeToolResults` (broader matching policy — results matched against any preceding tool_use, not only the adjacent assistant message); the new doc comment notes this so it isn't mistakenly merged.
- Pure refactor, no behavior change. `go build ./...`, `go vet`, and `internal/llm/...` tests all pass.