### PR TITLE
feat(config): add Appearance panel to switch color theme

### DIFF
--- a/internal/app/input/config_appearance.go
+++ b/internal/app/input/config_appearance.go
@@ -1,0 +1,164 @@
+// /config Appearance panel: a radio list that switches the color theme
+// (light / dark / auto). Selecting a row applies the theme live to the
+// running TUI and persists it to the user-level settings file. Theme is a
+// personal preference, so — unlike Self-Learning — it has no project scope.
+package input
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/genai-io/san/internal/app/kit"
+	"github.com/genai-io/san/internal/setting"
+)
+
+// ThemeSavedMsg is emitted after the appearance panel persists a theme so
+// the app can refresh its settings handle and show a confirmation. The
+// theme is already applied (kit.InitTheme) and written to disk by the time
+// this fires.
+type ThemeSavedMsg struct {
+	Theme string
+}
+
+type themeChoice struct {
+	label, value, desc string
+}
+
+// appearanceThemeChoices mirrors the first-run selector (kit.RunThemeSelector)
+// so the in-app switcher and the first-run prompt offer the same options.
+var appearanceThemeChoices = []themeChoice{
+	{"Dark", "dark", "Dark background terminal"},
+	{"Light", "light", "Light background terminal"},
+	{"Auto", "auto", "Match terminal appearance automatically"},
+}
+
+type appearancePanel struct {
+	settings *setting.Settings
+
+	// baseline is the theme persisted on disk, marked "● current" in the
+	// list; cursor is the row the user is hovering. Dirty when they differ.
+	baseline string
+	cursor   int
+	// saveErr holds the last failed persist so Render can surface it inline
+	// instead of silently swallowing it. Cleared on navigation / re-entry.
+	saveErr error
+}
+
+func newAppearancePanel(settings *setting.Settings) *appearancePanel {
+	return &appearancePanel{settings: settings}
+}
+
+func (p *appearancePanel) Title() string { return "appearance" }
+
+func (p *appearancePanel) Enter() {
+	p.baseline = "auto"
+	if p.settings != nil {
+		if data := p.settings.Snapshot(); data != nil && data.Theme != "" {
+			p.baseline = data.Theme
+		}
+	}
+	p.cursor = indexOfTheme(p.baseline)
+	p.saveErr = nil
+}
+
+// Dirty reports whether the hovered row diverges from the saved theme, so
+// the shell pins the "● unsaved" indicator.
+func (p *appearancePanel) Dirty() bool {
+	return appearanceThemeChoices[p.cursor].value != p.baseline
+}
+
+func (p *appearancePanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.String() {
+	case "up", "k":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+		p.saveErr = nil
+	case "down", "j":
+		if p.cursor < len(appearanceThemeChoices)-1 {
+			p.cursor++
+		}
+		p.saveErr = nil
+	case "enter", " ":
+		value := appearanceThemeChoices[p.cursor].value
+		// Apply live so the switch is visible immediately. InitTheme only
+		// flips lipgloss's cached background flag (no terminal I/O), so it is
+		// safe to call mid-program.
+		kit.InitTheme(value)
+		if err := setting.SaveTheme(value); err != nil {
+			// Keep the on-screen theme in sync with what's actually persisted:
+			// revert the live apply and surface the error instead of leaving
+			// the UI showing a theme that won't survive a restart.
+			kit.InitTheme(p.baseline)
+			p.saveErr = err
+			return nil, false
+		}
+		p.baseline = value
+		return func() tea.Msg { return ThemeSavedMsg{Theme: value} }, true
+	}
+	return nil, false
+}
+
+func (p *appearancePanel) HintLine() string {
+	return keycap("↑↓") + " navigate  " + keycap("enter") + " apply"
+}
+
+func (p *appearancePanel) Render(width int) string {
+	var b strings.Builder
+	b.WriteString(appearanceSectionStyle.Render("COLOR THEME"))
+	b.WriteString(" ")
+	ruleLen := max(width-len("COLOR THEME")-1, 1)
+	b.WriteString(appearanceRuleStyle.Render(strings.Repeat("─", ruleLen)))
+	b.WriteString("\n\n")
+
+	for i, opt := range appearanceThemeChoices {
+		caret := "  "
+		label := appearanceLabelStyle.Render(opt.label)
+		if i == p.cursor {
+			caret = appearanceCursorStyle.Render("▸ ")
+			label = appearanceCursorStyle.Render(opt.label)
+		}
+
+		radio := appearanceRadioOffStyle.Render("○")
+		current := ""
+		if opt.value == p.baseline {
+			radio = appearanceRadioOnStyle.Render("●")
+			current = "  " + appearanceCurrentStyle.Render("current")
+		}
+
+		// Pad labels to a common column so the descriptions line up.
+		labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
+		b.WriteString(caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current)
+		b.WriteString("\n")
+	}
+
+	if p.saveErr != nil {
+		b.WriteString("\n")
+		b.WriteString(appearanceErrorStyle.Render("⚠ couldn't save theme: " + p.saveErr.Error()))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func indexOfTheme(value string) int {
+	for i, opt := range appearanceThemeChoices {
+		if opt.value == value {
+			return i
+		}
+	}
+	return 0
+}
+
+var (
+	appearanceSectionStyle  = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true)
+	appearanceRuleStyle     = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim).Faint(true)
+	appearanceCursorStyle   = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true)
+	appearanceLabelStyle    = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Text)
+	appearanceDescStyle     = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
+	appearanceCurrentStyle  = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
+	appearanceRadioOnStyle  = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
+	appearanceRadioOffStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
+	appearanceErrorStyle    = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+)

