### PR TITLE
fix(app): update welcome header model name on model switch

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -87,7 +87,7 @@ func handleProviderModelSelected(deps OverlayDeps, state *ProviderState, msg Pro
 	})
 	ctx := context.Background()
 	providerRefreshConnection(deps, state, ctx, llm.Name(msg.ProviderName), msg.AuthMethod)
-	return nil
+	return deps.PrintWelcome(msg.ModelID)
 }
 
 func providerRefreshConnection(deps OverlayDeps, state *ProviderState, ctx context.Context, providerName llm.Name, authMethod llm.AuthMethod) {

--- a/internal/app/input/runtime.go
+++ b/internal/app/input/runtime.go
@@ -18,6 +18,7 @@ type OverlayDeps struct {
 
 	SwitchProvider          func(llm.Provider)
 	SetCurrentModel         func(*llm.CurrentModelInfo)
+	PrintWelcome            func(modelID string) tea.Cmd
 	ClearCachedInstructions func()
 	RefreshMemoryContext    func(cwd, reason string)
 	FireFileChanged         func(path, tool string)

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/kit"
@@ -39,6 +40,30 @@ func (m *model) overlayDeps() input.OverlayDeps {
 		SetCurrentModel: func(info *llm.CurrentModelInfo) {
 			m.env.CurrentModel = info
 			m.env.LoadThinkingEffortFromStore()
+		},
+		PrintWelcome: func(modelID string) tea.Cmd {
+			modelName := modelID
+			if m.services.LLM != nil {
+				if name := m.services.LLM.Store().CachedModelDisplayName(modelID); name != "" {
+					modelName = name
+				}
+			}
+			teal := lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
+			star := lipgloss.NewStyle().Foreground(welcomeStar)
+			dim := lipgloss.NewStyle().Foreground(welcomeDim)
+			line := teal.Render("< ") + teal.Render("SAN") + " " + star.Render("✦") + " " + teal.Render("/>")
+			if proj := projectName(m.env.CWD); proj != "" {
+				line += dim.Render("  ·  ") + dim.Render(proj)
+			}
+			line += dim.Render("  ·  ") + dim.Render(modelName)
+			// Overwrite the original welcome line in-place using ANSI cursor
+			// codes. The original printWelcome output is:
+			//   \n  (leading newline from renderWelcome)
+			//   <content>  (the styled welcome line)
+			//   \n  (trailing newline from fmt.Println)
+			// Move up 2 lines to the content line, clear it, rewrite, then
+			// position the cursor on the blank line below for the TUI.
+			return tea.Println("\033[2A\033[2K\r" + line + "\n")
 		},
 		ClearCachedInstructions: m.env.ClearCachedInstructions,
 		RefreshMemoryContext:    m.refreshMemoryContext,


### PR DESCRIPTION
## Summary
- The welcome splash header (`< SAN ✦ /> · san · <model>`) was printed once at startup and never updated when the user selected a different model via the provider selector
- Adds a `PrintWelcome` callback that uses ANSI cursor escape codes to overwrite the original welcome line in-place with the new model's display name

## Test plan
- [ ] Launch the app, verify the welcome header shows the initial model name
- [ ] Open the model selector (`/model`), select a different model
- [ ] Verify the welcome header updates in-place (no duplicate lines)
- [ ] Verify the status bar also shows the updated model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)