### PR TITLE
refactor(app): drop duplicate conv.OperationMode, use setting.OperationMode

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -12,16 +12,8 @@ import (
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/tool"
-)
-
-// OperationMode mirrors OperationMode to avoid importing setting in the render layer.
-type OperationMode int
-
-const (
-	ModeNormal OperationMode = iota
-	ModeAutoAccept
-	ModeBypassPermissions
 )
 
 const (
@@ -38,7 +30,7 @@ const (
 
 // OperationModeParams holds the parameters needed for rendering mode status.
 type OperationModeParams struct {
-	Mode             OperationMode
+	Mode             setting.OperationMode
 	InputTokens      int
 	OutputTokens     int
 	InputLimit       int
@@ -140,16 +132,16 @@ func compactStatusHint(percent float64) string {
 }
 
 // RenderOperationModeIndicator returns the mode status indicator for auto-accept or bypass mode.
-func RenderOperationModeIndicator(mode OperationMode) string {
+func RenderOperationModeIndicator(mode setting.OperationMode) string {
 	var icon, label string
 	var color lipgloss.TerminalColor
 
 	switch mode {
-	case ModeAutoAccept:
+	case setting.ModeAutoAccept:
 		icon = "⏵⏵"
 		label = " accept edits on"
 		color = kit.CurrentTheme.Success
-	case ModeBypassPermissions:
+	case setting.ModeBypassPermissions:
 		icon = "⏵⏵"
 		label = " bypass permissions on"
 		color = kit.CurrentTheme.Error

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -236,7 +236,7 @@ func (m model) renderModeStatus() string {
 		}
 	}
 	return conv.RenderModeStatus(conv.OperationModeParams{
-		Mode:             conv.OperationMode(m.env.OperationMode),
+		Mode:             m.env.OperationMode,
 		InputTokens:      m.env.InputTokens,
 		OutputTokens:     m.env.OutputTokens,
 		InputLimit:       kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),


### PR DESCRIPTION
The render layer (`internal/app/conv`) kept its own `OperationMode` enum "to avoid importing setting" — but it had already drifted (3 values vs `setting`'s 4, missing `ModeDontAsk`), and `conv` already imports `core`/`llm`/`tool`. `setting` does not import `app`, so there is no cycle.

- Delete `conv.OperationMode` and its constants; `OperationModeParams.Mode` and `RenderOperationModeIndicator` now take `setting.OperationMode`.
- Drop the `conv.OperationMode(...)` cast at the `view.go` call site.

Net negative; build, vet, and full tests pass.