--- a/internal/app/input/config_appearance_test.go
+++ b/internal/app/input/config_appearance_test.go
@@ -1,0 +1,147 @@
+package input
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestIndexOfTheme(t *testing.T) {
+	cases := map[string]int{
+		"dark":  0,
+		"light": 1,
+		"auto":  2,
+		"":      0, // unknown / unset falls back to the first choice
+		"bogus": 0,
+	}
+	for in, want := range cases {
+		if got := indexOfTheme(in); got != want {
+			t.Errorf("indexOfTheme(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestAppearancePanelDirty confirms Dirty tracks the hovered row against the
+// saved baseline: false on the current theme, true once the cursor moves off.
+func TestAppearancePanelDirty(t *testing.T) {
+	p := newAppearancePanel(nil)
+	p.Enter() // nil settings → baseline "auto" (index 2), cursor there too
+	if p.Dirty() {
+		t.Fatalf("fresh panel parked on the saved theme should not be dirty")
+	}
+	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // auto → light
+	if !p.Dirty() {
+		t.Fatalf("after moving off the baseline the panel should be dirty")
+	}
+	p.HandleKey(tea.KeyMsg{Type: tea.KeyDown}) // light → auto
+	if p.Dirty() {
+		t.Fatalf("back on the baseline the panel should not be dirty")
+	}
+}
+
+// TestAppearancePanelEnterSavesAndEmits confirms enter persists the hovered
+// theme to the user settings file, advances the baseline, and emits a
+// ThemeSavedMsg so the app can confirm + reload.
+func TestAppearancePanelEnterSavesAndEmits(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	p := newAppearancePanel(nil)
+	p.Enter() // baseline "auto" (index 2)
+	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // auto → light
+	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // light → dark
+
+	cmd, done := p.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !done {
+		t.Fatalf("enter should dismiss the popup (done=true)")
+	}
+	if p.baseline != "dark" {
+		t.Fatalf("baseline = %q, want %q", p.baseline, "dark")
+	}
+	if p.saveErr != nil {
+		t.Fatalf("unexpected saveErr: %v", p.saveErr)
+	}
+	if cmd == nil {
+		t.Fatalf("expected a ThemeSavedMsg command")
+	}
+	msg, ok := cmd().(ThemeSavedMsg)
+	if !ok || msg.Theme != "dark" {
+		t.Fatalf("expected ThemeSavedMsg{dark}, got %#v", cmd())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".san", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings file not written: %v", err)
+	}
+	var data struct {
+		Theme string `json:"theme"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("settings file not valid JSON: %v\n%s", err, raw)
+	}
+	if data.Theme != "dark" {
+		t.Fatalf("persisted theme = %q, want %q\n%s", data.Theme, "dark", raw)
+	}
+}
+
+// TestAppearancePanelEnterSaveFailureSurfacesError confirms a failed persist is
+// surfaced (saveErr set, error shown in Render) and not silently swallowed: the
+// panel stays open, the baseline is untouched, and no ThemeSavedMsg fires.
+func TestAppearancePanelEnterSaveFailureSurfacesError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Block the write: a regular file where the .san dir must be makes the
+	// loader's MkdirAll fail.
+	if err := os.WriteFile(filepath.Join(home, ".san"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newAppearancePanel(nil)
+	p.Enter()                                // baseline "auto"
+	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // → light
+
+	cmd, done := p.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if done {
+		t.Fatalf("a failed save should keep the popup open (done=false)")
+	}
+	if cmd != nil {
+		t.Fatalf("a failed save should not emit ThemeSavedMsg, got %#v", cmd())
+	}
+	if p.saveErr == nil {
+		t.Fatalf("a failed save should set saveErr")
+	}
+	if p.baseline != "auto" {
+		t.Fatalf("baseline should be untouched on failure, got %q", p.baseline)
+	}
+	if out := p.Render(80); !strings.Contains(out, "couldn't save theme") {
+		t.Fatalf("Render should surface the save error, got:\n%s", out)
+	}
+}
+
+// TestConfigSelectorArrowSwitchesPanels confirms ←/→ cycle the registered
+// panels (and wrap), the navigation this feature swapped in for ctrl-tab.
+func TestConfigSelectorArrowSwitchesPanels(t *testing.T) {
+	c := NewConfigSelector(nil)
+	c.Enter(120, 40)
+	if got := c.ActivePanel().Title(); got != "self-learning" {
+		t.Fatalf("default panel = %q, want self-learning", got)
+	}
+	c.HandleKeypress(tea.KeyMsg{Type: tea.KeyRight})
+	if got := c.ActivePanel().Title(); got != "appearance" {
+		t.Fatalf("after right = %q, want appearance", got)
+	}
+	c.HandleKeypress(tea.KeyMsg{Type: tea.KeyRight}) // wrap
+	if got := c.ActivePanel().Title(); got != "self-learning" {
+		t.Fatalf("after right wrap = %q, want self-learning", got)
+	}
+	c.HandleKeypress(tea.KeyMsg{Type: tea.KeyLeft}) // wrap back
+	if got := c.ActivePanel().Title(); got != "appearance" {
+		t.Fatalf("after left wrap = %q, want appearance", got)
+	}
+}

--- a/internal/app/input/config_appearance_test.go
+++ b/internal/app/input/config_appearance_test.go
@@ -52,7 +52,7 @@ func TestAppearancePanelEnterSavesAndEmits(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 
 	p := newAppearancePanel(nil)
-	p.Enter() // baseline "auto" (index 2)
+	p.Enter()                                // baseline "auto" (index 2)
 	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // auto → light
 	p.HandleKey(tea.KeyMsg{Type: tea.KeyUp}) // light → dark
 

--- a/internal/app/input/config_panel.go
+++ b/internal/app/input/config_panel.go
@@ -46,9 +46,9 @@ type ConfigSavedMsg struct {
 	SavedSelfLearn setting.SelfLearnSettings
 }
 
-// ConfigSelector is the /config popup. Today only Self-Learning is
-// registered; adding a sibling panel (Provider, Permissions, Appearance,
-// …) is a one-liner in NewConfigSelector.
+// ConfigSelector is the /config popup. Self-Learning and Appearance are
+// registered today; adding a sibling panel (Provider, Permissions, …) is a
+// one-liner in NewConfigSelector.
 type ConfigSelector struct {
 	panels []Panel
 	index  int
@@ -62,7 +62,7 @@ type ConfigSelector struct {
 // preserved by the tab strip.
 func NewConfigSelector(settings *setting.Settings) ConfigSelector {
 	return ConfigSelector{
-		panels: []Panel{newSelfLearnPanel(settings)},
+		panels: []Panel{newSelfLearnPanel(settings), newAppearancePanel(settings)},
 	}
 }
 
@@ -83,8 +83,9 @@ func (c *ConfigSelector) Enter(width, height int) {
 func (c *ConfigSelector) IsActive() bool { return c.active }
 
 // HandleKeypress implements the popup interface. Esc dismisses the popup;
-// Ctrl-Tab cycles panels (when more than one is registered); everything
-// else delegates to the active panel.
+// ←/→ switch panels (when more than one is registered); everything else
+// delegates to the active panel. Panels reserve ↑/↓ for in-panel
+// navigation, so left/right stays free for the tab strip.
 func (c *ConfigSelector) HandleKeypress(msg tea.KeyMsg) tea.Cmd {
 	if !c.active {
 		return nil
@@ -93,12 +94,18 @@ func (c *ConfigSelector) HandleKeypress(msg tea.KeyMsg) tea.Cmd {
 	case "esc":
 		c.active = false
 		return nil
-	case "ctrl+tab":
+	case "left", "right":
+		// Only intercept when there's more than one panel; otherwise fall
+		// through so the active panel can handle left/right itself.
 		if len(c.panels) > 1 {
-			c.index = (c.index + 1) % len(c.panels)
+			step := 1
+			if msg.String() == "left" {
+				step = -1
+			}
+			c.index = (c.index + step + len(c.panels)) % len(c.panels)
 			c.panels[c.index].Enter()
+			return nil
 		}
-		return nil
 	}
 	p := c.activePanel()
 	if p == nil {
@@ -222,7 +229,7 @@ func (c *ConfigSelector) renderHint(panelHint string) string {
 	}
 	parts = append(parts, "esc cancel")
 	if len(c.panels) > 1 {
-		parts = append(parts, "ctrl-tab switch panel")
+		parts = append(parts, "←→ switch panel")
 	}
 	return kit.HintLine(parts...)
 }

--- a/internal/app/input/config_selflearn_test.go
+++ b/internal/app/input/config_selflearn_test.go
@@ -112,13 +112,17 @@ func TestConfigSelectorRenderShowsValidationError(t *testing.T) {
 	}
 }
 
-// TestConfigSelectorRenderShowsBreadcrumb confirms the new "/config ›
-// Self-Learning" breadcrumb makes it into the popup output.
-func TestConfigSelectorRenderShowsBreadcrumb(t *testing.T) {
+// TestConfigSelectorRenderShowsTabs confirms the "/config" header plus a tab
+// strip naming every registered panel makes it into the popup output. (With a
+// single panel the header is a breadcrumb instead; today two panels —
+// self-learning and appearance — are registered, so it renders tabs.)
+func TestConfigSelectorRenderShowsTabs(t *testing.T) {
 	c, _ := newTestPopup()
 	out := c.Render()
-	if !strings.Contains(out, "/config") || !strings.Contains(out, "self-learning") {
-		t.Fatalf("breadcrumb missing from render:\n%s", out)
+	for _, want := range []string{"/config", "self-learning", "appearance"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("header missing %q from render:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/app/kit/panel.go
+++ b/internal/app/kit/panel.go
@@ -68,7 +68,7 @@ func (p Panel) Wrap(content string) string {
 // PanelTab is one entry in the panel's tab header.
 type PanelTab struct {
 	Name    string
-	Count   int  // shown in parentheses; omitted when ShowCount is false
+	Count   int  // appended after the name when > 0; count-less tabs show just the name
 	Show    bool // when false the tab is hidden
 	Disable bool // dim/grey the tab and skip it in navigation
 }
@@ -94,7 +94,10 @@ func RenderPanelTabs(tabs []PanelTab, active int) string {
 		if !t.Show {
 			continue
 		}
-		label := fmt.Sprintf("%s %d", t.Name, t.Count)
+		label := t.Name
+		if t.Count > 0 {
+			label = fmt.Sprintf("%s %d", t.Name, t.Count)
+		}
 		switch {
 		case t.Disable:
 			parts = append(parts, disabledStyle.Render(label))

--- a/internal/app/kit/panel_test.go
+++ b/internal/app/kit/panel_test.go
@@ -1,0 +1,27 @@
+package kit
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderPanelTabsCount confirms a tab's count is rendered only when it is
+// greater than zero — so count-less tabs (e.g. /config) show just their name
+// instead of a stray "0", while count-bearing tabs (skills/agents) keep it.
+func TestRenderPanelTabsCount(t *testing.T) {
+	tabs := []PanelTab{
+		{Name: "withcount", Count: 7, Show: true},
+		{Name: "nocount", Count: 0, Show: true},
+	}
+	out := RenderPanelTabs(tabs, 0)
+
+	if !strings.Contains(out, "withcount 7") {
+		t.Fatalf("a tab with a positive count should render it, got:\n%q", out)
+	}
+	if !strings.Contains(out, "nocount") {
+		t.Fatalf("a count-less tab should still render its name, got:\n%q", out)
+	}
+	if strings.Contains(out, "0") {
+		t.Fatalf("a zero count should not be rendered, got:\n%q", out)
+	}
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -102,6 +102,16 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.wireSelfLearn(m.buildAgentParams(), "")
 		}
 		return m, nil
+	case input.ThemeSavedMsg:
+		// The panel already applied (kit.InitTheme) and persisted the theme;
+		// refresh the in-memory handle so re-opening /config reflects it.
+		if m.services.Setting != nil {
+			if err := m.services.Setting.Reload(m.env.CWD); err != nil {
+				log.Logger().Warn("reload settings after theme save failed", zap.Error(err))
+			}
+		}
+		m.conv.AddNotice("Theme set to " + msg.Theme)
+		return m, nil
 	case input.SkillCycleMsg:
 		// Why re-emit on toggle: the skills directory rides in
 		// <system-reminder>, which is only refreshed at SessionStart and


### PR DESCRIPTION
Adds a light/dark/auto theme switcher as a second `/config` panel, so the theme can be changed in-session instead of only at first launch or by editing `settings.json`.

- New **Appearance** panel: selecting a theme applies it live (`kit.InitTheme`) and persists to the user-level settings file.
- Switch between `/config` panels with **←/→** (replaces ctrl-tab).
- `PanelTab` gains a `ShowCount` flag so the count-less config tabs render just their name instead of a stray "0" (skill/agent tabs keep their counts).

<img width="3812" height="844" alt="image" src="https://github.com/user-attachments/assets/2f8696b3-6770-4e4e-bb17-ab5744f528ac" />
