### PR TITLE
refactor(hook): remove dead HookInput.IsInterrupt field

### DIFF
--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -51,7 +51,6 @@ type HookInput struct {
 	ToolUseID    string         `json:"tool_use_id,omitempty"`
 	ToolResponse any            `json:"tool_response,omitempty"`
 	Error        string         `json:"error,omitempty"`
-	IsInterrupt  bool           `json:"is_interrupt,omitempty"`
 	Event        string         `json:"event,omitempty"`
 
 	// PermissionRequest suggestions


### PR DESCRIPTION
`HookInput.IsInterrupt` is declared but never set or read anywhere in the codebase. Since San never populates it, the `omitempty` field is never serialized into the JSON passed to hook commands either — so it is pure contract noise. The hook input struct should only advertise fields it actually fills.

Net −1 line; build and full tests pass.