### PR TITLE
refactor(llm): unify token-usage naming and report agent input/output separately

### DIFF
--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -42,39 +42,39 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 
 	// Bottom-right context usage reflects the latest prompt/output, not a
 	// lifetime sum across the whole session.
-	m.env.InputTokens = resp.TokensIn
-	m.env.OutputTokens = resp.TokensOut
-	m.env.TurnInputTokens += resp.TokensIn
-	m.env.TurnOutputTokens += resp.TokensOut
+	m.env.InputTokens = resp.InputTokens
+	m.env.OutputTokens = resp.OutputTokens
+	m.env.TurnInputTokens += resp.InputTokens
+	m.env.TurnOutputTokens += resp.OutputTokens
 
 	if m.env.CurrentModel != nil {
 		switch m.env.CurrentModel.Provider {
 		case llm.MinMax:
 			cost, ok := minmax.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.TokensIn,
-				OutputTokens:             resp.TokensOut,
-				CacheCreationInputTokens: resp.CacheCreateTokens,
-				CacheReadInputTokens:     resp.CacheReadTokens,
+				InputTokens:              resp.InputTokens,
+				OutputTokens:             resp.OutputTokens,
+				CacheCreationInputTokens: resp.CacheCreationInputTokens,
+				CacheReadInputTokens:     resp.CacheReadInputTokens,
 			})
 			if ok {
 				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
 			}
 		case llm.DeepSeek:
 			cost, ok := deepseek.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.TokensIn,
-				OutputTokens:             resp.TokensOut,
-				CacheCreationInputTokens: resp.CacheCreateTokens,
-				CacheReadInputTokens:     resp.CacheReadTokens,
+				InputTokens:              resp.InputTokens,
+				OutputTokens:             resp.OutputTokens,
+				CacheCreationInputTokens: resp.CacheCreationInputTokens,
+				CacheReadInputTokens:     resp.CacheReadInputTokens,
 			})
 			if ok {
 				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
 			}
 		case llm.Mimo:
 			cost, ok := mimo.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.TokensIn,
-				OutputTokens:             resp.TokensOut,
-				CacheCreationInputTokens: resp.CacheCreateTokens,
-				CacheReadInputTokens:     resp.CacheReadTokens,
+				InputTokens:              resp.InputTokens,
+				OutputTokens:             resp.OutputTokens,
+				CacheCreationInputTokens: resp.CacheCreationInputTokens,
+				CacheReadInputTokens:     resp.CacheReadInputTokens,
 			})
 			if ok {
 				m.env.ConversationCost = m.env.ConversationCost.Add(cost)

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -15,7 +15,7 @@ func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
 	m := &model{}
 	m.OnTurnBegin()
 
-	m.OnTokenUsage(&core.InferResponse{TokensIn: 1200, TokensOut: 80})
+	m.OnTokenUsage(&core.InferResponse{InputTokens: 1200, OutputTokens: 80})
 	if m.env.InputTokens != 1200 || m.env.OutputTokens != 80 {
 		t.Fatalf("first token update = in:%d out:%d, want in:1200 out:80", m.env.InputTokens, m.env.OutputTokens)
 	}
@@ -23,7 +23,7 @@ func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
 		t.Fatalf("first turn totals = in:%d out:%d, want in:1200 out:80", m.env.TurnInputTokens, m.env.TurnOutputTokens)
 	}
 
-	m.OnTokenUsage(&core.InferResponse{TokensIn: 400, TokensOut: 25})
+	m.OnTokenUsage(&core.InferResponse{InputTokens: 400, OutputTokens: 25})
 	if m.env.InputTokens != 400 || m.env.OutputTokens != 25 {
 		t.Fatalf("latest token update = in:%d out:%d, want in:400 out:25", m.env.InputTokens, m.env.OutputTokens)
 	}
