### PR TITLE
feat(llm): add Volcengine Ark provider

### DIFF
--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/ollama"
 	_ "github.com/genai-io/san/internal/llm/openai"
 	_ "github.com/genai-io/san/internal/llm/sensenova"
+	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
 var version = "1.20.0"

--- a/docs/cn/providers.md
+++ b/docs/cn/providers.md
@@ -1,6 +1,6 @@
 # LLM 提供商详解
 
-San 支持 10 个 LLM 提供商，通过空白导入（blank import）在 [`cmd/san/main.go`](../../cmd/san/main.go) 中自动注册。
+San 支持 11 个云端 LLM 提供商（另有 Ollama 本地提供商），通过空白导入（blank import）在 [`cmd/san/main.go`](../../cmd/san/main.go) 中自动注册。
 
 ---
 
@@ -50,6 +50,7 @@ import (
     _ "github.com/genai-io/san/internal/llm/deepseek"
     _ "github.com/genai-io/san/internal/llm/ollama"
     _ "github.com/genai-io/san/internal/llm/sensenova"
+    _ "github.com/genai-io/san/internal/llm/volcengine"
 )
 ```
 
@@ -211,6 +212,17 @@ off → low → medium → high → maximum
 - **特性**：
   - 兼容 Anthropic Messages API 格式
   - 使用静态模型目录，无需动态拉取模型列表
+  - 支持 Bearer Token 认证
+
+---
+
+### 11. Volcengine Ark（火山引擎方舟）
+
+- **包**：[`internal/llm/volcengine/`](../../internal/llm/volcengine/)
+- **API 变量**：`VOLCENGINE_API_KEY`（可选 `VOLCENGINE_BASE_URL`，默认 `https://ark.cn-beijing.volces.com/api/coding`；可选 `VOLCENGINE_MODEL` 作为模型列表回退）
+- **特性**：
+  - 兼容 Anthropic Messages API 格式（复用 anthropic provider 的流式逻辑）
+  - 优先从兼容的 `/v1/models` 获取模型列表，失败时回退到 `VOLCENGINE_MODEL`
   - 支持 Bearer Token 认证
 
 ---

--- a/docs/packages/llm.md
+++ b/docs/packages/llm.md
@@ -7,7 +7,7 @@ layer: feature
 
 Provider registry, model store, and active-connection handle for every LLM backend
 (Anthropic, OpenAI, Google, Moonshot, Alibaba, MiniMax, Z.ai/GLM, DeepSeek,
-Ollama, plus the generic openai-compat shim). Provider implementations live in
+Ollama, SenseNova, Volcengine Ark, plus the generic openai-compat shim). Provider implementations live in
 `internal/llm/<name>/` subpackages.
 
 ## Purpose
@@ -61,7 +61,7 @@ func ResetDefaultConn()       // test-only
   `~/.san/providers.json`; tracks current model.
 - `stream/` — provider-side helpers for SSE parsing.
 - Provider subpackages: `anthropic/`, `openai/`, `google/`, `moonshot/`,
