### PR TITLE
refactor(app): rename compaction Focus field to SummaryFocus

### DIFF
--- a/internal/app/conv/compact.go
+++ b/internal/app/conv/compact.go
@@ -32,7 +32,7 @@ const PhaseSummarizing = "Summarizing conversation history"
 
 type CompactState struct {
 	Active            bool
-	Focus             string
+	SummaryFocus      string
 	LastResult        string
 	LastError         bool
 	Phase             string
@@ -42,7 +42,7 @@ type CompactState struct {
 
 func (c *CompactState) Reset() {
 	c.Active = false
-	c.Focus = ""
+	c.SummaryFocus = ""
 	c.LastResult = ""
 	c.LastError = false
 	c.Phase = ""
@@ -57,7 +57,7 @@ func (c *CompactState) ClearResult() {
 
 func (c *CompactState) Complete(result string, isError bool) {
 	c.Active = false
-	c.Focus = ""
+	c.SummaryFocus = ""
 	c.LastResult = result
 	c.LastError = isError
 	c.Phase = ""
@@ -121,22 +121,22 @@ func RenderCompactStatus(_ int, spinnerView string, state CompactState) string {
 
 // CompactRequest holds all parameters needed to perform a conversation compaction.
 type CompactRequest struct {
-	Ctx        context.Context
-	Client     *llm.Client
-	Messages   []core.Message
-	Focus      string
-	HookEngine hook.Handler
-	Trigger    string
+	Ctx          context.Context
+	Client       *llm.Client
+	Messages     []core.Message
+	SummaryFocus string
+	HookEngine   hook.Handler
+	Trigger      string
 }
 
 func CompactCmd(req CompactRequest) tea.Cmd {
 	return func() tea.Msg {
 		ctx := req.Ctx
-		focus := req.Focus
+		focus := req.SummaryFocus
 		if req.HookEngine != nil {
 			outcome := req.HookEngine.Execute(ctx, hook.PreCompact, hook.HookInput{
 				Trigger:            req.Trigger,
-				CustomInstructions: req.Focus,
+				CustomInstructions: req.SummaryFocus,
 			})
 			if outcome.AdditionalContext != "" {
 				if focus != "" {

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -650,10 +650,10 @@ func (c *SlashCommandController) handleCompactCommand(_ context.Context, args st
 		return "Cannot compact while streaming.", nil, nil
 	}
 	c.env.Conversation.Compact.Active = true
-	c.env.Conversation.Compact.Focus = strings.TrimSpace(args)
+	c.env.Conversation.Compact.SummaryFocus = strings.TrimSpace(args)
 	c.env.Conversation.Compact.Phase = conv.PhaseSummarizing
 	c.env.Conversation.Compact.Count = len(c.env.Conversation.ConvertToProvider())
-	return "", tea.Batch(c.env.SpinnerTickCmd(), conv.CompactCmd(c.env.BuildCompactRequest(c.env.Conversation.Compact.Focus, "manual"))), nil
+	return "", tea.Batch(c.env.SpinnerTickCmd(), conv.CompactCmd(c.env.BuildCompactRequest(c.env.Conversation.Compact.SummaryFocus, "manual"))), nil
 }
 
 func lookupSkill(svc *skill.Registry, cmd string) (*skill.Skill, bool) {

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -25,12 +25,12 @@ func (m *model) BuildCompactRequest(focus, trigger string) conv.CompactRequest {
 		hookEngine = m.services.Hook
 	}
 	return conv.CompactRequest{
-		Ctx:        context.Background(),
-		Client:     m.buildLLMClient(),
-		Messages:   m.conv.ConvertToProvider(),
-		Focus:      focus,
-		HookEngine: hookEngine,
-		Trigger:    trigger,
+		Ctx:          context.Background(),
+		Client:       m.buildLLMClient(),
+		Messages:     m.conv.ConvertToProvider(),
+		SummaryFocus: focus,
+		HookEngine:   hookEngine,
+		Trigger:      trigger,
 	}
 }
 


### PR DESCRIPTION
`CompactState.Focus` / `CompactRequest.Focus` hold the optional `/compact` emphasis text (the prompt appends "Focus the summary on: X"). Rename to `SummaryFocus` to say exactly what it is and avoid confusion with a UI "focus".

The hook-boundary mapping stays as `CustomInstructions: req.SummaryFocus` — that is the correct domain→hook-protocol translation (the `PreCompact` hook field is named `CustomInstructions`), not a duplicate to collapse.

Pure rename; build and full tests pass.