@@ -52,7 +52,7 @@ func TestOnTokenUsageClearsCompactedStatusOnNextInfer(t *testing.T) {
 	m := &model{}
 	m.userInput.Provider.StatusMessage = "compacted"
 
-	m.OnTokenUsage(&core.InferResponse{TokensIn: 400, TokensOut: 25})
+	m.OnTokenUsage(&core.InferResponse{InputTokens: 400, OutputTokens: 25})
 
 	if m.userInput.Provider.StatusMessage != "" {
 		t.Fatalf("StatusMessage = %q, want compacted badge cleared on next infer", m.userInput.Provider.StatusMessage)

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -177,14 +177,14 @@ func NewAgent(cfg Config) Agent {
 // Result represents the outcome of one completed turn (end_turn).
 // Emitted to Outbox as Event{Type: OnTurn, Data: result}.
 type Result struct {
-	Content    string     // final text output of this turn
-	Messages   []Message  // full conversation history
-	Steps      int        // LLM inference steps in this turn
-	ToolUses   int        // tool calls in this turn
-	TokensIn   int        // input tokens consumed
-	TokensOut  int        // output tokens produced
-	StopReason StopReason // why the loop stopped
-	StopDetail string     // human-readable detail (e.g. hook block reason)
+	Content      string     // final text output of this turn
+	Messages     []Message  // full conversation history
+	Steps        int        // LLM inference steps in this turn
+	ToolUses     int        // tool calls in this turn
+	InputTokens  int        // input tokens consumed
+	OutputTokens int        // output tokens produced
+	StopReason   StopReason // why the loop stopped
+	StopDetail   string     // human-readable detail (e.g. hook block reason)
 }
 
 // EventType identifies an agent lifecycle event.

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -301,7 +301,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 	makeResult := func(content string, stop StopReason, detail string) *Result {
 		return &Result{
 			Content: content, Messages: a.snapshot(),
-			Steps: steps, ToolUses: toolUses, TokensIn: tokensIn, TokensOut: tokensOut,
+			Steps: steps, ToolUses: toolUses, InputTokens: tokensIn, OutputTokens: tokensOut,
 			StopReason: stop, StopDetail: detail,
 		}
 	}
@@ -352,10 +352,10 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 		}
 
 		steps++
-		lastInputTokens = resp.TokensIn
+		lastInputTokens = resp.InputTokens
 		lastPromptTextLen = currentPromptTextLen
-		tokensIn += resp.TokensIn
-		tokensOut += resp.TokensOut
+		tokensIn += resp.InputTokens
+		tokensOut += resp.OutputTokens
 
 		a.emit(ctx, PostInferEvent(a.id, resp))
 		a.append(Message{

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -24,15 +24,15 @@ type InferRequest struct {
 
 // InferResponse is the final aggregated response from one LLM call.
 type InferResponse struct {
-	Content           string     // text output
-	Thinking          string     // chain-of-thought (extended thinking)
-	ThinkingSignature string     // signature for replaying thinking blocks
-	ToolCalls         []ToolCall // tool execution requests
-	StopReason        StopReason
-	TokensIn          int
-	TokensOut         int
-	CacheCreateTokens int
-	CacheReadTokens   int
+	Content                  string     // text output
+	Thinking                 string     // chain-of-thought (extended thinking)
+	ThinkingSignature        string     // signature for replaying thinking blocks
+	ToolCalls                []ToolCall // tool execution requests
+	StopReason               StopReason
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
 }
 
 // Chunk is one piece of a streaming LLM response.

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -11,15 +11,6 @@ import (
 // nor the provider specifies a limit.
 const defaultMaxTokens = 8192
 
-// TokenUsage tracks token consumption for a conversation.
-type TokenUsage struct {
-	InputTokens              int
-	OutputTokens             int
-	CacheCreationInputTokens int
-	CacheReadInputTokens     int
-	TotalTokens              int
-}
-
 // Client adapts a Provider to core.LLM.
 //
 // It also provides streaming and completion methods for the loop/app layer,
@@ -33,7 +24,7 @@ type Client struct {
 	model          string
 	maxTokens      int
 	thinkingEffort string
-	tokens         TokenUsage
+	tokens         Usage
 }
 
 // NewClient wraps an existing provider as a core.LLM with streaming and
@@ -170,12 +161,11 @@ func (l *Client) AddUsage(usage Usage) {
 	l.tokens.OutputTokens += usage.OutputTokens
 	l.tokens.CacheCreationInputTokens += usage.CacheCreationInputTokens
 	l.tokens.CacheReadInputTokens += usage.CacheReadInputTokens
-	l.tokens.TotalTokens = l.tokens.InputTokens + l.tokens.OutputTokens
 	l.mu.Unlock()
 }
 
 // Tokens returns the accumulated token usage.
-func (l *Client) Tokens() TokenUsage {
+func (l *Client) Tokens() Usage {
 	l.mu.RLock()
 	t := l.tokens
 	l.mu.RUnlock()
@@ -350,14 +340,14 @@ func toInferResponse(r *CompletionResponse) *core.InferResponse {
 		return nil
 	}
 	return &core.InferResponse{
-		Content:           r.Content,
-		Thinking:          r.Thinking,
-		ThinkingSignature: r.ThinkingSignature,
-		ToolCalls:         r.ToolCalls,
-		StopReason:        core.StopReason(r.StopReason),
-		TokensIn:          r.Usage.InputTokens,
-		TokensOut:         r.Usage.OutputTokens,
-		CacheCreateTokens: r.Usage.CacheCreationInputTokens,
-		CacheReadTokens:   r.Usage.CacheReadInputTokens,
+		Content:                  r.Content,
+		Thinking:                 r.Thinking,
+		ThinkingSignature:        r.ThinkingSignature,
+		ToolCalls:                r.ToolCalls,
+		StopReason:               core.StopReason(r.StopReason),
+		InputTokens:              r.Usage.InputTokens,
+		OutputTokens:             r.Usage.OutputTokens,
+		CacheCreationInputTokens: r.Usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     r.Usage.CacheReadInputTokens,
 	}
 }

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -171,13 +171,23 @@ func (r CompletionResponse) LogToolCallSummary(escaper func(string) string) stri
 	return sb.String()
 }
 
-// Usage contains token usage information.
+// Usage contains token usage information. Field names use the project's domain
+// vocabulary (InputTokens/CacheCreationInputTokens/…); the json tags preserve each
+// provider's wire format (e.g. Anthropic's cache_creation_input_tokens).
 type Usage struct {
 	InputTokens              int `json:"input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 }
+
+// Total returns InputTokens + OutputTokens — a coarse aggregate used only for
+// run summaries and progress display, never for billing (cost estimates use the
+// full per-bucket breakdown, cache counters included). Cache counters are not
+// added here, preserving the historical "total" semantics; note this can
+// undercount real prompt size on providers (e.g. Anthropic) whose InputTokens
+// excludes the cache-creation/read buckets.
+func (u Usage) Total() int { return u.InputTokens + u.OutputTokens }
 
 // --- Streaming Types ---
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -181,14 +181,6 @@ type Usage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 }
 
-// Total returns InputTokens + OutputTokens — a coarse aggregate used only for
-// run summaries and progress display, never for billing (cost estimates use the
-// full per-bucket breakdown, cache counters included). Cache counters are not
-// added here, preserving the historical "total" semantics; note this can
-// undercount real prompt size on providers (e.g. Anthropic) whose InputTokens
-// excludes the cache-creation/read buckets.
-func (u Usage) Total() int { return u.InputTokens + u.OutputTokens }
-
 // --- Streaming Types ---
 
 // ChunkType represents the type of a stream chunk from a provider.

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -376,10 +376,10 @@ func (r *Recorder) onPostInfer(ev core.Event) {
 			StopReason: string(resp.StopReason),
 			LatencyMs:  latencyMs,
 			Usage: &transcript.InferenceUsage{
-				InputTokens:       resp.TokensIn,
-				OutputTokens:      resp.TokensOut,
-				CacheCreateTokens: resp.CacheCreateTokens,
-				CacheReadTokens:   resp.CacheReadTokens,
+				InputTokens:              resp.InputTokens,
+				OutputTokens:             resp.OutputTokens,
+				CacheCreationInputTokens: resp.CacheCreationInputTokens,
+				CacheReadInputTokens:     resp.CacheReadInputTokens,
 			},
 		},
 	})

--- a/internal/session/recorder_order_test.go
+++ b/internal/session/recorder_order_test.go
@@ -44,7 +44,7 @@ func TestRecorderWritesMessageBeforeInference(t *testing.T) {
 
 	// Assistant reply appends after PostInfer.
 	rec.OnAgentEvent(core.Event{Type: core.PostInfer, Source: "main", Data: &core.InferResponse{
-		StopReason: core.StopEndTurn, TokensIn: 10, TokensOut: 5,
+		StopReason: core.StopEndTurn, InputTokens: 10, OutputTokens: 5,
 	}})
 	assistantMsg := core.Message{ID: "m2", Role: core.RoleAssistant, Content: "hi"}
 	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Source: "main", Data: assistantMsg})

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -38,7 +38,7 @@ func TestRecorderWritesRequestedAndRespondedPerTurn(t *testing.T) {
 		SystemDigest: "sha256:sys", ToolsDigest: "sha256:tools", MessageIDs: []string{"m1", "m2"},
 	}})
 	rec.OnAgentEvent(core.Event{Type: core.PostInfer, Source: "main", Data: &core.InferResponse{
-		StopReason: core.StopEndTurn, TokensIn: 42, TokensOut: 8, CacheReadTokens: 10,
+		StopReason: core.StopEndTurn, InputTokens: 42, OutputTokens: 8, CacheReadInputTokens: 10,
 	}})
 
 	tx, err := fs.Load(context.Background(), "sess-1")
@@ -93,7 +93,7 @@ func TestRecorderWritesRequestedAndRespondedPerTurn(t *testing.T) {
 	if resp.StopReason != string(core.StopEndTurn) {
 		t.Fatalf("responded.StopReason = %q", resp.StopReason)
 	}
-	if resp.Usage == nil || resp.Usage.InputTokens != 42 || resp.Usage.OutputTokens != 8 || resp.Usage.CacheReadTokens != 10 {
+	if resp.Usage == nil || resp.Usage.InputTokens != 42 || resp.Usage.OutputTokens != 8 || resp.Usage.CacheReadInputTokens != 10 {
 		t.Fatalf("responded.Usage = %+v", resp.Usage)
 	}
 }

--- a/internal/session/transcript/fs_store_impl_test.go
+++ b/internal/session/transcript/fs_store_impl_test.go
@@ -318,7 +318,7 @@ func TestFileStoreWritesExpectedEventShapes(t *testing.T) {
 			Turn:       1,
 			StopReason: "end_turn",
 			LatencyMs:  1234,
-			Usage:      &InferenceUsage{InputTokens: 100, OutputTokens: 20, CacheReadTokens: 10},
+			Usage:      &InferenceUsage{InputTokens: 100, OutputTokens: 20, CacheReadInputTokens: 10},
 		},
 	}); err != nil {
 		t.Fatalf("AppendInference(response): %v", err)

--- a/internal/session/transcript/records.go
+++ b/internal/session/transcript/records.go
@@ -145,10 +145,10 @@ type InferenceRecord struct {
 }
 
 type InferenceUsage struct {
-	InputTokens       int `json:"inputTokens"`
-	OutputTokens      int `json:"outputTokens"`
-	CacheCreateTokens int `json:"cacheCreateTokens,omitempty"`
-	CacheReadTokens   int `json:"cacheReadTokens,omitempty"`
+	InputTokens              int `json:"inputTokens"`
+	OutputTokens             int `json:"outputTokens"`
+	CacheCreationInputTokens int `json:"cacheCreateTokens,omitempty"`
+	CacheReadInputTokens     int `json:"cacheReadTokens,omitempty"`
 }
 
 // SystemSectionRecord carries the payload for system.section.added /

--- a/internal/subagent/adapter.go
+++ b/internal/subagent/adapter.go
@@ -45,18 +45,19 @@ func (a *ExecutorAdapter) Run(ctx context.Context, req tool.AgentExecRequest) (*
 	}
 
 	return &tool.AgentExecResult{
-		AgentID:     result.AgentID,
-		AgentName:   result.AgentName,
-		OutputFile:  result.TranscriptPath,
-		Model:       result.Model,
-		Success:     result.Success,
-		Content:     result.Content,
-		StepCount:   result.StepCount,
-		ToolUses:    result.ToolUses,
-		TotalTokens: result.TokenUsage.Total(),
-		Duration:    result.Duration,
-		Progress:    result.Progress,
-		Error:       result.Error,
+		AgentID:           result.AgentID,
+		AgentName:         result.AgentName,
+		OutputFile:        result.TranscriptPath,
+		Model:             result.Model,
+		Success:           result.Success,
+		Content:           result.Content,
+		StepCount:         result.StepCount,
+		ToolUses:          result.ToolUses,
+		TotalInputTokens:  result.TokenUsage.InputTokens,
+		TotalOutputTokens: result.TokenUsage.OutputTokens,
+		Duration:          result.Duration,
+		Progress:          result.Progress,
+		Error:             result.Error,
 	}, nil
 }
 

--- a/internal/subagent/adapter.go
+++ b/internal/subagent/adapter.go
@@ -53,7 +53,7 @@ func (a *ExecutorAdapter) Run(ctx context.Context, req tool.AgentExecRequest) (*
 		Content:     result.Content,
 		StepCount:   result.StepCount,
 		ToolUses:    result.ToolUses,
-		TotalTokens: result.TokenUsage.TotalTokens,
+		TotalTokens: result.TokenUsage.Total(),
 		Duration:    result.Duration,
 		Progress:    result.Progress,
 		Error:       result.Error,

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -167,7 +167,7 @@ func (e *Executor) RunBackground(req AgentRequest) (*task.AgentTask, error) {
 
 		agentTask.SetIdentity(req.Agent, result.AgentID)
 		agentTask.SetOutputFile(result.TranscriptPath)
-		agentTask.UpdateProgress(result.StepCount, result.TokenUsage.TotalTokens)
+		agentTask.UpdateProgress(result.StepCount, result.TokenUsage.Total())
 
 		if result.Success {
 			agentTask.Complete(nil)

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -167,7 +167,7 @@ func (e *Executor) RunBackground(req AgentRequest) (*task.AgentTask, error) {
 
 		agentTask.SetIdentity(req.Agent, result.AgentID)
 		agentTask.SetOutputFile(result.TranscriptPath)
-		agentTask.UpdateProgress(result.StepCount, result.TokenUsage.Total())
+		agentTask.UpdateProgress(result.StepCount, result.TokenUsage.InputTokens+result.TokenUsage.OutputTokens)
 
 		if result.Success {
 			agentTask.Complete(nil)

--- a/internal/subagent/executor_run.go
+++ b/internal/subagent/executor_run.go
@@ -40,8 +40,8 @@ func (r *preparedRun) recordUsage(resp *core.InferResponse) {
 	if r.req.OnProgress == nil || resp == nil {
 		return
 	}
-	r.inputTokens += resp.TokensIn
-	r.outputTokens += resp.TokensOut
+	r.inputTokens += resp.InputTokens
+	r.outputTokens += resp.OutputTokens
 	if r.inputTokens > 0 || r.outputTokens > 0 {
 		r.sendProgress(formatUsageProgress(r.inputTokens, r.outputTokens))
 	}
@@ -136,8 +136,8 @@ func (e *Executor) logRunCompletion(run *preparedRun, result *core.Result, succe
 		zap.String("agent", run.cfg.displayName),
 		zap.String("stopReason", string(result.StopReason)),
 		zap.Int("steps", result.Steps),
-		zap.Int("inputTokens", result.TokensIn),
-		zap.Int("outputTokens", result.TokensOut),
+		zap.Int("inputTokens", result.InputTokens),
+		zap.Int("outputTokens", result.OutputTokens),
 	}
 	if success {
 		log.Logger().Info("Agent completed", logFields...)
@@ -168,7 +168,7 @@ func (e *Executor) buildAgentResult(run *preparedRun, result *core.Result) *Agen
 		Messages:       result.Messages,
 		StepCount:      result.Steps,
 		ToolUses:       result.ToolUses,
-		TokenUsage:     llm.TokenUsage{InputTokens: result.TokensIn, OutputTokens: result.TokensOut, TotalTokens: result.TokensIn + result.TokensOut},
+		TokenUsage:     llm.Usage{InputTokens: result.InputTokens, OutputTokens: result.OutputTokens},
 		Duration:       time.Since(run.startedAt),
 		Progress:       append([]string(nil), run.progress...),
 		Error:          errMsg,
@@ -188,7 +188,7 @@ func (e *Executor) buildCancelledAgentResult(run *preparedRun, result *core.Resu
 		Messages:   result.Messages,
 		StepCount:  result.Steps,
 		ToolUses:   result.ToolUses,
-		TokenUsage: llm.TokenUsage{InputTokens: result.TokensIn, OutputTokens: result.TokensOut, TotalTokens: result.TokensIn + result.TokensOut},
+		TokenUsage: llm.Usage{InputTokens: result.InputTokens, OutputTokens: result.OutputTokens},
 		Duration:   time.Since(run.startedAt),
 		Progress:   append([]string(nil), run.progress...),
 		Error:      "agent cancelled",

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -357,7 +357,7 @@ type AgentResult struct {
 	Messages       []core.Message
 	StepCount      int
 	ToolUses       int
-	TokenUsage     llm.TokenUsage
+	TokenUsage     llm.Usage
 	Duration       time.Duration
 	Progress       []string
 	Error          string

--- a/internal/tool/agent.go
+++ b/internal/tool/agent.go
@@ -81,18 +81,19 @@ type AgentExecRequest struct {
 
 // AgentExecResult contains the result of agent execution.
 type AgentExecResult struct {
-	AgentID     string
-	AgentName   string
-	OutputFile  string
-	Model       string
-	Success     bool
-	Content     string
-	StepCount   int
-	ToolUses    int
-	TotalTokens int
-	Duration    time.Duration
-	Progress    []string
-	Error       string
+	AgentID           string
+	AgentName         string
+	OutputFile        string
+	Model             string
+	Success           bool
+	Content           string
+	StepCount         int
+	ToolUses          int
+	TotalInputTokens  int
+	TotalOutputTokens int
+	Duration          time.Duration
+	Progress          []string
+	Error             string
 }
 
 // AgentTaskInfo contains info about a background agent task.

--- a/internal/tool/agent/agent.go
+++ b/internal/tool/agent/agent.go
@@ -262,10 +262,10 @@ func buildAgentHookResponse(result *tool.AgentExecResult, agentType, prompt stri
 		"status":            status,
 		"prompt":            prompt,
 		"totalDurationMs":   result.Duration.Milliseconds(),
-		"totalTokens":       result.TotalTokens,
 		"totalToolUseCount": result.ToolUses,
 		"usage": map[string]any{
-			"total_tokens": result.TotalTokens,
+			"total_input_tokens":  result.TotalInputTokens,
+			"total_output_tokens": result.TotalOutputTokens,
 		},
 	}
 }

--- a/internal/tool/agent/agent_test_helpers_test.go
+++ b/internal/tool/agent/agent_test_helpers_test.go
@@ -17,14 +17,15 @@ func (s *stubSendMessageExecutor) Run(ctx context.Context, req tool.AgentExecReq
 	s.lastRun = req
 	if s.runResult == nil {
 		s.runResult = &tool.AgentExecResult{
-			AgentID:     "agent-resumed-2",
-			AgentName:   "Explore",
-			Model:       "sonnet",
-			Success:     true,
-			Content:     "done",
-			StepCount:   2,
-			ToolUses:    1,
-			TotalTokens: 42,
+			AgentID:           "agent-resumed-2",
+			AgentName:         "Explore",
+			Model:             "sonnet",
+			Success:           true,
+			Content:           "done",
+			StepCount:         2,
+			ToolUses:          1,
+			TotalInputTokens:  30,
+			TotalOutputTokens: 12,
 		}
 	}
 	return s.runResult, nil

--- a/internal/tool/agent/continuation.go
+++ b/internal/tool/agent/continuation.go
@@ -74,8 +74,8 @@ func formatForegroundAgentResult(agentType string, result *tool.AgentExecResult,
 	}
 
 	var outputBuilder strings.Builder
-	fmt.Fprintf(&outputBuilder, "Agent: %s\nModel: %s\nSteps: %d\nToolUses: %d\nTokens: %d\nDuration: %s\n",
-		displayName, result.Model, result.StepCount, result.ToolUses, result.TotalTokens, toolresult.FormatDuration(agentDuration))
+	fmt.Fprintf(&outputBuilder, "Agent: %s\nModel: %s\nSteps: %d\nToolUses: %d\nTokens: in=%d out=%d\nDuration: %s\n",
+		displayName, result.Model, result.StepCount, result.ToolUses, result.TotalInputTokens, result.TotalOutputTokens, toolresult.FormatDuration(agentDuration))
 	if result.AgentID != "" {
 		fmt.Fprintf(&outputBuilder, "AgentID: %s\n", result.AgentID)
 	}

--- a/tests/integration/loop/loop_test.go
+++ b/tests/integration/loop/loop_test.go
@@ -28,7 +28,7 @@ func TestAgent_SingleTurn_EndTurn(t *testing.T) {
 	if result.Steps != 1 {
 		t.Errorf("expected 1 step, got %d", result.Steps)
 	}
-	if result.TokensIn == 0 {
+	if result.InputTokens == 0 {
 		t.Error("expected non-zero input tokens")
 	}
 }
@@ -182,10 +182,10 @@ func TestAgent_TokenAccumulation(t *testing.T) {
 
 	// Each of the first 2 responses has 10+5 usage, third has 20+10
 	// Total: 10+10+20=40 input, 5+5+10=20 output
-	if result.TokensIn != 40 {
-		t.Errorf("expected 40 input tokens, got %d", result.TokensIn)
+	if result.InputTokens != 40 {
+		t.Errorf("expected 40 input tokens, got %d", result.InputTokens)
 	}
-	if result.TokensOut != 20 {
-		t.Errorf("expected 20 output tokens, got %d", result.TokensOut)
+	if result.OutputTokens != 20 {
+		t.Errorf("expected 20 output tokens, got %d", result.OutputTokens)
 	}
 }

--- a/tests/integration/testutil/core_helpers.go
+++ b/tests/integration/testutil/core_helpers.go
@@ -33,12 +33,12 @@ func (f *FakeLLM) Infer(_ context.Context, _ core.InferRequest) (<-chan core.Chu
 		ch <- core.Chunk{
 			Done: true,
 			Response: &core.InferResponse{
-				Content:    resp.Content,
-				Thinking:   resp.Thinking,
-				ToolCalls:  legacyToCoreCalls(resp.ToolCalls),
-				StopReason: core.StopReason(resp.StopReason),
-				TokensIn:   resp.Usage.InputTokens,
-				TokensOut:  resp.Usage.OutputTokens,
+				Content:      resp.Content,
+				Thinking:     resp.Thinking,
+				ToolCalls:    legacyToCoreCalls(resp.ToolCalls),
+				StopReason:   core.StopReason(resp.StopReason),
+				InputTokens:  resp.Usage.InputTokens,
+				OutputTokens: resp.Usage.OutputTokens,
 			},
 		}
 	}()


### PR DESCRIPTION
Two related cleanups to how token usage is modeled and surfaced.

**Unify field naming.** The four counters were spelled several ways across layers (`TokensIn`/`CacheCreateTokens` vs `InputTokens`/`CacheCreationInputTokens`), forcing field-by-field remapping at every boundary.
- One Go field set everywhere: `InputTokens`, `OutputTokens`, `CacheCreationInputTokens`, `CacheReadInputTokens`. JSON tags are unchanged, so provider-wire and session-file formats are preserved.
- Delete the redundant `llm.TokenUsage`; its derived total is now `Usage.Total()`.

**Report input/output separately.** The agent tool collapsed a run to a single total and emitted it twice in the hook response.
- `AgentExecResult` carries `TotalInputTokens`/`TotalOutputTokens`.
- Hook `usage` map reports `total_input_tokens`/`total_output_tokens`; the duplicated total is dropped.
- Run summary line shows `Tokens: in=N out=M`.