-  `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `openaicompat/`.
+  `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `sensenova/`, `volcengine/`, `openaicompat/`.
 
 ## Lifecycle
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -12,17 +12,18 @@ import (
 type Name string
 
 const (
-	Anthropic Name = "anthropic"
-	OpenAI    Name = "openai"
-	Google    Name = "google"
-	Moonshot  Name = "moonshot"
-	Alibaba   Name = "alibaba"
-	MinMax    Name = "minmax"
-	BigModel  Name = "bigmodel"
-	DeepSeek  Name = "deepseek"
-	SenseNova Name = "sensenova"
-	Ollama    Name = "ollama"
-	Mimo      Name = "mimo"
+	Anthropic  Name = "anthropic"
+	OpenAI     Name = "openai"
+	Google     Name = "google"
+	Moonshot   Name = "moonshot"
+	Alibaba    Name = "alibaba"
+	MinMax     Name = "minmax"
+	BigModel   Name = "bigmodel"
+	DeepSeek   Name = "deepseek"
+	SenseNova  Name = "sensenova"
+	Ollama     Name = "ollama"
+	Mimo       Name = "mimo"
+	Volcengine Name = "volcengine"
 )
 
 // AuthMethod represents an authentication method for an LLM provider.

--- a/internal/llm/volcengine/apikey.go
+++ b/internal/llm/volcengine/apikey.go
@@ -1,0 +1,39 @@
+package volcengine
+
+import (
+	"context"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+const defaultBaseURL = "https://ark.cn-beijing.volces.com/api/coding"
+
+var APIKeyMeta = llm.Meta{
+	Provider:    llm.Volcengine,
+	AuthMethod:  llm.AuthAPIKey,
+	EnvVars:     []string{"VOLCENGINE_API_KEY"},
+	DisplayName: "Bearer Token API",
+}
+
+func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
+	baseURL := secret.Resolve("VOLCENGINE_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := secret.Resolve("VOLCENGINE_API_KEY")
+	client := anthropicsdk.NewClient(
+		anthropicoption.WithAuthToken(apiKey),
+		anthropicoption.WithBaseURL(baseURL),
+	)
+	return NewClientWithConfig(client, "volcengine:api_key", baseURL, apiKey), nil
+}
+
+func init() {
+	llm.RegisterProviderDisplay(llm.Volcengine, llm.ProviderDisplay{Name: "Volcengine Ark (火山引擎)", Order: 120})
+	llm.Register(APIKeyMeta, NewAPIKeyClient)
+}

--- a/internal/llm/volcengine/catalog.go
+++ b/internal/llm/volcengine/catalog.go
@@ -1,0 +1,27 @@
+package volcengine
+
+import (
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+func StaticModels() []llm.ModelInfo {
+	modelID := secret.Resolve("VOLCENGINE_MODEL")
+	if modelID == "" {
+		return nil
+	}
+	return []llm.ModelInfo{{
+		ID:          modelID,
+		Name:        modelID,
+		DisplayName: modelID,
+	}}
+}
+
+func CatalogModel(modelID string) (llm.ModelInfo, bool) {
+	for _, entry := range StaticModels() {
+		if entry.ID == modelID {
+			return entry, true
+		}
+	}
+	return llm.ModelInfo{}, false
+}

--- a/internal/llm/volcengine/client.go
+++ b/internal/llm/volcengine/client.go
@@ -1,0 +1,147 @@
+package volcengine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/genai-io/san/internal/llm"
+	anthropicprovider "github.com/genai-io/san/internal/llm/anthropic"
+)
+
+var modelsClient = &http.Client{Timeout: 10 * time.Second}
+
+type Client struct {
+	inner   *anthropicprovider.Client
+	baseURL string
+	apiKey  string
+}
+
+func NewClient(client anthropicsdk.Client, name string) *Client {
+	return &Client{inner: anthropicprovider.NewClient(client, name)}
+}
+
+func NewClientWithConfig(client anthropicsdk.Client, name, baseURL, apiKey string) *Client {
+	return &Client{
+		inner:   anthropicprovider.NewClient(client, name),
+		baseURL: baseURL,
+		apiKey:  apiKey,
+	}
+}
+
+func (c *Client) Name() string { return c.inner.Name() }
+
+func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	return c.inner.Stream(ctx, opts)
+}
+
+type modelEntry struct {
+	ID          string   `json:"id"`
+	DisplayName string   `json:"display_name"`
+	Name        string   `json:"name"`
+	Status      string   `json:"status"`
+	TaskType    []string `json:"task_type"`
+	Modalities  struct {
+		Output []string `json:"output_modalities"`
+	} `json:"modalities"`
+	TokenLimits struct {
+		ContextWindow int `json:"context_window"`
+		MaxInput      int `json:"max_input_token_length"`
+		MaxOutput     int `json:"max_output_token_length"`
+	} `json:"token_limits"`
+}
+
+type modelsResponse struct {
+	Data []modelEntry `json:"data"`
+}
+
+func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	models, err := c.fetchModels(ctx)
+	if err == nil && len(models) > 0 {
+		return models, nil
+	}
+	return StaticModels(), nil
+}
+
+func (c *Client) fetchModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	if c.baseURL == "" || c.apiKey == "" {
+		return nil, fmt.Errorf("missing volcengine model API configuration")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(c.baseURL, "/")+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := modelsClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list volcengine models: %s", resp.Status)
+	}
+
+	var result modelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	models := make([]llm.ModelInfo, 0, len(result.Data))
+	for _, m := range result.Data {
+		if !isUsableModel(m) {
+			continue
+		}
+		models = append(models, modelInfo(m))
+	}
+	return models, nil
+}
+
+func isUsableModel(m modelEntry) bool {
+	if strings.EqualFold(m.Status, "Shutdown") || strings.EqualFold(m.Status, "Retiring") {
+		return false
+	}
+	if !containsFold(m.Modalities.Output, "text") && !containsFold(m.TaskType, "TextGeneration") && !containsFold(m.TaskType, "VisualQuestionAnswering") {
+		return false
+	}
+	return m.ID != ""
+}
+
+func modelInfo(m modelEntry) llm.ModelInfo {
+	name := m.DisplayName
+	if name == "" {
+		name = m.Name
+	}
+	if name == "" {
+		name = m.ID
+	}
+	inputLimit := m.TokenLimits.MaxInput
+	if inputLimit == 0 {
+		inputLimit = m.TokenLimits.ContextWindow
+	}
+	return llm.ModelInfo{
+		ID:               m.ID,
+		Name:             name,
+		DisplayName:      name,
+		InputTokenLimit:  inputLimit,
+		OutputTokenLimit: m.TokenLimits.MaxOutput,
+	}
+}
+
+func containsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}
+
+var _ llm.Provider = (*Client)(nil)

