### PR TITLE
fix(mimo): populate InputTokens from CacheReadInputTokens

### DIFF
--- a/internal/llm/mimo/client.go
+++ b/internal/llm/mimo/client.go
@@ -35,8 +35,22 @@ func NewClient(client anthropicsdk.Client, name string) *Client {
 func (c *Client) Name() string { return c.inner.Name() }
 
 // Stream delegates to the anthropic provider for full API compatibility.
+// Mimo reports all input tokens as CacheReadInputTokens; fix up InputTokens
+// so downstream consumers (logging, cost tracking) see the correct count.
 func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
-	return c.inner.Stream(ctx, opts)
+	in := c.inner.Stream(ctx, opts)
+	out := make(chan llm.StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range in {
+			if chunk.Type == llm.ChunkTypeDone && chunk.Response != nil &&
+				chunk.Response.Usage.InputTokens == 0 && chunk.Response.Usage.CacheReadInputTokens > 0 {
+				chunk.Response.Usage.InputTokens = chunk.Response.Usage.CacheReadInputTokens
+			}
+			out <- chunk
+		}
+	}()
+	return out
 }
 
 // modelsResponse is the OpenRouter-style response from the Mimo models API.


### PR DESCRIPTION
## What & why

Mimo reports all input tokens as `CacheReadInputTokens`, leaving `InputTokens` at 0. This breaks downstream consumers (logging, cost tracking) that read `InputTokens`. The fix intercepts the final `Done` chunk and copies `CacheReadInputTokens` into `InputTokens` when the latter is zero.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

Verified by observing token counts in the CLI output — `InputTokens` now correctly reflects the actual input token count instead of showing 0.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)