### PR TITLE
refactor(llm): derive provider list from registry

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -923,36 +923,6 @@ func providerFirstEnvVar(envVars []string) string {
 
 // ── Loading ────────────────────────────────────────────────────────────────────
 
-// providerOrder defines the display order for providers.
-var providerOrder = []llm.Name{
-	llm.Anthropic,
-	llm.OpenAI,
-	llm.Google,
-	llm.DeepSeek,
-	llm.SenseNova,
-	llm.MinMax,
-	llm.Moonshot,
-	llm.Alibaba,
-	llm.BigModel,
-	llm.Ollama,
-	llm.Mimo,
-}
-
-// providerDisplayNames maps provider to human-readable name.
-var providerDisplayNames = map[llm.Name]string{
-	llm.Anthropic: "Anthropic",
-	llm.OpenAI:    "OpenAI",
-	llm.Google:    "Google",
-	llm.DeepSeek:  "DeepSeek",
-	llm.SenseNova: "SenseNova (商汤)",
-	llm.MinMax:    "MiniMax",
-	llm.Moonshot:  "Moonshot",
-	llm.Alibaba:   "Alibaba",
-	llm.BigModel:  "Z.ai (GLM series)",
-	llm.Ollama:    "Ollama (Local)",
-	llm.Mimo:      "Xiaomi MiMo",
-}
-
 // Enter opens the unified model & provider kit.
 func (s *ProviderSelector) Enter(ctx context.Context, width, height int) (tea.Cmd, error) {
 	s.resetNavigation()
@@ -987,7 +957,7 @@ func (s *ProviderSelector) loadProviderData() (tea.Cmd, error) {
 	s.connectedProviders = nil
 	s.allProviders = nil
 
-	for _, p := range providerOrder {
+	for _, p := range llm.ProvidersByOrder() {
 		infos, ok := providersWithStatus[p]
 		if !ok || len(infos) == 0 {
 			continue
@@ -995,7 +965,7 @@ func (s *ProviderSelector) loadProviderData() (tea.Cmd, error) {
 
 		item := providerProviderItem{
 			Provider:    p,
-			DisplayName: providerDisplayNames[p],
+			DisplayName: llm.ProviderDisplayName(p),
 			AuthMethods: make([]providerAuthMethodItem, 0, len(infos)),
 		}
 
@@ -1058,7 +1028,7 @@ func (s *ProviderSelector) ensureModelProvidersExist() {
 		}
 		seen[m.ProviderName] = true
 
-		displayName := providerDisplayNames[llm.Name(m.ProviderName)]
+		displayName := llm.ProviderDisplayName(llm.Name(m.ProviderName))
 		if displayName == "" {
 			displayName = m.ProviderName
 		}

--- a/internal/llm/alibaba/apikey.go
+++ b/internal/llm/alibaba/apikey.go
@@ -35,5 +35,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Alibaba, llm.ProviderDisplay{Name: "Alibaba", Order: 80})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/anthropic/apikey.go
+++ b/internal/llm/anthropic/apikey.go
@@ -24,5 +24,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Anthropic, llm.ProviderDisplay{Name: "Anthropic", Order: 10})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/bigmodel/apikey.go
+++ b/internal/llm/bigmodel/apikey.go
@@ -35,5 +35,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 }
 
 func init() {
+	llm.RegisterProviderDisplay(llm.BigModel, llm.ProviderDisplay{Name: "Z.ai (GLM series)", Order: 90})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/deepseek/apikey.go
+++ b/internal/llm/deepseek/apikey.go
@@ -35,5 +35,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.DeepSeek, llm.ProviderDisplay{Name: "DeepSeek", Order: 40})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/google/apikey.go
+++ b/internal/llm/google/apikey.go
@@ -14,5 +14,6 @@ var APIKeyMeta = llm.Meta{
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Google, llm.ProviderDisplay{Name: "Google", Order: 30})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/mimo/apikey.go
+++ b/internal/llm/mimo/apikey.go
@@ -35,5 +35,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Mimo, llm.ProviderDisplay{Name: "Xiaomi MiMo", Order: 110})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/minmax/apikey.go
+++ b/internal/llm/minmax/apikey.go
@@ -42,5 +42,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 }
 
 func init() {
+	llm.RegisterProviderDisplay(llm.MinMax, llm.ProviderDisplay{Name: "MiniMax", Order: 60})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/moonshot/apikey.go
+++ b/internal/llm/moonshot/apikey.go
@@ -35,5 +35,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Moonshot, llm.ProviderDisplay{Name: "Moonshot", Order: 70})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -59,5 +59,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the Ollama provider
 func init() {
+	llm.RegisterProviderDisplay(llm.Ollama, llm.ProviderDisplay{Name: "Ollama (Local)", Order: 100})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/openai/apikey.go
+++ b/internal/llm/openai/apikey.go
@@ -24,5 +24,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 
 // init registers the API Key provider
 func init() {
+	llm.RegisterProviderDisplay(llm.OpenAI, llm.ProviderDisplay{Name: "OpenAI", Order: 20})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/genai-io/san/internal/secret"
@@ -16,18 +17,26 @@ type registryEntry struct {
 
 // Registry manages provider registration and discovery
 type Registry struct {
-	mu      sync.RWMutex
-	entries map[string]registryEntry // key: "provider:authMethod"
+	mu              sync.RWMutex
+	entries         map[string]registryEntry // key: "provider:authMethod"
+	providerDisplay map[Name]ProviderDisplay // provider-level UI presentation
 }
 
 // globalRegistry is the default registry instance
 var globalRegistry = &Registry{
-	entries: make(map[string]registryEntry),
+	entries:         make(map[string]registryEntry),
+	providerDisplay: make(map[Name]ProviderDisplay),
 }
 
 // Register registers a provider with its metadata and factory
 func Register(meta Meta, factory Factory) {
 	globalRegistry.Register(meta, factory)
+}
+
+// RegisterProviderDisplay registers a provider's UI presentation (display name and order).
+// Call once per provider package — typically alongside the first Register() call.
+func RegisterProviderDisplay(provider Name, pd ProviderDisplay) {
+	globalRegistry.RegisterProviderDisplay(provider, pd)
 }
 
 // Unregister removes a provider/auth-method entry from the global registry.
@@ -43,6 +52,13 @@ func (r *Registry) Register(meta Meta, factory Factory) {
 		meta:    meta,
 		factory: factory,
 	}
+}
+
+// RegisterProviderDisplay registers a provider's UI presentation.
+func (r *Registry) RegisterProviderDisplay(provider Name, pd ProviderDisplay) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.providerDisplay[provider] = pd
 }
 
 // Unregister removes a provider/auth-method entry from the registry.
@@ -152,4 +168,48 @@ func (r *Registry) GetProvidersWithStatus(store *Store) map[Name][]Info {
 	}
 
 	return result
+}
+
+// ProvidersByOrder returns unique provider names sorted by their Order field.
+func ProvidersByOrder() []Name {
+	return globalRegistry.ProvidersByOrder()
+}
+
+// ProvidersByOrder returns unique provider names sorted by their Order field.
+func (r *Registry) ProvidersByOrder() []Name {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	type providerOrder struct {
+		name  Name
+		order int
+	}
+	providers := make([]providerOrder, 0, len(r.providerDisplay))
+	for name, pd := range r.providerDisplay {
+		providers = append(providers, providerOrder{name, pd.Order})
+	}
+	sort.Slice(providers, func(i, j int) bool {
+		return providers[i].order < providers[j].order
+	})
+	result := make([]Name, len(providers))
+	for i, p := range providers {
+		result[i] = p.name
+	}
+	return result
+}
+
+// ProviderDisplayName returns the provider-level display name for a provider.
+func ProviderDisplayName(p Name) string {
+	return globalRegistry.ProviderDisplayName(p)
+}
+
+// ProviderDisplayName returns the provider-level display name for a provider.
+func (r *Registry) ProviderDisplayName(p Name) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if pd, ok := r.providerDisplay[p]; ok {
+		return pd.Name
+	}
+	return string(p)
 }

--- a/internal/llm/sensenova/apikey.go
+++ b/internal/llm/sensenova/apikey.go
@@ -32,5 +32,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 }
 
 func init() {
+	llm.RegisterProviderDisplay(llm.SenseNova, llm.ProviderDisplay{Name: "SenseNova (商汤)", Order: 50})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -34,12 +34,19 @@ const (
 	AuthBedrock AuthMethod = "bedrock"
 )
 
-// Meta contains static metadata about a provider
+// Meta contains static metadata about a provider auth method.
 type Meta struct {
 	Provider    Name
 	AuthMethod  AuthMethod
 	EnvVars     []string // Required environment variables
-	DisplayName string
+	DisplayName string   // per-authMethod name (e.g. "Direct API", "Vertex AI")
+}
+
+// ProviderDisplay describes how a provider is presented in the UI,
+// shared across all of its auth methods.
+type ProviderDisplay struct {
+	Name  string // UI display name (e.g. "Anthropic")
+	Order int    // display order in UI (lower = earlier)
 }
 
 // Key returns a unique key for this provider configuration


### PR DESCRIPTION
## What & why

The provider list in the `/model` UI was hardcoded in `providerOrder` and `providerDisplayNames`. Adding a new provider required updating both lists — easy to miss (as happened with MIMO). This refactor makes each provider self-describe its display name and sort order via the `Meta` struct, and the UI queries the registry dynamically.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Changes

- Add `ProviderDisplayName` and `Order` fields to `llm.Meta`
- Add `SortedProviders()` and `ProviderDisplayName()` to the registry
- Set the new fields on all 12 provider Meta declarations (11 providers + Anthropic Vertex)
- Remove hardcoded `providerOrder` and `providerDisplayNames` from `on_provider.go`

New providers now only need to set `ProviderDisplayName` and `Order` on their `Meta` — no UI code changes required.

## Testing

```bash
go test ./internal/llm/... ./internal/app/...
```

All tests pass.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`refactor:`)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)