### PR TITLE
feat(release): add Windows builds to release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,14 @@ release: format
 	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(BINDIR)/$(BINARY)_darwin_arm64 $(SRCDIR)
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BINDIR)/$(BINARY)_linux_amd64 $(SRCDIR)
 	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(BINDIR)/$(BINARY)_linux_arm64 $(SRCDIR)
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BINDIR)/$(BINARY)_windows_amd64.exe $(SRCDIR)
+	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(BINDIR)/$(BINARY)_windows_arm64.exe $(SRCDIR)
 	cd $(BINDIR) && cp $(BINARY)_darwin_amd64 $(BINARY) && tar -czf $(BINARY)_darwin_amd64.tar.gz $(BINARY) && rm $(BINARY)
 	cd $(BINDIR) && cp $(BINARY)_darwin_arm64 $(BINARY) && tar -czf $(BINARY)_darwin_arm64.tar.gz $(BINARY) && rm $(BINARY)
 	cd $(BINDIR) && cp $(BINARY)_linux_amd64 $(BINARY) && tar -czf $(BINARY)_linux_amd64.tar.gz $(BINARY) && rm $(BINARY)
 	cd $(BINDIR) && cp $(BINARY)_linux_arm64 $(BINARY) && tar -czf $(BINARY)_linux_arm64.tar.gz $(BINARY) && rm $(BINARY)
+	cd $(BINDIR) && cp $(BINARY)_windows_amd64.exe $(BINARY).exe && zip $(BINARY)_windows_amd64.zip $(BINARY).exe && rm $(BINARY).exe
+	cd $(BINDIR) && cp $(BINARY)_windows_arm64.exe $(BINARY).exe && zip $(BINARY)_windows_arm64.zip $(BINARY).exe && rm $(BINARY).exe
 
 release-push:
 	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make release-push VERSION=v1.15.2"; exit 1; }


### PR DESCRIPTION
## What & why

Add Windows (amd64 + arm64) cross-compilation to the `make release` target so Windows users can download pre-built binaries without needing a Go toolchain.

Windows binaries are packaged as `.zip` archives (the expected format on Windows), alongside the existing `.tar.gz` tarballs for macOS and Linux.

Closes #48

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

Cross-compilation verified on macOS:

```bash
GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o san.exe ./cmd/san
file san.exe
# PE32+ executable (console) x86-64, for MS Windows
```

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)