### PR TITLE
fix(mimo): add provider to UI list and use secret.Resolve for base URL

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -743,6 +743,7 @@ var providerOrder = []llm.Name{
 	llm.Alibaba,
 	llm.BigModel,
 	llm.Ollama,
+	llm.Mimo,
 }
 
 // providerDisplayNames maps provider to human-readable name.
@@ -757,6 +758,7 @@ var providerDisplayNames = map[llm.Name]string{
 	llm.Alibaba:   "Alibaba",
 	llm.BigModel:  "Z.ai (GLM series)",
 	llm.Ollama:    "Ollama (Local)",
+	llm.Mimo:      "Xiaomi MiMo",
 }
 
 // Enter opens the unified model & provider kit.

--- a/internal/llm/mimo/apikey.go
+++ b/internal/llm/mimo/apikey.go
@@ -2,7 +2,6 @@ package mimo
 
 import (
 	"context"
-	"os"
 
 	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
 	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
@@ -22,7 +21,7 @@ var APIKeyMeta = llm.Meta{
 // NewAPIKeyClient creates a new Mimo client using API Key authentication.
 // The Mimo API is Anthropic-compatible. Base URL is read from MIMO_BASE_URL.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("MIMO_BASE_URL")
+	baseURL := secret.Resolve("MIMO_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://api.xiaomimimo.com/anthropic"
 	}


### PR DESCRIPTION
## What & why

The MIMO provider was registered at startup but missing from the hardcoded `providerOrder` and `providerDisplayNames` lists in the provider UI, so it never appeared in the `/model` selector.

Also switches `MIMO_BASE_URL` lookup from `os.Getenv` to `secret.Resolve` for consistency with other providers (supports both env vars and `secrets.json`).

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

Verified MIMO appears in the provider list and `secret.Resolve` correctly reads `MIMO_BASE_URL` from environment.

```bash
GOCACHE=/private/tmp/san-go-build-cache go test ./...
```

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix:`)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)