### PR TITLE
refactor(core): remove dead Message.Meta field

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -37,7 +37,7 @@ type Agent interface {
 
 	// Messages returns a snapshot of the conversation history.
 	// The returned slice is a shallow copy — do not mutate Message fields
-	// that contain maps, slices, or pointers (Meta, ToolCalls, ToolResult).
+	// that contain slices or pointers (Images, ToolCalls, ToolResult).
 	Messages() []Message
 
 	// SetMessages replaces the conversation history.

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -45,18 +45,17 @@ const (
 // agent run loop exchange, append to history, and persist. It holds no
 // UI/display state — for the rendered TUI view-model, see ChatMessage.
 type Message struct {
-	ID                string         `json:"id,omitempty"`
-	Role              Role           `json:"role"`
-	Content           string         `json:"content,omitempty"`
-	DisplayContent    string         `json:"display_content,omitempty"`
-	Images            []Image        `json:"images,omitempty"`
-	Thinking          string         `json:"thinking,omitempty"`
-	ThinkingSignature string         `json:"thinking_signature,omitempty"`
-	ToolCalls         []ToolCall     `json:"tool_calls,omitempty"`
-	ToolResult        *ToolResult    `json:"tool_result,omitempty"`
-	From              string         `json:"from,omitempty"`
-	Signal            Signal         `json:"-"`
-	Meta              map[string]any `json:"meta,omitempty"`
+	ID                string      `json:"id,omitempty"`
+	Role              Role        `json:"role"`
+	Content           string      `json:"content,omitempty"`
+	DisplayContent    string      `json:"display_content,omitempty"`
+	Images            []Image     `json:"images,omitempty"`
+	Thinking          string      `json:"thinking,omitempty"`
+	ThinkingSignature string      `json:"thinking_signature,omitempty"`
+	ToolCalls         []ToolCall  `json:"tool_calls,omitempty"`
+	ToolResult        *ToolResult `json:"tool_result,omitempty"`
+	From              string      `json:"from,omitempty"`
+	Signal            Signal      `json:"-"`
 }
 
 // ChatMessage is the TUI view-model for one conversation entry: the same


### PR DESCRIPTION
## What

Remove the unused `Meta map[string]any` field from `core.Message` and fix the `Agent.Messages()` doc comment that still listed it as a reference-typed field to guard against mutating.

## Why

Follow-up to #132, which clarified the `Message` / `ChatMessage` definitions but left `Message.Meta` in place. The field is a `map[string]any` grab-bag with **zero writes, zero reads, and no persistence** anywhere in the tree — pure noise on the central wire/agent-chain struct. Removing it sharpens the type's contract: every remaining field has a real purpose.

Verified dead across `internal/`, `cmd/`, and `tests/`:
- no `Meta:` in any `Message{...}` construction
- no `msg.Meta` / `.Meta` reads on a message
- no `"meta"` key in session persistence

## Safety

No behavior change — `Meta` was `omitempty` and never set, so serialized transcript output is byte-identical. `gofmt`, `go build ./...`, `go vet`, and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)