### PR TITLE
fix(tui): commit streaming output to scrollback at newline boundaries

### DIFF
--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -5,13 +5,17 @@ import (
 )
 
 type StreamState struct {
-	Active       bool
-	BuildingTool string
+	Active            bool
+	BuildingTool      string
+	ScrollbackLen     int  // bytes of last assistant message already committed to scrollback
+	ThinkingCommitted bool // whether thinking text has been committed to scrollback
 }
 
 func (s *StreamState) Stop() {
 	s.Active = false
 	s.BuildingTool = ""
+	s.ScrollbackLen = 0
+	s.ThinkingCommitted = false
 }
 
 type ConversationModel struct {

--- a/internal/app/conv/markdown.go
+++ b/internal/app/conv/markdown.go
@@ -157,6 +157,25 @@ func isTableLine(line string) bool {
 	return strings.HasPrefix(trimmed, "|") && strings.Contains(trimmed[1:], "|")
 }
 
+// isAllTableLines reports whether every non-empty line in s looks like a
+// markdown table row.  Returns false when s is empty or contains only
+// whitespace.
+func isAllTableLines(s string) bool {
+	lines := strings.Split(s, "\n")
+	found := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		found = true
+		if !isTableLine(trimmed) {
+			return false
+		}
+	}
+	return found
+}
+
 // findTableEnd finds the end index (exclusive) of consecutive table lines.
 func findTableEnd(lines []string, start int) int {
 	i := start

--- a/internal/app/conv/markdown_test.go
+++ b/internal/app/conv/markdown_test.go
@@ -351,6 +351,31 @@ func TestMDRenderer_Table(t *testing.T) {
 	}
 }
 
