### PR TITLE
feat(provider): add Ctrl+D to remove API key with confirmation

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -203,6 +203,11 @@ type ProviderSelector struct {
 	apiKeyProviderIdx int // index into allProviders
 	apiKeyAuthIdx     int // index into that provider's AuthMethods
 
+	// Inline confirm-remove prompt
+	confirmRemoveActive  bool
+	confirmRemoveEnvVar  string
+	confirmRemoveItemIdx int // index into visibleItems for the pending remove
+
 	// Models tab: search filter and the two flags that disambiguate keys
 	// whose meaning depends on what the user is doing.
 	searchQuery    string              // active filter text; "" means no filter
@@ -419,6 +424,11 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 		return s.handleAPIKeyInput(key)
 	}
 
+	// Route to confirm-remove if active
+	if s.confirmRemoveActive {
+		return s.handleConfirmRemove(key)
+	}
+
 	switch key.Type {
 	case tea.KeyTab:
 		if s.searchQuery == "" {
@@ -482,6 +492,9 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 
 	case tea.KeyCtrlE:
 		return s.handleCredentialEdit()
+
+	case tea.KeyCtrlD:
+		return s.handleCredentialRemove()
 	}
 
 	// Vim navigation (only when search query is empty)
@@ -753,6 +766,104 @@ func (s *ProviderSelector) handleCredentialEditForAuthMethod(item providerListIt
 	s.apiKeyProviderIdx = item.ProviderIdx
 	s.apiKeyAuthIdx = s.findAuthMethodIndex(item)
 	s.initAPIKeyInput(envVar)
+	return nil
+}
+
+// handleCredentialRemove handles Ctrl+D: shows a confirmation prompt before removing.
+func (s *ProviderSelector) handleCredentialRemove() tea.Cmd {
+	if s.activeTab != providerTabProviders {
+		return nil
+	}
+	if s.selectedIdx < 0 || s.selectedIdx >= len(s.visibleItems) {
+		return nil
+	}
+
+	item := s.visibleItems[s.selectedIdx]
+
+	var envVars []string
+	switch item.Kind {
+	case providerItemProvider:
+		if item.Provider == nil || len(item.Provider.AuthMethods) != 1 {
+			return nil
+		}
+		envVars = item.Provider.AuthMethods[0].EnvVars
+	case providerItemAuthMethod:
+		if item.AuthMethod == nil {
+			return nil
+		}
+		envVars = item.AuthMethod.EnvVars
+	default:
+		return nil
+	}
+
+	envVar := providerFirstEnvVar(envVars)
+	if envVar == "" {
+		return nil
+	}
+
+	s.confirmRemoveActive = true
+	s.confirmRemoveEnvVar = envVar
+	s.confirmRemoveItemIdx = s.selectedIdx
+	return nil
+}
+
+// handleConfirmRemove handles keypresses while the confirm-remove prompt is active.
+func (s *ProviderSelector) handleConfirmRemove(key tea.KeyMsg) tea.Cmd {
+	s.confirmRemoveActive = false
+	switch key.String() {
+	case "y", "Y":
+		return s.executeCredentialRemove()
+	default:
+		return nil
+	}
+}
+
+// executeCredentialRemove performs the actual credential removal.
+func (s *ProviderSelector) executeCredentialRemove() tea.Cmd {
+	envVar := s.confirmRemoveEnvVar
+
+	// Resolve the provider and auth method from the item
+	item := s.visibleItems[s.confirmRemoveItemIdx]
+	var providerName llm.Name
+	var authMethod llm.AuthMethod
+	switch item.Kind {
+	case providerItemProvider:
+		if item.Provider == nil || len(item.Provider.AuthMethods) != 1 {
+			return nil
+		}
+		providerName = item.Provider.AuthMethods[0].Provider
+		authMethod = item.Provider.AuthMethods[0].AuthMethod
+	case providerItemAuthMethod:
+		if item.AuthMethod == nil {
+			return nil
+		}
+		providerName = item.AuthMethod.Provider
+		authMethod = item.AuthMethod.AuthMethod
+	default:
+		return nil
+	}
+
+	// Remove from secret store and unset env var
+	if store := secret.Default(); store != nil {
+		_ = store.Delete(envVar)
+	}
+	os.Unsetenv(envVar)
+
+	// Disconnect provider and remove cached models from the llm store
+	if s.store != nil {
+		_ = s.store.Disconnect(providerName)
+		_ = s.store.RemoveCachedModels(providerName, authMethod)
+
+		// Clear current model if it belongs to the disconnected provider
+		if cur := s.store.GetCurrentModel(); cur != nil && cur.Provider == providerName {
+			_ = s.store.ClearCurrentModel()
+		}
+	}
+
+	// Reload provider data to reflect the removed credential
+	s.resetConnectionResult()
+	_, _ = s.loadProviderData()
+	s.rebuildVisibleItems()
 	return nil
 }
 

--- a/internal/app/input/on_provider_edit_test.go
+++ b/internal/app/input/on_provider_edit_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/genai-io/san/internal/secret"
 )
 
