### PR TITLE
fix: remove hardcoded model fallback when no model selected

### DIFF
--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -109,7 +109,7 @@ func (m *env) GetModelID() string {
 	if m.CurrentModel != nil {
 		return m.CurrentModel.ModelID
 	}
-	return "claude-sonnet-4-20250514"
+	return ""
 }
 
 // GetModelDisplayName returns a human-readable display name for the current
@@ -117,6 +117,9 @@ func (m *env) GetModelID() string {
 // raw model ID if no display name is found.
 func (m *env) GetModelDisplayName() string {
 	id := m.GetModelID()
+	if id == "" {
+		return "no model selected"
+	}
 	if m.store == nil {
 		return id
 	}

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -857,6 +857,12 @@ func (s *ProviderSelector) executeCredentialRemove() tea.Cmd {
 		// Clear current model if it belongs to the disconnected provider
 		if cur := s.store.GetCurrentModel(); cur != nil && cur.Provider == providerName {
 			_ = s.store.ClearCurrentModel()
+			llm.Default().SetCurrentModel(nil)
+		}
+
+		// If no connections remain, clear the runtime provider too
+		if len(s.store.GetConnections()) == 0 {
+			llm.Default().SetProvider(nil)
 		}
 	}
 

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -39,6 +39,7 @@ func (m *model) overlayDeps() input.OverlayDeps {
 		},
 		SetCurrentModel: func(info *llm.CurrentModelInfo) {
 			m.env.CurrentModel = info
+			llm.Default().SetCurrentModel(info)
 			m.env.LoadThinkingEffortFromStore()
 		},
 		PrintWelcome: func(modelID string) tea.Cmd {
@@ -55,7 +56,9 @@ func (m *model) overlayDeps() input.OverlayDeps {
 			if proj := projectName(m.env.CWD); proj != "" {
 				line += dim.Render("  ·  ") + dim.Render(proj)
 			}
-			line += dim.Render("  ·  ") + dim.Render(modelName)
+			if modelName != "" {
+				line += dim.Render("  ·  ") + dim.Render(modelName)
+			}
 			// Overwrite the original welcome line in-place using ANSI cursor
 			// codes. The original printWelcome output is:
 			//   \n  (leading newline from renderWelcome)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -81,8 +81,19 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case input.PromptSuggestionMsg:
 		input.HandlePromptSuggestion(&m.userInput, m.conv.Stream.Active, m.userInput.Textarea.Value(), msg)
 		return m, nil
-	case kit.DismissedMsg, input.ToolToggleMsg:
+	case kit.DismissedMsg:
+		// Sync env state with llm.Default. Credential removal (Ctrl+D in
+		// the Providers tab) clears the store's CurrentModel and updates
+		// llm.Default — but the per-turn env fields would stay stale until
+		// the next explicit model selection without this refresh.
+		prevModel := m.env.CurrentModel
+		m.env.CurrentModel = m.services.LLM.CurrentModel()
+		m.env.LLMProvider = m.services.LLM.Provider()
+		if prevModel != nil && m.env.CurrentModel == nil {
+			return m, m.overlayDeps().PrintWelcome(m.env.GetModelDisplayName())
+		}
 		return m, nil
+	case input.ToolToggleMsg:
 	case input.ConfigSavedMsg:
 		// Refresh the in-memory settings handle so re-opening /config (and any
 		// in-session reader) sees the just-saved values rather than the stale

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -223,7 +223,7 @@ func (m model) renderTrackerList() string {
 }
 
 func (m model) renderModeStatus() string {
-	modelName := m.env.GetModelID()
+	modelName := m.env.GetModelDisplayName()
 	thinkingEffort := m.env.EffectiveThinkingEffort()
 	showThinking := true
 	if m.env.CurrentModel != nil && m.env.CurrentModel.Provider == llm.OpenAI && thinkingEffort != "" {
@@ -286,7 +286,7 @@ func (m model) messageRenderParams() conv.RenderContext {
 		// Per-tick UI state
 		SpinnerView:  m.conv.Spinner.View(),
 		Blink:        m.conv.Blink,
-		ModelName:    m.env.GetModelID(),
+		ModelName:    m.env.GetModelDisplayName(),
 		InputTokens:  m.env.InputTokens,
 		OutputTokens: m.env.OutputTokens,
 


### PR DESCRIPTION
When a provider credential is removed via Ctrl+D in the Providers tab, the store's CurrentModel was cleared but the in-memory env.CurrentModel and llm.Conn.currentModel stayed stale, causing the footer and header to display the old (now-orphaned) model name.

This also fixes the hardcoded 'claude-sonnet-4-20250514' fallback in GetModelID() — it now returns empty when no model is configured, and the display layer shows 'no model selected'.

**Changes:**
- `env.GetModelID()`: returns `""` instead of the hardcoded model when `CurrentModel` is nil
- `env.GetModelDisplayName()`: returns `"no model selected"` when no model is active
- Clear `llm.Default().SetCurrentModel(nil)` and `llm.Default().SetProvider(nil)` on credential removal
- Sync `env.CurrentModel` and `env.LLMProvider` from `llm.Default()` on popup dismiss (`DismissedMsg`)
- Switch view layer to use `GetModelDisplayName()` so footer and conversation header consistently show the right message
- Sync `llm.Default().SetCurrentModel()` on model selection so all three state layers (store, llm.Conn, env) stay consistent