### PR TITLE
fix(ci): skip pages deploy workflow in forked repos

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'genai-io/san'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## What & why

The `Deploy landing page` workflow fails when triggered in forked repos because the `deploy-pages` action requires the `github-pages` environment and `pages`/`id-token` write permissions that are unavailable in forks. Add a guard so the job only runs on the origin repo (`genai-io/san`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

Verified the `if` condition syntax is valid GitHub Actions expression.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix:`)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)