+// isolateSecretStore points the secret store at a throwaway HOME so tests never
+// read or write the developer's real ~/.san/secrets.json. secret.Default() is a
+// sync.Once singleton, so it must be reset around each test.
+func isolateSecretStore(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	secret.ResetDefault()
+	t.Cleanup(secret.ResetDefault)
+}
+
 func TestHandleCredentialEditForSingleAuthMethod(t *testing.T) {
 	m := NewProviderSelector()
 	m.active = true
@@ -118,6 +128,7 @@ func TestHandleCredentialEditForMultipleAuthMethods(t *testing.T) {
 }
 
 func TestHandleCredentialEditUpdatesOnEnter(t *testing.T) {
+	isolateSecretStore(t)
 	t.Setenv("OPENAI_API_KEY", "")
 
 	m := NewProviderSelector()
@@ -324,10 +335,10 @@ func TestEditCredentialFlowWithKeyboardShortcuts(t *testing.T) {
 }
 
 func TestHandleCredentialRemoveSingleAuthMethod(t *testing.T) {
+	isolateSecretStore(t)
 	t.Setenv("OPENAI_API_KEY", "test-key-to-remove")
 	if store := secret.Default(); store != nil {
 		_ = store.Set("OPENAI_API_KEY", "test-key-to-remove")
-		t.Cleanup(func() { _ = store.Delete("OPENAI_API_KEY") })
 	}
 
 	m := NewProviderSelector()
@@ -442,15 +453,12 @@ func TestHandleCredentialRemoveCancel(t *testing.T) {
 }
 
 func TestHandleCredentialRemoveMultipleAuthMethods(t *testing.T) {
+	isolateSecretStore(t)
 	t.Setenv("ANTHROPIC_API_KEY", "test-ak-key")
 	t.Setenv("BEDROCK_API_KEY", "test-bk-key")
 	if store := secret.Default(); store != nil {
 		_ = store.Set("ANTHROPIC_API_KEY", "test-ak-key")
 		_ = store.Set("BEDROCK_API_KEY", "test-bk-key")
-		t.Cleanup(func() {
-			_ = store.Delete("ANTHROPIC_API_KEY")
-			_ = store.Delete("BEDROCK_API_KEY")
-		})
 	}
 
 	m := NewProviderSelector()
@@ -523,10 +531,10 @@ func TestHandleCredentialRemoveMultipleAuthMethods(t *testing.T) {
 }
 
 func TestHandleCredentialRemoveKeyboardShortcut(t *testing.T) {
+	isolateSecretStore(t)
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	if store := secret.Default(); store != nil {
 		_ = store.Set("OPENAI_API_KEY", "test-key")
-		t.Cleanup(func() { _ = store.Delete("OPENAI_API_KEY") })
 	}
 
 	m := NewProviderSelector()
@@ -622,13 +630,11 @@ func TestHandleCredentialRemoveNonProvidersTab(t *testing.T) {
 }
 
 func TestHandleCredentialRemoveClearsModelsAndConnection(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateSecretStore(t)
 	t.Setenv("OPENAI_API_KEY", "test-key-to-remove")
 
 	if secretStore := secret.Default(); secretStore != nil {
 		_ = secretStore.Set("OPENAI_API_KEY", "test-key-to-remove")
-		t.Cleanup(func() { _ = secretStore.Delete("OPENAI_API_KEY") })
 	}
 
 	store, err := llm.NewStore()

--- a/internal/app/input/on_provider_edit_test.go
+++ b/internal/app/input/on_provider_edit_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
 )
 
 func TestHandleCredentialEditForSingleAuthMethod(t *testing.T) {
@@ -117,6 +118,8 @@ func TestHandleCredentialEditForMultipleAuthMethods(t *testing.T) {
 }
 
 func TestHandleCredentialEditUpdatesOnEnter(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
 	m := NewProviderSelector()
 	m.active = true
 	m.activeTab = providerTabProviders
@@ -161,16 +164,6 @@ func TestHandleCredentialEditUpdatesOnEnter(t *testing.T) {
 
 	// Update the API key
 	m.apiKeyInput.SetValue("NEW_TEST_KEY")
-
-	// Save and restore env var to avoid leaking into other tests
-	origVal, _ := os.LookupEnv("OPENAI_API_KEY")
-	defer func() {
-		if origVal != "" {
-			os.Setenv("OPENAI_API_KEY", origVal)
-		} else {
-			os.Unsetenv("OPENAI_API_KEY")
-		}
-	}()
 
 	// Simulate Enter key to submit
 	cmd = m.handleAPIKeyInput(tea.KeyMsg{Type: tea.KeyEnter})
@@ -327,5 +320,399 @@ func TestEditCredentialFlowWithKeyboardShortcuts(t *testing.T) {
 	}
 	if m.apiKeyEnvVar != "OPENAI_API_KEY" {
 		t.Fatal("incorrect environment variable set for API key input")
+	}
+}
+
+func TestHandleCredentialRemoveSingleAuthMethod(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key-to-remove")
+	if store := secret.Default(); store != nil {
+		_ = store.Set("OPENAI_API_KEY", "test-key-to-remove")
+		t.Cleanup(func() { _ = store.Delete("OPENAI_API_KEY") })
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.OpenAI,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"OPENAI_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	// Select the provider
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	// First press: shows confirmation
+	cmd := m.handleCredentialRemove()
+	if cmd != nil {
+		t.Fatal("handleCredentialRemove should not return a command")
+	}
+	if !m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be true after Ctrl+D")
+	}
+	// Env var should still be set at this point
+	if os.Getenv("OPENAI_API_KEY") != "test-key-to-remove" {
+		t.Fatal("OPENAI_API_KEY should not be removed until confirmed")
+	}
+
+	// Confirm with 'y'
+	cmd = m.handleConfirmRemove(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd != nil {
+		t.Fatal("handleConfirmRemove should not return a command")
+	}
+	if m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be false after confirm")
+	}
+
+	// Verify env var is unset
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		t.Fatal("OPENAI_API_KEY should be unset after confirm")
+	}
+
+	// Verify secret store is cleared
+	if store := secret.Default(); store != nil {
+		if store.Get("OPENAI_API_KEY") != "" {
+			t.Fatal("OPENAI_API_KEY should be removed from secret store")
+		}
+	}
+}
+
+func TestHandleCredentialRemoveCancel(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.OpenAI,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"OPENAI_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	// Show confirmation
+	m.handleCredentialRemove()
+	if !m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be true")
+	}
+
+	// Cancel with Esc
+	m.handleConfirmRemove(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be false after cancel")
+	}
+
+	// Env var should remain
+	if os.Getenv("OPENAI_API_KEY") != "test-key" {
+		t.Fatal("OPENAI_API_KEY should not be removed after cancel")
+	}
+}
+
+func TestHandleCredentialRemoveMultipleAuthMethods(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-ak-key")
+	t.Setenv("BEDROCK_API_KEY", "test-bk-key")
+	if store := secret.Default(); store != nil {
+		_ = store.Set("ANTHROPIC_API_KEY", "test-ak-key")
+		_ = store.Set("BEDROCK_API_KEY", "test-bk-key")
+		t.Cleanup(func() {
+			_ = store.Delete("ANTHROPIC_API_KEY")
+			_ = store.Delete("BEDROCK_API_KEY")
+		})
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    llm.Anthropic,
+			DisplayName: "Anthropic",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.Anthropic,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"ANTHROPIC_API_KEY"},
+				},
+				{
+					Provider:    llm.Anthropic,
+					AuthMethod:  llm.AuthBedrock,
+					DisplayName: "AWS Bedrock",
+					Status:      llm.StatusAvailable,
+					EnvVars:     []string{"BEDROCK_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	// Select the provider row — should not show confirmation (multiple auth methods)
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	cmd := m.handleCredentialRemove()
+	if cmd != nil {
+		t.Fatal("handleCredentialRemove should return nil for provider with multiple auth methods")
+	}
+	if m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be false for provider with multiple auth methods")
+	}
+
+	// Expand and select the specific auth method
+	m.expandedProviderIdx = 0
+	m.rebuildVisibleItems()
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemAuthMethod && item.AuthMethod != nil && item.AuthMethod.AuthMethod == llm.AuthAPIKey {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	// Show confirmation and confirm
+	m.handleCredentialRemove()
+	if !m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be true for auth method row")
+	}
+	m.handleConfirmRemove(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		t.Fatal("ANTHROPIC_API_KEY should be unset after confirm")
+	}
+	// BEDROCK should remain
+	if os.Getenv("BEDROCK_API_KEY") != "test-bk-key" {
+		t.Fatal("BEDROCK_API_KEY should not be affected")
+	}
+}
+
+func TestHandleCredentialRemoveKeyboardShortcut(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	if store := secret.Default(); store != nil {
+		_ = store.Set("OPENAI_API_KEY", "test-key")
+		t.Cleanup(func() { _ = store.Delete("OPENAI_API_KEY") })
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.OpenAI,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"OPENAI_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	// Select the provider
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	// Trigger remove with Ctrl+D (shows confirmation)
+	cmd := m.HandleKeypress(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if cmd != nil {
+		t.Fatal("handleCredentialRemove should not return a command")
+	}
+	if !m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be true after Ctrl+D")
+	}
+
+	// Confirm with 'y' via HandleKeypress
+	cmd = m.HandleKeypress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd != nil {
+		t.Fatal("handleConfirmRemove should not return a command")
+	}
+
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		t.Fatal("OPENAI_API_KEY should be unset after confirm")
+	}
+}
+
+func TestHandleCredentialRemoveNonProvidersTab(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabModels
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.OpenAI,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"OPENAI_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	cmd := m.handleCredentialRemove()
+	if cmd != nil {
+		t.Fatal("handleCredentialRemove should return nil on non-providers tab")
+	}
+	if m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be false on non-providers tab")
+	}
+
+	// Env var should remain
+	if os.Getenv("OPENAI_API_KEY") != "test-key" {
+		t.Fatal("OPENAI_API_KEY should not be removed on non-providers tab")
+	}
+}
+
+func TestHandleCredentialRemoveClearsModelsAndConnection(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("OPENAI_API_KEY", "test-key-to-remove")
+
+	if secretStore := secret.Default(); secretStore != nil {
+		_ = secretStore.Set("OPENAI_API_KEY", "test-key-to-remove")
+		t.Cleanup(func() { _ = secretStore.Delete("OPENAI_API_KEY") })
+	}
+
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	// Connect and cache models
+	if err := store.Connect(llm.OpenAI, llm.AuthAPIKey); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if err := store.CacheModels(llm.OpenAI, llm.AuthAPIKey, []llm.ModelInfo{
+		{ID: "gpt-4o", DisplayName: "GPT-4o"},
+	}); err != nil {
+		t.Fatalf("CacheModels() error = %v", err)
+	}
+	if err := store.SetCurrentModel("gpt-4o", llm.OpenAI, llm.AuthAPIKey); err != nil {
+		t.Fatalf("SetCurrentModel() error = %v", err)
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.store = store
+	m.allProviders = []providerProviderItem{
+		{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			AuthMethods: []providerAuthMethodItem{
+				{
+					Provider:    llm.OpenAI,
+					AuthMethod:  llm.AuthAPIKey,
+					DisplayName: "API Key",
+					Status:      llm.StatusConnected,
+					EnvVars:     []string{"OPENAI_API_KEY"},
+				},
+			},
+		},
+	}
+	m.rebuildVisibleItems()
+
+	// Verify preconditions
+	if !store.IsConnected(llm.OpenAI, llm.AuthAPIKey) {
+		t.Fatal("expected OpenAI to be connected before remove")
+	}
+	if _, ok := store.GetCachedModels(llm.OpenAI, llm.AuthAPIKey); !ok {
+		t.Fatal("expected cached models before remove")
+	}
+	if cur := store.GetCurrentModel(); cur == nil || cur.Provider != llm.OpenAI {
+		t.Fatal("expected current model to be OpenAI before remove")
+	}
+
+	// Select the provider, show confirmation, and confirm
+	for i, item := range m.visibleItems {
+		if item.Kind == providerItemProvider {
+			m.selectedIdx = i
+			break
+		}
+	}
+
+	m.handleCredentialRemove()
+	if !m.confirmRemoveActive {
+		t.Fatal("confirmRemoveActive should be true")
+	}
+
+	m.handleConfirmRemove(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	// Verify env var is unset
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		t.Fatal("OPENAI_API_KEY should be unset after confirm")
+	}
+
+	// Verify connection is removed
+	if store.IsConnected(llm.OpenAI, llm.AuthAPIKey) {
+		t.Fatal("OpenAI should be disconnected after confirm")
+	}
+
+	// Verify cached models are removed
+	if _, ok := store.GetCachedModels(llm.OpenAI, llm.AuthAPIKey); ok {
+		t.Fatal("cached models should be removed after confirm")
+	}
+
+	// Verify current model is cleared
+	if cur := store.GetCurrentModel(); cur != nil {
+		t.Fatalf("current model should be cleared after confirm, got %v", cur)
 	}
 }

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -136,6 +136,12 @@ func (s *ProviderSelector) renderItemList(sb *strings.Builder) {
 			sb.WriteString(s.renderAPIKeyInput())
 			sb.WriteString("\n")
 		}
+
+		// Inline confirm-remove prompt (render below the relevant item)
+		if s.confirmRemoveActive && i == s.confirmRemoveItemIdx {
+			sb.WriteString(s.renderConfirmRemove())
+			sb.WriteString("\n")
+		}
 	}
 
 	if endIdx < len(s.visibleItems) {
@@ -339,17 +345,34 @@ func (s *ProviderSelector) renderAPIKeyInput() string {
 	return "      " + boxStyle.Render(inputView)
 }
 
+func (s *ProviderSelector) renderConfirmRemove() string {
+	warnStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.AdaptiveColor{Dark: "#F87171", Light: "#DC2626"})
+	msg := warnStyle.Render("Remove "+s.confirmRemoveEnvVar+"?") +
+		kit.DimStyle().Render("  y/N")
+
+	inputBg := lipgloss.AdaptiveColor{Dark: "#1E293B", Light: "#F1F5F9"}
+	boxStyle := lipgloss.NewStyle().
+		Background(inputBg).
+		Padding(0, 1)
+
+	return "      " + boxStyle.Render(msg)
+}
+
 // ── Footer hints ────────────────────────────────────────────────────────────
 
 func (s *ProviderSelector) renderHints() string {
 	if s.apiKeyActive {
 		return kit.DimStyle().Render("Paste API key · Enter confirm · Esc cancel")
 	}
+	if s.confirmRemoveActive {
+		return kit.DimStyle().Render("y confirm · any other key cancel")
+	}
 
 	var parts []string
 	parts = append(parts, "↑/↓ navigate")
 	if s.activeTab == providerTabProviders {
-		parts = append(parts, "Ctrl+E edit", "Enter connect/refresh")
+		parts = append(parts, "Ctrl+E edit", "Ctrl+D remove", "Enter connect/refresh")
 	} else {
 		parts = append(parts, "Space mark · Enter confirm")
 	}

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -184,6 +184,33 @@ func (s *Store) GetConnections() map[string]ConnectionInfo {
 	return result
 }
 
+// Disconnect removes the connection for a provider.
+func (s *Store) Disconnect(provider Name) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.data.Connections, string(provider))
+	return s.save()
+}
+
+// RemoveCachedModels removes cached models for a provider and auth method.
+func (s *Store) RemoveCachedModels(provider Name, authMethod AuthMethod) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.data.Models, makemodelCacheKey(provider, authMethod))
+	return s.save()
+}
+
+// ClearCurrentModel clears the current model selection.
+func (s *Store) ClearCurrentModel() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.data.Current = nil
+	return s.save()
+}
+
 // CacheModels saves model information for a provider.
 func (s *Store) CacheModels(provider Name, authMethod AuthMethod, models []ModelInfo) error {
 	s.mu.Lock()

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -38,6 +38,15 @@ func Default() *Store {
 	return defaultStore
 }
 
+// ResetDefault discards the cached default store so the next Default() call
+// re-resolves it against the current HOME. Intended for tests that isolate the
+// secret store via t.Setenv("HOME", t.TempDir()); without it the sync.Once in
+// Default() would pin the path to the real ~/.san on first use.
+func ResetDefault() {
+	defaultStore = nil
+	defaultOnce = sync.Once{}
+}
+
 func (s *Store) load() error {
 	raw, err := os.ReadFile(s.path)
 	if err != nil {

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -74,6 +74,13 @@ func (s *Store) Get(key string) string {
 	return s.data[key]
 }
 
+func (s *Store) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return s.save()
+}
+
 // ResolveEnv returns the value for an environment variable name,
 // checking os.Getenv first, then falling back to the stored value.
 func (s *Store) ResolveEnv(envVar string) string {


### PR DESCRIPTION
## Summary
- Add Ctrl+D shortcut to remove stored API keys from the provider selector
- Shows an inline confirmation prompt (y/N) before removing
- On confirm: removes key from secret store and env, disconnects provider, clears cached models, and resets current model if it belonged to the removed provider
- Adds `Disconnect`, `RemoveCachedModels`, and `ClearCurrentModel` methods to `llm.Store`
- Adds `Delete` method to `secret.Store`

## Test plan
- [x] Ctrl+D on single-auth provider shows confirmation, 'y' removes key
- [x] Ctrl+D on specific auth method row removes only that credential
- [x] Any key other than 'y' cancels the removal
- [x] Models and connection are cleared from store after removal
- [x] Non-providers tab ignores Ctrl+D

🤖 Generated with [Claude Code](https://claude.com/claude-code)