--- a/internal/llm/volcengine/client_test.go
+++ b/internal/llm/volcengine/client_test.go
@@ -1,0 +1,238 @@
+package volcengine
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
+)
+
+func TestName(t *testing.T) {
+	c := NewClient(anthropicsdk.NewClient(), "volcengine:api_key")
+	if got := c.Name(); got != "volcengine:api_key" {
+		t.Fatalf("Name() = %q, want %q", got, "volcengine:api_key")
+	}
+}
+
+func TestStaticModelsWithoutModel(t *testing.T) {
+	t.Setenv("VOLCENGINE_MODEL", "")
+	models := StaticModels()
+	if len(models) != 0 {
+		t.Fatalf("expected no models, got %d", len(models))
+	}
+}
+
+func TestStaticModelsEnvOverride(t *testing.T) {
+	t.Setenv("VOLCENGINE_MODEL", "ep-custom-model")
+	models := StaticModels()
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ID != "ep-custom-model" {
+		t.Fatalf("model ID = %q, want ep-custom-model", models[0].ID)
+	}
+}
+
+func TestCatalogModel(t *testing.T) {
+	t.Setenv("VOLCENGINE_MODEL", "ep-custom-model")
+	info, ok := CatalogModel("ep-custom-model")
+	if !ok {
+		t.Fatal("expected model to be found in catalog")
+	}
+	if info.DisplayName != "ep-custom-model" {
+		t.Fatalf("DisplayName = %q, want ep-custom-model", info.DisplayName)
+	}
+
+	_, ok = CatalogModel("unknown")
+	if ok {
+		t.Fatal("expected unknown model to not be found")
+	}
+}
+
+func TestAPIKeyMeta(t *testing.T) {
+	if APIKeyMeta.Provider != llm.Volcengine {
+		t.Fatalf("provider = %q, want %q", APIKeyMeta.Provider, llm.Volcengine)
+	}
+	if APIKeyMeta.AuthMethod != llm.AuthAPIKey {
+		t.Fatalf("auth method = %q, want %q", APIKeyMeta.AuthMethod, llm.AuthAPIKey)
+	}
+	if len(APIKeyMeta.EnvVars) != 1 || APIKeyMeta.EnvVars[0] != "VOLCENGINE_API_KEY" {
+		t.Fatalf("env vars = %v, want [VOLCENGINE_API_KEY]", APIKeyMeta.EnvVars)
+	}
+	if APIKeyMeta.Key() != "volcengine:api_key" {
+		t.Fatalf("key = %q, want volcengine:api_key", APIKeyMeta.Key())
+	}
+}
+
+type modelsTransport struct {
+	body string
+	code int
+	auth string
+}
+
+func (t *modelsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.auth = req.Header.Get("Authorization")
+	code := t.code
+	if code == 0 {
+		code = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: code,
+		Status:     http.StatusText(code),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Request:    req,
+	}, nil
+}
+
+func withMockModelsClient(transport http.RoundTripper, fn func()) {
+	orig := modelsClient
+	modelsClient = &http.Client{Transport: transport}
+	defer func() { modelsClient = orig }()
+	fn()
+}
+
+func TestListModelsFromAPI(t *testing.T) {
+	transport := &modelsTransport{body: `{"data":[
+		{"id":"ep-model-1","display_name":"Ark Model 1","task_type":["TextGeneration"],"modalities":{"output_modalities":["text"]},"token_limits":{"context_window":262144,"max_input_token_length":229376,"max_output_token_length":32768}},
+		{"id":"ep-model-2","name":"Ark Model 2","task_type":["VisualQuestionAnswering"],"modalities":{"output_modalities":["text"]},"token_limits":{"context_window":32768,"max_output_token_length":12288}},
+		{"id":"shutdown-model","name":"Shutdown","status":"Shutdown","task_type":["TextGeneration"],"modalities":{"output_modalities":["text"]}},
+		{"id":"retiring-model","name":"Retiring","status":"Retiring","task_type":["TextGeneration"],"modalities":{"output_modalities":["text"]}},
+		{"id":"embedding-model","name":"Embedding","task_type":["TextEmbedding"],"modalities":{}},
+		{"id":"image-model","name":"Image","task_type":["TextToImage"],"modalities":{"output_modalities":["image"]}}
+	]}`}
+	withMockModelsClient(transport, func() {
+		c := NewClientWithConfig(anthropicsdk.NewClient(), "volcengine:test", "https://example.com/api/coding", "test-token")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+		if len(models) != 2 {
+			t.Fatalf("expected 2 models, got %d: %+v", len(models), models)
+		}
+		if models[0].ID != "ep-model-1" || models[0].DisplayName != "Ark Model 1" {
+			t.Fatalf("unexpected first model: %+v", models[0])
+		}
+		if models[0].InputTokenLimit != 229376 || models[0].OutputTokenLimit != 32768 {
+			t.Fatalf("unexpected first model limits: %+v", models[0])
+		}
+		if models[1].InputTokenLimit != 32768 || models[1].OutputTokenLimit != 12288 {
+			t.Fatalf("unexpected second model limits: %+v", models[1])
+		}
+		if transport.auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer test-token", transport.auth)
+		}
+	})
+}
+
+func TestListModelsFallbackToEnvModel(t *testing.T) {
+	t.Setenv("VOLCENGINE_MODEL", "ep-fallback")
+	withMockModelsClient(&modelsTransport{code: http.StatusUnauthorized}, func() {
+		c := NewClientWithConfig(anthropicsdk.NewClient(), "volcengine:test", "https://example.com/api/coding", "test-token")
+		models, err := c.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+		if len(models) != 1 || models[0].ID != "ep-fallback" {
+			t.Fatalf("fallback models = %+v, want ep-fallback", models)
+		}
+	})
+}
+
+type captureTransport struct {
+	auth string
+	body []byte
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.auth = req.Header.Get("Authorization")
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		t.body = body
+	}
+
+	streamBody := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"doubao-seed-code","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(streamBody)),
+		Request:    req,
+	}, nil
+}
+
+func TestStreamSendsBearerAuthAndRequest(t *testing.T) {
+	transport := &captureTransport{}
+	client := anthropicsdk.NewClient(
+		anthropicoption.WithAuthToken("test-token"),
+		anthropicoption.WithBaseURL("https://example.com/api/coding"),
+		anthropicoption.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	c := NewClient(client, "volcengine:test")
+
+	ch := c.Stream(context.Background(), llm.CompletionOptions{
+		Model:    "doubao-seed-code",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+
+	var text string
+	var gotDone bool
+	for chunk := range ch {
+		switch chunk.Type {
+		case llm.ChunkTypeText:
+			text += chunk.Text
+		case llm.ChunkTypeDone:
+			gotDone = true
+		case llm.ChunkTypeError:
+			t.Fatalf("stream error: %v", chunk.Error)
+		}
+	}
+
+	if transport.auth != "Bearer test-token" {
+		t.Fatalf("Authorization = %q, want Bearer test-token", transport.auth)
+	}
+	if !strings.Contains(string(transport.body), `"model":"doubao-seed-code"`) {
+		t.Fatalf("request body missing model: %s", string(transport.body))
+	}
+	if !gotDone {
+		t.Fatal("stream ended without done chunk")
+	}
+	if text != "hello" {
+		t.Fatalf("text = %q, want hello", text)
+	}
+}
+
+func TestDefaultBaseURL(t *testing.T) {
+	if defaultBaseURL != "https://ark.cn-beijing.volces.com/api/coding" {
+		t.Fatalf("defaultBaseURL = %q", defaultBaseURL)
+	}
+}
+
+func TestProviderImplementsInterface(t *testing.T) {
+	var _ llm.Provider = (*Client)(nil)
+}


### PR DESCRIPTION
## What & why

Add a Volcengine Ark LLM provider that reuses the Anthropic-compatible streaming path with Ark's coding endpoint. Model listing now reads Ark's `/v1/models`, filters out unusable/non-text inventory, and keeps token limits for model selection.

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] Other:

## Testing

```bash
go test ./internal/llm/volcengine ./internal/llm ./internal/app/input
go test ./...
```

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [x] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)