### PR TITLE
refactor(core): remove dead Config.Color / agent.color field

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -109,7 +109,6 @@ type Config struct {
 	System            System                                                    // required: system prompt layers
 	Tools             Tools                                                     // required: available tools (wrap with tool.WithPermission for permission)
 	AgentType         string                                                    // optional: agent type identifier for hook events
-	Color             string                                                    // optional: display color for TUI (e.g. "#ff6600", "blue")
 	CompactFunc       func(ctx context.Context, msgs []Message) (string, error) // optional: summarize messages for compaction
 	CWD               string
 	MaxSteps          int // max LLM inference steps per turn, 0 = unlimited
@@ -150,7 +149,6 @@ func NewAgent(cfg Config) Agent {
 	a := &agent{
 		id:                cfg.ID,
 		agentType:         cfg.AgentType,
-		color:             cfg.Color,
 		system:            cfg.System,
 		tools:             cfg.Tools,
 		compactFunc:       cfg.CompactFunc,

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -18,7 +18,6 @@ import (
 type agent struct {
 	id                string
 	agentType         string
-	color             string
 	system            System
 	tools             Tools
 	compactFunc       func(ctx context.Context, msgs []Message) (string, error)


### PR DESCRIPTION
`core.Config.Color` carried an `// optional: display color for TUI` comment but no caller ever set it; it was only copied into the unexported `agent.color`, which is never read anywhere. The TUI sources agent colors from the agent config (`app/view.go`), not from `core.Agent`. A write-only field with a misleading comment is worse than none — drop both fields and the assignment.

Net −3 lines; build, vet, and full tests pass.