### PR TITLE
test(selflearn): fix flaky concurrency-cap retry test hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,11 @@ test:
 # counted too (a plain `./internal/...` run drops ~6 points of real coverage).
 # covermode=atomic is required when -race is enabled. The race detector needs
 # cgo, so override the global CGO_ENABLED=0 here; this only affects the
-# ephemeral test binaries, not the statically linked release builds.
+# ephemeral test binaries, not the statically linked release builds. -timeout
+# bounds a hung test to 2 minutes (no package legitimately runs that long) so a
+# deadlock fails fast instead of burning the 10-minute default.
 cover:
-	CGO_ENABLED=1 go test -race -covermode=atomic \
+	CGO_ENABLED=1 go test -race -covermode=atomic -timeout 120s \
 		-coverpkg=./internal/... -coverprofile=coverage.out \
 		./internal/... ./tests/integration/...
 

--- a/internal/selflearn/reviewer_test.go
+++ b/internal/selflearn/reviewer_test.go
@@ -33,6 +33,40 @@ func assertNoFire(t *testing.T, fired <-chan ReviewKind) {
 	}
 }
 
+// mustStart waits for a review goroutine to signal start, failing fast instead
+// of blocking forever (and tripping the 10-minute package timeout) if none does.
+func mustStart(t *testing.T, started <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("expected a review to start, none did")
+	}
+}
+
+// waitInFlightClear blocks until no review is in flight. inFlight is cleared in
+// the review goroutine's defer, *after* the callback returns — so synchronizing
+// on a callback side effect (e.g. the fired channel) does not imply it has been
+// cleared yet. Tests that fire a follow-up review must wait here first, or they
+// race the reset and the follow-up is dropped as "still in flight".
+func waitInFlightClear(t *testing.T, r *Reviewer) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		r.mu.Lock()
+		inFlight := r.inFlight
+		r.mu.Unlock()
+		if !inFlight {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("review still in flight after 1s")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
 // TestReviewKindString covers the log-friendly labels surfaced to the
 // wire-up's review-summary log entry.
 func TestReviewKindString(t *testing.T) {
@@ -114,7 +148,7 @@ func TestConcurrencyCapDropsAndRetries(t *testing.T) {
 	})
 
 	r.Observe(endTurn(0)) // fires review #1 (now in-flight, blocked)
-	<-started
+	mustStart(t, started)
 
 	r.Observe(endTurn(0)) // arrives while #1 in-flight → dropped, NOT reset
 	select {
@@ -127,10 +161,14 @@ func TestConcurrencyCapDropsAndRetries(t *testing.T) {
 	if k := waitFire(t, fired); !k.Has(KindMemory) {
 		t.Fatalf("want memory, got %v", k)
 	}
+	// waitFire synced on the fired channel, which the callback sends *before*
+	// returning; inFlight is only cleared afterwards. Wait for that so the
+	// retry below fires deterministically instead of racing the reset.
+	waitInFlightClear(t, r)
 
 	// The dropped trigger left the counter tripped: the next clean turn fires.
 	r.Observe(endTurn(0))
-	<-started
+	mustStart(t, started)
 	if k := waitFire(t, fired); !k.Has(KindMemory) {
 		t.Fatalf("retry: want memory, got %v", k)
 	}


### PR DESCRIPTION
`TestConcurrencyCapDropsAndRetries` hung for the full 10-minute test timeout on the post-#133 main run, failing CI. The reviewer's drop/retry logic is correct; the test raced it.

The test synced on the `fired` channel — sent by the review callback *before* it returns — but `inFlight` is cleared in the goroutine's defer *after* the callback returns. The follow-up `Observe` could therefore run while `inFlight` was still set, get dropped as still-in-flight, and leave the bare `<-started` blocking until the timeout.

- Wait for `inFlight` to clear before the retry so it fires deterministically.
- Replace the bare `<-started` receives with a 1s-bounded helper (fail fast, not hang).
- Add `-timeout 120s` to `make cover` so a hung test fails in 2 min instead of 10.

Verified: 200× under `-race` + `-coverpkg` all pass; full `make cover` green.