### PR TITLE
refactor(agent): unify duplicated AgentRequest into tool.AgentExecRequest

### DIFF
--- a/cmd/san/agent.go
+++ b/cmd/san/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/tool"
 )
 
 var agentRunOpts struct {
@@ -115,7 +116,7 @@ func runHeadlessAgent() error {
 	fmt.Printf("Prompt: %s\n", agentRunOpts.prompt)
 	fmt.Println("---")
 
-	req := subagent.AgentRequest{
+	req := tool.AgentExecRequest{
 		Agent:    agentRunOpts.agentType,
 		Prompt:   agentRunOpts.prompt,
 		Model:    agentRunOpts.model,

--- a/internal/subagent/adapter.go
+++ b/internal/subagent/adapter.go
@@ -19,27 +19,11 @@ func NewExecutorAdapter(executor *Executor) *ExecutorAdapter {
 // Verify ExecutorAdapter implements tool.AgentExecutor
 var _ tool.AgentExecutor = (*ExecutorAdapter)(nil)
 
-// Run executes an agent and returns the result
+// Run executes an agent and projects the rich AgentResult down to the
+// tool-facing AgentExecResult (flattening token usage, dropping internal
+// fields the tool layer does not need).
 func (a *ExecutorAdapter) Run(ctx context.Context, req tool.AgentExecRequest) (*tool.AgentExecResult, error) {
-	agentReq := AgentRequest{
-		Agent:       req.Agent,
-		Name:        req.Name,
-		Prompt:      req.Prompt,
-		Description: req.Description,
-		Background:  req.Background,
-		Model:       req.Model,
-		MaxSteps:    req.MaxSteps,
-		Mode:        req.Mode,
-		ResumeID:    req.ResumeID,
-		Isolation:   req.Isolation,
-		OnQuestion:  req.OnQuestion,
-	}
-
-	if req.OnProgress != nil {
-		agentReq.OnProgress = ProgressCallback(req.OnProgress)
-	}
-
-	result, err := a.Executor.Run(ctx, agentReq)
+	result, err := a.Executor.Run(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -63,20 +47,9 @@ func (a *ExecutorAdapter) Run(ctx context.Context, req tool.AgentExecRequest) (*
 
 // RunBackground executes an agent in background
 func (a *ExecutorAdapter) RunBackground(req tool.AgentExecRequest) (tool.AgentTaskInfo, error) {
-	agentReq := AgentRequest{
-		Agent:       req.Agent,
-		Name:        req.Name,
-		Prompt:      req.Prompt,
-		Description: req.Description,
-		Background:  true,
-		Model:       req.Model,
-		MaxSteps:    req.MaxSteps,
-		Mode:        req.Mode,
-		ResumeID:    req.ResumeID,
-		Isolation:   req.Isolation,
-	}
+	req.Background = true
 
-	agentTask, err := a.Executor.RunBackground(agentReq)
+	agentTask, err := a.Executor.RunBackground(req)
 	if err != nil {
 		return tool.AgentTaskInfo{}, err
 	}

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -98,7 +98,7 @@ func (e *Executor) GetParentModelID() string {
 
 // Run executes an agent request and returns the result.
 // For background agents, this should be called in a goroutine.
-func (e *Executor) Run(ctx context.Context, req AgentRequest) (*AgentResult, error) {
+func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentResult, error) {
 	run, err := e.prepareRun(req)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func (e *Executor) Run(ctx context.Context, req AgentRequest) (*AgentResult, err
 }
 
 // RunBackground executes an agent in the background and returns the task.
-func (e *Executor) RunBackground(req AgentRequest) (*task.AgentTask, error) {
+func (e *Executor) RunBackground(req tool.AgentExecRequest) (*task.AgentTask, error) {
 	config, ok := defaultRegistry.Get(req.Agent)
 	if !ok {
 		return nil, fmt.Errorf("unknown agent type: %s", req.Agent)
@@ -143,7 +143,6 @@ func (e *Executor) RunBackground(req AgentRequest) (*task.AgentTask, error) {
 		cancel,
 	)
 	agentTask.SetIdentity(req.Agent, req.ResumeID)
-	req.LiveTaskID = agentTask.GetID()
 
 	task.Default().RegisterTask(agentTask)
 
@@ -179,14 +178,14 @@ func (e *Executor) RunBackground(req AgentRequest) (*task.AgentTask, error) {
 	return agentTask, nil
 }
 
-func (e *Executor) validateRequest(req AgentRequest) error {
+func (e *Executor) validateRequest(req tool.AgentExecRequest) error {
 	if strings.TrimSpace(req.Prompt) == "" {
 		return fmt.Errorf("agent prompt cannot be empty")
 	}
 	return nil
 }
 
-func (e *Executor) prepareWorkspace(req AgentRequest) (string, func(), error) {
+func (e *Executor) prepareWorkspace(req tool.AgentExecRequest) (string, func(), error) {
 	if req.Isolation != "worktree" {
 		return e.cwd, func() {}, nil
 	}
@@ -198,7 +197,7 @@ func (e *Executor) prepareWorkspace(req AgentRequest) (string, func(), error) {
 	return result.Path, cleanup, nil
 }
 
-func (e *Executor) prepareRunConfig(req AgentRequest) (*runConfig, error) {
+func (e *Executor) prepareRunConfig(req tool.AgentExecRequest) (*runConfig, error) {
 	config, ok := defaultRegistry.Get(req.Agent)
 	if !ok {
 		return nil, fmt.Errorf("unknown agent type: %s", req.Agent)
@@ -226,7 +225,7 @@ func (e *Executor) prepareRunConfig(req AgentRequest) (*runConfig, error) {
 	}, nil
 }
 
-func (e *Executor) fireSubagentStart(req AgentRequest, agentHookID string) {
+func (e *Executor) fireSubagentStart(req tool.AgentExecRequest, agentHookID string) {
 	if e.hooks == nil {
 		return
 	}
@@ -314,7 +313,7 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	return ag, cleanup, nil
 }
 
-func (e *Executor) loadConversation(ag core.Agent, ctx context.Context, rc *runConfig, req AgentRequest) error {
+func (e *Executor) loadConversation(ag core.Agent, ctx context.Context, rc *runConfig, req tool.AgentExecRequest) error {
 	// Resume from saved session
 	if req.ResumeID != "" {
 		if err := e.resumeFromSession(ag, ctx, req.ResumeID, req.Prompt); err != nil {
@@ -359,7 +358,7 @@ func interpretStopReason(result *core.Result, maxSteps int) (success bool, errMs
 	return success, errMsg
 }
 
-func (e *Executor) fireSubagentStop(req AgentRequest, agentHookID, agentSessionID, agentTranscriptPath, resultContent string) {
+func (e *Executor) fireSubagentStop(req tool.AgentExecRequest, agentHookID, agentSessionID, agentTranscriptPath, resultContent string) {
 	if e.hooks == nil {
 		return
 	}

--- a/internal/subagent/executor_prompt.go
+++ b/internal/subagent/executor_prompt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/genai-io/san/internal/core/system"
 	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/tool"
 )
 
 // buildBrief renders the SubagentBrief consumed by system.WithSubagentIdentity.
@@ -148,14 +149,14 @@ func formatAgentProgress(params map[string]any) string {
 	return fmt.Sprintf("Agent - %s: %s", agentType, desc)
 }
 
-func displayNameFor(config *AgentConfig, req AgentRequest) string {
+func displayNameFor(config *AgentConfig, req tool.AgentExecRequest) string {
 	if req.Name != "" {
 		return req.Name
 	}
 	return displayAgentName(config.Name, requestPermissionMode(config, req))
 }
 
-func requestPermissionMode(config *AgentConfig, req AgentRequest) PermissionMode {
+func requestPermissionMode(config *AgentConfig, req tool.AgentExecRequest) PermissionMode {
 	if req.Mode != "" {
 		return NormalizePermissionMode(req.Mode)
 	}

--- a/internal/subagent/executor_run.go
+++ b/internal/subagent/executor_run.go
@@ -8,11 +8,12 @@ import (
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
+	"github.com/genai-io/san/internal/tool"
 	"go.uber.org/zap"
 )
 
 type preparedRun struct {
-	req              AgentRequest
+	req              tool.AgentExecRequest
 	cfg              *runConfig
 	cwd              string
 	startedAt        time.Time
@@ -47,7 +48,7 @@ func (r *preparedRun) recordUsage(resp *core.InferResponse) {
 	}
 }
 
-func (e *Executor) prepareRun(req AgentRequest) (*preparedRun, error) {
+func (e *Executor) prepareRun(req tool.AgentExecRequest) (*preparedRun, error) {
 	if err := e.validateRequest(req); err != nil {
 		return nil, err
 	}

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/skill"
+	"github.com/genai-io/san/internal/tool"
 )
 
 type stubSubagentSessionStore struct {
@@ -43,7 +44,7 @@ func (s *stubSubagentSessionStore) LoadSubagentMessages(agentID string) ([]core.
 func TestPrepareRunConfigRespectsOverrides(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
 
-	rc, err := executor.prepareRunConfig(AgentRequest{
+	rc, err := executor.prepareRunConfig(tool.AgentExecRequest{
 		Agent:    "general-purpose",
 		Name:     "Scout",
 		Model:    "override-model",
@@ -74,7 +75,7 @@ func TestPrepareRunConfigRespectsOverrides(t *testing.T) {
 func TestPrepareRunConfigDoesNotLowerBuiltinMaxSteps(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
 
-	rc, err := executor.prepareRunConfig(AgentRequest{
+	rc, err := executor.prepareRunConfig(tool.AgentExecRequest{
 		Agent:    "general-purpose",
 		MaxSteps: 20,
 	})
@@ -127,7 +128,7 @@ func TestShouldRetryWithParentModelOnlyForMissingDifferentModel(t *testing.T) {
 func TestBuildCancelledAgentResultUsesPreparedRunMetadata(t *testing.T) {
 	executor := &Executor{}
 	run := &preparedRun{
-		req: AgentRequest{Agent: "general-purpose"},
+		req: tool.AgentExecRequest{Agent: "general-purpose"},
 		cfg: &runConfig{
 			displayName: "Scout",
 			modelID:     "test-model",

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
-	"github.com/genai-io/san/internal/tool"
 	"gopkg.in/yaml.v3"
 )
 
@@ -323,26 +322,6 @@ func (c *AgentConfig) GetSystemPrompt() string {
 		}
 	})
 	return c.SystemPrompt
-}
-
-// ProgressCallback is called when the agent makes progress
-type ProgressCallback func(msg string)
-
-// AgentRequest represents a request to spawn an agent
-type AgentRequest struct {
-	Agent       string
-	Name        string
-	Prompt      string
-	Description string
-	Background  bool
-	Model       string
-	MaxSteps    int
-	Mode        string
-	ResumeID    string
-	LiveTaskID  string
-	Isolation   string
-	OnProgress  ProgressCallback
-	OnQuestion  tool.AskQuestionFunc
 }
 
 // AgentResult contains the result of an agent execution

--- a/tests/integration/agent/agent_test.go
+++ b/tests/integration/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
+	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
 	_ "github.com/genai-io/san/internal/tool/registry"
 	"github.com/genai-io/san/tests/integration/testutil"
@@ -31,7 +32,7 @@ func TestAgent_GeneralExploreMode(t *testing.T) {
 	}
 
 	executor := subagent.NewExecutor(mp, t.TempDir(), "fake-model", nil)
-	result, err := executor.Run(context.Background(), subagent.AgentRequest{
+	result, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:       "general-purpose",
 		Mode:        "explore",
 		Prompt:      "Find all Go files",
@@ -56,7 +57,7 @@ func TestAgent_UnknownAgent(t *testing.T) {
 	mp := &testutil.MockProvider{}
 	executor := subagent.NewExecutor(mp, t.TempDir(), "fake-model", nil)
 
-	_, err := executor.Run(context.Background(), subagent.AgentRequest{
+	_, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "NonExistent",
 		Prompt: "do something",
 	})
@@ -80,7 +81,7 @@ func TestAgent_MaxStepsRespected(t *testing.T) {
 		&testutil.MockProvider{Responses: responses},
 		t.TempDir(), "fake-model", nil,
 	)
-	result, err := executor.Run(context.Background(), subagent.AgentRequest{
+	result, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "general-purpose",
 		Prompt: "keep going",
 	})
@@ -121,7 +122,7 @@ func TestAgent_ModelResolution(t *testing.T) {
 					executor.GetParentModelID(), tt.parentModel)
 			}
 
-			_, err := executor.Run(context.Background(), subagent.AgentRequest{
+			_, err := executor.Run(context.Background(), tool.AgentExecRequest{
 				Agent:  "general-purpose",
 				Prompt: "test",
 				Model:  tt.reqModel,
@@ -179,7 +180,7 @@ func TestAgent_ExploreMode_BlocksWrites(t *testing.T) {
 	}
 
 	executor := subagent.NewExecutor(mp, t.TempDir(), "fake-model", nil)
-	result, err := executor.Run(context.Background(), subagent.AgentRequest{
+	result, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "general-purpose",
 		Mode:   "explore",
 		Prompt: "try to write a file",
@@ -242,7 +243,7 @@ func TestAgent_SubagentHooks_Fire(t *testing.T) {
 	}
 
 	executor := subagent.NewExecutor(mp, tmpDir, "fake-model", engine)
-	_, err := executor.Run(context.Background(), subagent.AgentRequest{
+	_, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "general-purpose",
 		Prompt: "test hooks",
 	})
@@ -282,7 +283,7 @@ func TestAgent_BackgroundExecution(t *testing.T) {
 	}
 
 	executor := subagent.NewExecutor(mp, t.TempDir(), "fake-model", nil)
-	agentTask, err := executor.RunBackground(subagent.AgentRequest{
+	agentTask, err := executor.RunBackground(tool.AgentExecRequest{
 		Agent:       "general-purpose",
 		Prompt:      "background task",
 		Description: "bg test",
@@ -333,7 +334,7 @@ func TestAgent_OnProgressReceivesToolUpdates(t *testing.T) {
 
 	executor := subagent.NewExecutor(mp, tmpDir, "fake-model", nil)
 	var progress []string
-	result, err := executor.Run(context.Background(), subagent.AgentRequest{
+	result, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "general-purpose",
 		Mode:   "explore",
 		Prompt: "inspect the readme",


### PR DESCRIPTION
`subagent.AgentRequest` was a field-for-field copy of `tool.AgentExecRequest`: the adapter copied every field with no transformation, the only extra field (`LiveTaskID`) was written but never read, and `ProgressCallback` was identical to `tool.ProgressFunc`. Continues the agent-type unification from #138.

- Delete `subagent.AgentRequest` and `ProgressCallback`; the `Executor` now consumes `tool.AgentExecRequest` directly (subagent already depends on `tool`).
- Drop the dead `LiveTaskID` field; collapse the adapter's `Run`/`RunBackground` from field-by-field copies to pass-throughs.
- Keep the `AgentResult → tool.AgentExecResult` projection: it does real work (flattens `llm.Usage`, maps `TranscriptPath`, drops internal `Messages`/`Summary`) and keeps `tool` from importing `llm`.

Net −44 lines; build, vet, and full tests pass.