### PR TITLE
refactor(setting): remove dead SessionPermissions.IsBypassAvailable field

### DIFF
--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -210,9 +210,6 @@ type SessionPermissions struct {
 	// Set automatically when entering AutoAccept mode.
 	WorkingDirectories []string
 
-	// IsBypassAvailable controls whether BypassPermissions mode can be entered.
-	IsBypassAvailable bool
-
 	// ShouldAvoidPrompts is set for headless/async subagents that cannot
 	// show interactive dialogs. When true, ask → deny automatically.
 	ShouldAvoidPrompts bool


### PR DESCRIPTION
`SessionPermissions.IsBypassAvailable` carries a comment claiming it "controls whether BypassPermissions mode can be entered", but nothing ever sets or reads it (no json tag either — it is a pure internal field). Bypass availability is gated elsewhere. A dead field with a misleading comment is worse than none.

Net −3 lines; build and full tests pass.