### PR TITLE
refactor(agent): unify duplicated AgentConfigInfo into one type

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -159,24 +159,11 @@ type agentRegistryAdapter struct {
 	reg *subagent.Registry
 }
 
-func (a *agentRegistryAdapter) ListConfigs() []input.AgentConfigInfo {
+func (a *agentRegistryAdapter) ListConfigs() []tool.AgentConfigInfo {
 	configs := a.reg.ListConfigs()
-	out := make([]input.AgentConfigInfo, len(configs))
+	out := make([]tool.AgentConfigInfo, len(configs))
 	for i, cfg := range configs {
-		var tools []string
-		if cfg.AllowTools != nil {
-			tools = cfg.AllowTools.DisplayNames()
-		}
-		out[i] = input.AgentConfigInfo{
-			Name:           cfg.Name,
-			Description:    cfg.Description,
-			Color:          cfg.Color,
-			Model:          cfg.Model,
-			PermissionMode: string(cfg.PermissionMode),
-			Tools:          tools,
-			SourceFile:     cfg.SourceFile,
-			Source:         cfg.Source,
-		}
+		out[i] = subagent.ToAgentConfigInfo(cfg)
 	}
 	return out
 }

--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -8,25 +8,12 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/genai-io/san/internal/app/kit"
+	"github.com/genai-io/san/internal/tool"
 )
-
-// AgentConfigInfo holds display info for a single agent configuration.
-type AgentConfigInfo struct {
-	Name           string
-	Description    string
-	Color          string
-	Model          string
-	PermissionMode string
-	Tools          []string // nil = all tools
-	SourceFile     string
-	// Source indicates where the agent definition came from:
-	// "built-in", "user", "project", or "plugin". Empty defaults to project.
-	Source string
-}
 
 // AgentRegistry provides agent display and management for the selector UI.
 type AgentRegistry interface {
-	ListConfigs() []AgentConfigInfo
+	ListConfigs() []tool.AgentConfigInfo
 	GetDisabledAt(userLevel bool) map[string]bool
 	SetEnabled(name string, enabled bool, userLevel bool) error
 }

--- a/internal/subagent/adapter.go
+++ b/internal/subagent/adapter.go
@@ -105,12 +105,24 @@ func (a *ExecutorAdapter) GetAgentConfig(agentType string) (tool.AgentConfigInfo
 		return tool.AgentConfigInfo{}, false
 	}
 
+	return ToAgentConfigInfo(config), true
+}
+
+// ToAgentConfigInfo projects an agent definition into the display info shared by
+// the Agent tool and the TUI agent selector.
+func ToAgentConfigInfo(c *AgentConfig) tool.AgentConfigInfo {
+	var tools []string
+	if c.AllowTools != nil {
+		tools = c.AllowTools.DisplayNames()
+	}
 	return tool.AgentConfigInfo{
-		Name:           config.Name,
-		Description:    config.Description,
-		Color:          config.Color,
-		Model:          config.Model,
-		PermissionMode: string(config.PermissionMode),
-		Tools:          config.AllowTools.DisplayNames(),
-	}, true
+		Name:           c.Name,
+		Description:    c.Description,
+		Color:          c.Color,
+		Model:          c.Model,
+		PermissionMode: string(c.PermissionMode),
+		Tools:          tools,
+		SourceFile:     c.SourceFile,
+		Source:         c.Source,
+	}
 }

--- a/internal/tool/agent.go
+++ b/internal/tool/agent.go
@@ -103,12 +103,18 @@ type AgentTaskInfo struct {
 	OutputFile string
 }
 
-// AgentConfigInfo contains agent configuration for display.
+// AgentConfigInfo contains agent configuration for display. It is the single
+// projection of an agent definition, shared by the Agent tool (GetAgentConfig)
+// and the TUI agent selector.
 type AgentConfigInfo struct {
 	Name           string
 	Description    string
 	Color          string
 	Model          string
 	PermissionMode string
-	Tools          []string
+	Tools          []string // nil = all tools
+	SourceFile     string
+	// Source indicates where the agent definition came from:
+	// "built-in", "user", "project", or "plugin". Empty defaults to project.
+	Source string
 }


### PR DESCRIPTION
The same agent-config display projection existed twice — `tool.AgentConfigInfo` (6 fields) and a strict superset `app/input.AgentConfigInfo` (+ `Source`/`SourceFile`) — each built by its own inline projection of `subagent.AgentConfig`. The `tool` copy was an incomplete subset that dropped provenance.

- Add `Source`/`SourceFile` to `tool.AgentConfigInfo`; it is now the single canonical type, used by both the Agent tool and the TUI agent selector.
- Add `subagent.ToAgentConfigInfo` as the one projection; `GetAgentConfig` and the selector's `ListConfigs` share it.
- Delete `app/input.AgentConfigInfo`.

Net −8 lines; build, full tests, and layercheck pass.