### PR TITLE
refactor(core): drop Message.From, pass agent ID to MessageEvent explicitly

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -296,7 +296,9 @@ func StopEvent(agentID string, err error) Event {
 	return Event{Type: OnStop, Source: agentID, Data: err}
 }
 func ChunkEvent(agentID string, c Chunk) Event { return Event{Type: OnChunk, Source: agentID, Data: c} }
-func MessageEvent(msg Message) Event           { return Event{Type: OnMessage, Source: msg.From, Data: msg} }
+func MessageEvent(agentID string, msg Message) Event {
+	return Event{Type: OnMessage, Source: agentID, Data: msg}
+}
 func AppendEvent(agentID string, msg Message) Event {
 	return Event{Type: OnAppend, Source: agentID, Data: msg}
 }

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -283,7 +283,7 @@ func (a *agent) ingest(ctx context.Context, msg Message) bool {
 		a.applyCompaction(ctx, msg.Content, len(a.snapshot()), "manual")
 		return false
 	}
-	a.emit(ctx, MessageEvent(msg))
+	a.emit(ctx, MessageEvent(a.id, msg))
 	if msg.Signal == "" {
 		a.append(msg)
 		return true
@@ -358,7 +358,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 
 		a.emit(ctx, PostInferEvent(a.id, resp))
 		a.append(Message{
-			Role: RoleAssistant, From: a.id,
+			Role:    RoleAssistant,
 			Content: resp.Content, Thinking: resp.Thinking,
 			ThinkingSignature: resp.ThinkingSignature,
 			ToolCalls:         resp.ToolCalls,
@@ -374,7 +374,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 				return makeResult(resp.Content, StopMaxOutputRecoveryExhausted, ""), nil
 			}
 			maxOutputRecoveryCount++
-			a.append(Message{Role: RoleUser, From: "system", Content: TruncatedResumePrompt})
+			a.append(Message{Role: RoleUser, Content: TruncatedResumePrompt})
 			continue
 		}
 
@@ -762,7 +762,7 @@ func (a *agent) snapshot() []Message {
 
 func (a *agent) appendResult(tc ToolCall, content string, isError bool) {
 	a.append(Message{
-		Role: RoleTool, From: tc.Name, Content: content,
+		Role: RoleTool, Content: content,
 		ToolResult: &ToolResult{ToolCallID: tc.ID, ToolName: tc.Name, Content: content, IsError: isError},
 	})
 }

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -54,7 +54,6 @@ type Message struct {
 	ThinkingSignature string      `json:"thinking_signature,omitempty"`
 	ToolCalls         []ToolCall  `json:"tool_calls,omitempty"`
 	ToolResult        *ToolResult `json:"tool_result,omitempty"`
-	From              string      `json:"from,omitempty"`
 	Signal            Signal      `json:"-"`
 }
 


### PR DESCRIPTION
`Message.From` was read in exactly one place — `MessageEvent`, to set `Event.Source` — and set at three core call sites; nothing outside `core` touched it. The only event path that read it (`ingest`) carried inbox messages whose `From` was usually empty, so `OnMessage.Source` was effectively blank.

- Remove the `From` field from `Message`.
- `MessageEvent` now takes the agent ID explicitly (`MessageEvent(a.id, msg)`), so an emitted message's provenance is the receiving agent, not a duplicated per-message field.

Net −1 field, +1/−1 at the call sites; build and full tests pass.