+func Test_isAllTableLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"header only", "| Name | Value |\n", true},
+		{"header + separator", "| Name | Value |\n|------|-------|\n", true},
+		{"full table", "| Name |\n|---|\n| val |\n", true},
+		{"table + trailing blank", "| Name |\n|---|\n| val |\n\n", true},
+		{"non-table text", "Hello world\n", false},
+		{"table then paragraph", "| Name |\n|---|\nParagraph\n", false},
+		{"empty string", "", false},
+		{"just blank lines", "\n\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAllTableLines(tt.input)
+			if got != tt.want {
+				t.Errorf("isAllTableLines(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMDRenderer_TableWithLinks(t *testing.T) {
 	r := NewMDRenderer(80)
 

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -259,6 +259,17 @@ func commitStreamTail(m *Model, flush bool) tea.Cmd {
 		return pickCmd(cmds)
 	}
 	commit := delta[:lastNewline+1]
+
+	// If every non-empty line in the commit looks like a table row the
+	// table may still be incomplete. Skip so the lines stay in the live
+	// View area and renderMarkdownContent can process the full block once
+	// a non-table line marks its end — or the final flush. Blank lines
+	// after a table signal the block is complete (avoids an infinite
+	// skip loop).
+	if isAllTableLines(strings.TrimRight(commit, "\n")) && !strings.HasSuffix(commit, "\n\n") {
+		return pickCmd(cmds)
+	}
+
 	m.Stream.ScrollbackLen += len(commit)
 	rendered := renderMarkdownContent(m.MDRenderer, strings.TrimRight(commit, "\n"))
 	cmds = append(cmds, tea.Println(rendered))

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -2,6 +2,8 @@
 package conv
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/genai-io/san/internal/app/kit"
@@ -151,6 +153,8 @@ func applyPreInfer(rt Runtime, m *Model) tea.Cmd {
 	rt.OnTurnBegin()
 	m.Stream.Active = true
 	m.Stream.BuildingTool = ""
+	m.Stream.ScrollbackLen = 0
+	m.Stream.ThinkingCommitted = false
 	commitCmds := rt.CommitMessages()
 	m.Append(core.ChatMessage{Role: core.RoleAssistant, Content: ""})
 	cmds := append(commitCmds, m.Spinner.Tick)
@@ -172,14 +176,105 @@ func applyChunk(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 	if chunk.Text != "" || chunk.Thinking != "" {
 		m.AppendToLast(chunk.Text, chunk.Thinking)
 	}
+
+	// Commit newly streamed text to terminal scrollback at newline
+	// boundaries so the user can scroll up to see earlier parts of a long
+	// response that have been truncated from the active view. Both thinking
+	// and content text are committed as plain text — the View() area shows
+	// the live formatted tail. When the stream finishes we advance
+	// CommittedCount so CommitMessages does not re-print the same message
+	// (which would duplicate output).
+	var cmds []tea.Cmd
+	if cmd := commitStreamTail(m, false); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
 	if chunk.Done && chunk.Response != nil && len(chunk.Response.ToolCalls) == 0 {
 		m.Stream.Active = false
+		// Flush any remaining tail that hasn't hit a newline yet.
+		if cmd := commitStreamTail(m, true); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		// commitStreamTail already flushed the full text to scrollback.
+		// Skip CommitMessages for this message to avoid duplicating it.
+		m.CommittedCount = len(m.Messages)
 		commitCmds := rt.CommitMessages()
 		if len(commitCmds) > 0 {
-			return tea.Batch(commitCmds...)
+			cmds = append(cmds, commitCmds...)
 		}
 	}
-	return nil
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// commitStreamTail flushes newly streamed assistant text (thinking and
+// content) to terminal scrollback and advances Stream.ScrollbackLen past
+// whatever it commits.  Thinking text is committed on the first call
+// (ScrollbackLen == 0).  When flush is false it commits content only
+// through the last newline (so a partial trailing line doesn't appear as
+// left-edge flicker); when true it commits the entire remaining tail.
+// Returns nil when there is nothing to commit.
+func commitStreamTail(m *Model, flush bool) tea.Cmd {
+	if len(m.Messages) == 0 {
+		return nil
+	}
+	last := m.Messages[len(m.Messages)-1]
+	if last.Role != core.RoleAssistant {
+		return nil
+	}
+
+	var cmds []tea.Cmd
+
+	// Commit thinking text once — it arrives incrementally but we
+	// only want the final version in scrollback. Commit it when
+	// content first appears (meaning thinking is done) and only once.
+	if len(last.Thinking) > 0 && !m.Stream.ThinkingCommitted && len(last.Content) > 0 {
+		cmds = append(cmds, tea.Println(last.Thinking))
+		m.Stream.ThinkingCommitted = true
+	}
+
+	if len(last.Content) <= m.Stream.ScrollbackLen {
+		return pickCmd(cmds)
+	}
+
+	delta := last.Content[m.Stream.ScrollbackLen:]
+	if flush {
+		m.Stream.ScrollbackLen = len(last.Content)
+		// Flush thinking if it hasn't been committed yet (edge case:
+		// content never triggered the thinking commit above).
+		if len(last.Thinking) > 0 && !m.Stream.ThinkingCommitted {
+			cmds = append(cmds, tea.Println(last.Thinking))
+			m.Stream.ThinkingCommitted = true
+		}
+		// Render through markdown so headings, bold, tables, etc.
+		// appear styled in scrollback instead of raw syntax.
+		cmds = append(cmds, tea.Println(renderMarkdownContent(m.MDRenderer, delta)))
+		return pickCmd(cmds)
+	}
+
+	lastNewline := strings.LastIndex(delta, "\n")
+	if lastNewline < 0 {
+		return pickCmd(cmds)
+	}
+	commit := delta[:lastNewline+1]
+	m.Stream.ScrollbackLen += len(commit)
+	rendered := renderMarkdownContent(m.MDRenderer, strings.TrimRight(commit, "\n"))
+	cmds = append(cmds, tea.Println(rendered))
+	return pickCmd(cmds)
+}
+
+// pickCmd returns the single command, a batch, or nil.
+func pickCmd(cmds []tea.Cmd) tea.Cmd {
+	switch len(cmds) {
+	case 0:
+		return nil
+	case 1:
+		return cmds[0]
+	default:
+		return tea.Batch(cmds...)
+	}
 }
 
 func applyPostInfer(rt Runtime, m *Model, ev core.Event) tea.Cmd {

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -44,14 +44,6 @@ type RenderContext struct {
 
 	// ── Modal interlock — suppress chrome under a tool prompt ───
 	InteractivePromptActive bool
-
-	// ── Incremental scrollback commit ────────────────────────────
-	// ScrollbackLen tracks bytes of the last assistant message that
-	// have already been committed to terminal scrollback. When > 0
-	// and the last message is streaming, RenderMessageAt renders
-	// only the uncommitted portion so the live View() area stays
-	// small and cursor movement does not trigger terminal auto-scroll.
-	ScrollbackLen int
 }
 
 // inlinedToolResults precomputes which ToolResult messages should be
@@ -175,13 +167,12 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 	case core.RoleNotice:
 		sb.WriteString(RenderSystemMessage(msg.Content))
 	case core.RoleAssistant:
-		// When scrollback has already committed part of this streaming
-		// message, only render the uncommitted tail so the live View()
-		// stays small and cursor movement doesn't trigger auto-scroll.
-		// Also clear thinking once content has started — the thinking
+		// Clear thinking once content has started — the thinking
 		// phase is over and re-rendering it clutters the live view.
-		if isStreaming && p.ScrollbackLen > 0 && p.ScrollbackLen < len(msg.Content) {
-			msg.Content = msg.Content[p.ScrollbackLen:]
+		// The full message is always rendered (not truncated by
+		// ScrollbackLen) so the View height stays stable and the
+		// input area doesn't jump. tailLines clips if it's too tall.
+		if isStreaming && len(msg.Content) > 0 {
 			msg.Thinking = ""
 		}
 		sb.WriteString(renderAssistantWithTools(p, msg, idx, isStreaming))

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -44,6 +44,14 @@ type RenderContext struct {
 
 	// ── Modal interlock — suppress chrome under a tool prompt ───
 	InteractivePromptActive bool
+
+	// ── Incremental scrollback commit ────────────────────────────
+	// ScrollbackLen tracks bytes of the last assistant message that
+	// have already been committed to terminal scrollback. When > 0
+	// and the last message is streaming, RenderMessageAt renders
+	// only the uncommitted portion so the live View() area stays
+	// small and cursor movement does not trigger terminal auto-scroll.
+	ScrollbackLen int
 }
 
 // inlinedToolResults precomputes which ToolResult messages should be
@@ -167,6 +175,15 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 	case core.RoleNotice:
 		sb.WriteString(RenderSystemMessage(msg.Content))
 	case core.RoleAssistant:
+		// When scrollback has already committed part of this streaming
+		// message, only render the uncommitted tail so the live View()
+		// stays small and cursor movement doesn't trigger auto-scroll.
+		// Also clear thinking once content has started — the thinking
+		// phase is over and re-rendering it clutters the live view.
+		if isStreaming && p.ScrollbackLen > 0 && p.ScrollbackLen < len(msg.Content) {
+			msg.Content = msg.Content[p.ScrollbackLen:]
+			msg.Thinking = ""
+		}
 		sb.WriteString(renderAssistantWithTools(p, msg, idx, isStreaming))
 	}
 

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -21,10 +21,11 @@ type RenderContext struct {
 	InlinedResults inlinedToolResults
 
 	// ── Streaming + in-flight tool execution ────────────────────
-	StreamActive bool
-	BuildingTool string
-	PendingCalls []core.ToolCall
-	CurrentIdx   int
+	StreamActive  bool
+	BuildingTool  string
+	ScrollbackLen int // bytes of last assistant message already in terminal scrollback
+	PendingCalls  []core.ToolCall
+	CurrentIdx    int
 
 	// ── Renderer / terminal env ─────────────────────────────────
 	Width      int
@@ -167,13 +168,20 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 	case core.RoleNotice:
 		sb.WriteString(RenderSystemMessage(msg.Content))
 	case core.RoleAssistant:
-		// Clear thinking once content has started — the thinking
-		// phase is over and re-rendering it clutters the live view.
-		// The full message is always rendered (not truncated by
-		// ScrollbackLen) so the View height stays stable and the
-		// input area doesn't jump. tailLines clips if it's too tall.
-		if isStreaming && len(msg.Content) > 0 {
-			msg.Thinking = ""
+		if isStreaming {
+			// Trim the portion already committed to terminal scrollback
+			// so it doesn't appear twice (once in scrollback, once in
+			// the live View area). The live tail stays short, which also
+			// reduces cursor movement from re-rendering and makes it
+			// easier to maintain a scrolled-up position.
+			if p.ScrollbackLen > 0 && p.ScrollbackLen < len(msg.Content) {
+				msg.Content = msg.Content[p.ScrollbackLen:]
+			}
+			// Clear thinking once content has started — the thinking
+			// phase is over and re-rendering it clutters the live view.
+			if len(msg.Content) > 0 {
+				msg.Thinking = ""
+			}
 		}
 		sb.WriteString(renderAssistantWithTools(p, msg, idx, isStreaming))
 	}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -297,9 +297,6 @@ func (m model) messageRenderParams() conv.RenderContext {
 
 		// Modal interlock
 		InteractivePromptActive: m.conv.Modal.Question != nil && m.conv.Modal.Question.IsActive(),
-
-		// Incremental scrollback commit
-		ScrollbackLen: m.conv.Stream.ScrollbackLen,
 	}
 }
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -297,6 +297,9 @@ func (m model) messageRenderParams() conv.RenderContext {
 
 		// Modal interlock
 		InteractivePromptActive: m.conv.Modal.Question != nil && m.conv.Modal.Question.IsActive(),
+
+		// Incremental scrollback commit
+		ScrollbackLen: m.conv.Stream.ScrollbackLen,
 	}
 }
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -274,10 +274,11 @@ func (m model) messageRenderParams() conv.RenderContext {
 		InlinedResults: conv.PrecomputeInlinedResults(m.conv.Messages),
 
 		// Streaming + tool execution
-		StreamActive: m.conv.Stream.Active,
-		BuildingTool: m.conv.Stream.BuildingTool,
-		PendingCalls: m.conv.Tool.PendingCalls,
-		CurrentIdx:   m.conv.Tool.CurrentIdx,
+		StreamActive:  m.conv.Stream.Active,
+		BuildingTool:  m.conv.Stream.BuildingTool,
+		ScrollbackLen: m.conv.Stream.ScrollbackLen,
+		PendingCalls:  m.conv.Tool.PendingCalls,
+		CurrentIdx:    m.conv.Tool.CurrentIdx,
 
 		// Renderer env
 		Width:      m.env.Width,


### PR DESCRIPTION
## User-Facing Change

Previously, streaming output was confined to a small fixed viewport. Once the output exceeded the viewport size, the earlier lines were clipped and completely inaccessible — users had to wait until the full response finished before they could scroll back to read anything that had scrolled off screen.

Now, like the Claude Code CLI, the entire terminal scrolls naturally as output streams in. Completed lines are progressively flushed to native terminal scrollback, so users can freely use the mouse wheel (or trackpad scroll) to review earlier content at any point during streaming — no need to wait for the response to complete.

## Problem

PR #77 simplified the scrolling architecture by removing the in-app scroll viewport and mouse capture, relying on native terminal scrollback. The `tailLines()` cap shows the latest lines of the streaming output in View(), but drops earlier lines — with no way for the user to scroll up to them.

## Root Cause

During streaming, the active (uncommitted) assistant message stays entirely in View(). `tailLines()` truncates it to the available terminal height, showing only the last N lines. The truncated top portion is neither in View() nor in scrollback — the mouse wheel cannot reach it.

Additionally, View() re-renders every frame during streaming. The cursor movement from bubbletea's re-rendering causes the terminal to auto-scroll, making it impossible to maintain a scrolled-up position even for content that IS in scrollback.

## Solution

Restore incremental scrollback commits with proper deduplication:

1. **`commitStreamTail`**: flush completed lines of both thinking and content text to native terminal scrollback at newline boundaries during streaming. Thinking text is committed once (when content first appears). At stream end, `CommittedCount` is advanced to skip `CommitMessages` — preventing duplicate output.

2. **`ScrollbackLen` in `RenderContext`**: tracks bytes of the last assistant message already committed to scrollback. The View() renderer uses this to only draw the **uncommitted tail**, keeping the live area small so cursor movement does not trigger terminal auto-scroll.

3. **Thinking clearing**: when `ScrollbackLen > 0` (content is streaming), the thinking text is cleared from View() rendering — the thinking phase is over and re-rendering it clutters the live view.

## Changes

| File | Change |
|------|--------|
| `conv/conversation.go` | Add `ScrollbackLen` and `ThinkingCommitted` to `StreamState` |
| `conv/update.go` | Add `commitStreamTail` function, call it from `applyChunk` |
| `conv/view.go` | Add `ScrollbackLen` to `RenderContext`, trim content and clear thinking in `RenderMessageAt` |
| `app/view.go` | Pass `ScrollbackLen` through `messageRenderParams` |

## Behavior

- **Thinking phase**: thinking text shows briefly in View(), then committed to scrollback once, hidden from View()
- **Content streaming**: completed lines go to scrollback (mouse-wheel accessible), only the incomplete last line stays in View() (small, stable)
- **Stream end**: remaining tail flushed to scrollback, no duplicate output

🤖 Generated with [Claude Code](https://claude.com/claude-code)