### PR TITLE
feat(persona): add internal/persona package

### DIFF
--- a/internal/persona/README.md.tmpl
+++ b/internal/persona/README.md.tmpl
@@ -1,0 +1,35 @@
+# Personas
+
+A persona is a switchable bundle of a system prompt, a skill set, and a config
+overlay. Switch with `/persona <name>` (or `/persona` to open a picker).
+
+Each persona is a directory under `~/.san/personas/<name>/` (user level) or
+`.san/personas/<name>/` inside a project (project overrides user):
+
+    <name>/
+      system/
+        identity.md    # optional — who you are
+        behavior.md    # optional — how you communicate and work
+        rules.md       # optional — safety + tool/task/git rules
+      skills/
+        <skill>/SKILL.md   # optional — skills bundled with this persona
+      settings.json    # optional — description, skill states, config overlay
+
+Every file is optional. Provide only the parts you want to change; anything you
+omit falls back to San's built-in default. The smallest useful persona is a
+single `system/identity.md`.
+
+## settings.json
+
+    {
+      "description": "ML research specialist (PyTorch/JAX)",
+      "skills": { "lit-review": "active", "deep-research": "disable" },
+      "disabledTools": { "WebSearch": false },
+      "permissions": { "allow": ["Bash(pytest:*)"] }
+    }
+
+`skills` maps a skill name to `active` / `enable` / `disable`, applied in memory
+while the persona is selected. The rest is a settings overlay applied on top of
+your user and project settings while the persona is active.
+
+The `default` persona is built in and has no directory.

--- a/internal/persona/path.go
+++ b/internal/persona/path.go
@@ -33,16 +33,12 @@ func IsPersonaFile(cwd, path string) bool {
 }
 
 func personaRoots(cwd string) []string {
-	var roots []string
+	var dirs []string
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		roots = append(roots, home)
+		dirs = append(dirs, filepath.Join(home, confdir.Name, "personas"))
 	}
 	if cwd != "" {
-		roots = append(roots, cwd)
-	}
-	dirs := make([]string, 0, len(roots))
-	for _, root := range roots {
-		dirs = append(dirs, filepath.Join(root, confdir.Name, "personas"))
+		dirs = append(dirs, filepath.Join(cwd, confdir.Name, "personas"))
 	}
 	return dirs
 }

--- a/internal/persona/path.go
+++ b/internal/persona/path.go
@@ -1,0 +1,60 @@
+package persona
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/genai-io/san/internal/confdir"
+)
+
+// IsPersonaFile reports whether path points inside a user- or project-level
+// persona directory (any file under <root>/.san/personas/<name>/). Used to
+// trigger a registry reload when a persona file is edited.
+func IsPersonaFile(cwd, path string) bool {
+	if path == "" {
+		return false
+	}
+	// Cheap substring guard before paying for filepath.Abs/UserHomeDir.
+	slash := filepath.ToSlash(path)
+	if !strings.Contains(slash, "/"+confdir.Name+"/personas/") {
+		return false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	for _, dir := range personaRoots(cwd) {
+		if isWithinDir(abs, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func personaRoots(cwd string) []string {
+	var roots []string
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		roots = append(roots, home)
+	}
+	if cwd != "" {
+		roots = append(roots, cwd)
+	}
+	dirs := make([]string, 0, len(roots))
+	for _, root := range roots {
+		dirs = append(dirs, filepath.Join(root, confdir.Name, "personas"))
+	}
+	return dirs
+}
+
+func isWithinDir(path, dir string) bool {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absDir, path)
+	if err != nil || rel == "." || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/persona/persona.go
+++ b/internal/persona/persona.go
@@ -1,0 +1,185 @@
+// Package persona manages user-defined personas: switchable bundles of a
+// system prompt, a skill set, and a config overlay.
+//
+// A persona is a directory:
+//
+//	<name>/
+//	  system/
+//	    identity.md   (optional) overrides the identity part
+//	    behavior.md   (optional) overrides the behavior part
+//	    rules.md      (optional) overrides the rules part
+//	  skills/
+//	    <skill>/SKILL.md   persona-scoped skills
+//	  settings.json   (optional) description + skill states + config overlay
+//
+// Personas live under:
+//   - ~/.san/personas/<name>/   (user level)
+//   - .san/personas/<name>/     (project level — overrides user)
+//
+// The "default" persona is virtual: it represents San's built-in prompt with
+// no skills and no overlay, and has no directory.
+//
+// This package only discovers, parses, and serves personas. Applying one
+// (system-prompt override, skill activation, settings overlay) belongs to the
+// system, skill, and app layers.
+package persona
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DefaultName is the reserved name of the virtual built-in persona. An empty
+// selection and "default" are equivalent — both mean "use San's built-ins".
+const DefaultName = "default"
+
+// Scope tells where a persona was loaded from.
+type Scope int
+
+const (
+	ScopeBuiltin Scope = iota // virtual default persona
+	ScopeUser                 // ~/.san/personas/
+	ScopeProject              // .san/personas/  (overrides user)
+)
+
+// Persona is one persona bundle parsed from disk.
+type Persona struct {
+	Name        string // directory name, kebab-case
+	Description string // one-liner from settings.json
+	Dir         string // absolute path to the persona directory ("" for default)
+	Scope       Scope
+
+	// System-prompt part overrides — raw markdown bodies. An empty string
+	// means "use San's built-in default for that part".
+	Identity string
+	Behavior string
+	Rules    string
+
+	// SkillDirs are absolute paths to skill directories (each holding a
+	// SKILL.md) bundled with this persona.
+	SkillDirs []string
+
+	// Settings is the parsed settings.json (description, skill states, config
+	// overlay), or nil when the persona has no settings.json.
+	Settings *Settings
+}
+
+// IsBuiltin reports whether this persona is the virtual default.
+func (p Persona) IsBuiltin() bool { return p.Scope == ScopeBuiltin }
+
+// DefaultPersona returns the virtual built-in persona shown in the selector.
+// Its part overrides are empty — the built-in prompt is rendered by the system
+// builder, not from this struct.
+func DefaultPersona() *Persona {
+	return &Persona{
+		Name:        DefaultName,
+		Description: "Built-in San persona — software engineering generalist",
+		Scope:       ScopeBuiltin,
+	}
+}
+
+// parseDir loads a persona from a directory. It returns (nil, false) when the
+// directory is not a persona — no system/ part files, no skills, and no
+// settings.json.
+func parseDir(dir string) (*Persona, bool) {
+	p := &Persona{Name: filepath.Base(dir), Dir: dir}
+	found := false
+
+	// system/<part>.md overrides — pure markdown bodies (no frontmatter).
+	sysDir := filepath.Join(dir, "system")
+	p.Identity = readPart(sysDir, "identity.md")
+	p.Behavior = readPart(sysDir, "behavior.md")
+	p.Rules = readPart(sysDir, "rules.md")
+	if p.Identity != "" || p.Behavior != "" || p.Rules != "" {
+		found = true
+	}
+
+	// skills/<name>/SKILL.md bundle.
+	p.SkillDirs = skillDirs(filepath.Join(dir, "skills"))
+	if len(p.SkillDirs) > 0 {
+		found = true
+	}
+
+	// settings.json — description + skill states + config overlay.
+	if s, ok := parseSettings(filepath.Join(dir, "settings.json")); ok {
+		p.Settings = s
+		p.Description = s.Description
+		found = true
+	}
+
+	if !found {
+		return nil, false
+	}
+	return p, true
+}
+
+// readPart reads system/<file>, trimmed. A missing file yields "".
+func readPart(sysDir, file string) string {
+	data, err := os.ReadFile(filepath.Join(sysDir, file))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// skillDirs returns the immediate subdirectories of root that contain a
+// SKILL.md (the persona's bundled skills).
+func skillDirs(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sub := filepath.Join(root, e.Name())
+		if hasSkillFile(sub) {
+			out = append(out, sub)
+		}
+	}
+	return out
+}
+
+func hasSkillFile(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.EqualFold(e.Name(), "SKILL.md") {
+			return true
+		}
+	}
+	return false
+}
+
+// sortPersonas orders personas for stable display: default first, then
+// project-level, then user-level, alphabetical within each group. Display
+// order differs from Scope precedence (which ranks project > user when
+// resolving name collisions) — project entries are shown above user ones
+// because they are more specific to the current context.
+func sortPersonas(items []*Persona) {
+	sort.Slice(items, func(i, j int) bool {
+		wi, wj := displayWeight(items[i].Scope), displayWeight(items[j].Scope)
+		if wi != wj {
+			return wi < wj
+		}
+		return items[i].Name < items[j].Name
+	})
+}
+
+func displayWeight(s Scope) int {
+	switch s {
+	case ScopeBuiltin:
+		return 0
+	case ScopeProject:
+		return 1
+	case ScopeUser:
+		return 2
+	}
+	return 3
+}

--- a/internal/persona/persona_test.go
+++ b/internal/persona/persona_test.go
@@ -1,0 +1,230 @@
+package persona
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestParseDir_LoadsParts(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ml-researcher")
+	writeFile(t, filepath.Join(dir, "system", "identity.md"), "You are an ML researcher.\n")
+	writeFile(t, filepath.Join(dir, "system", "behavior.md"), "  Discuss like a peer.  ")
+	writeFile(t, filepath.Join(dir, "skills", "lit-review", "SKILL.md"), "---\nname: lit-review\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, "settings.json"), `{"description":"ML research","skills":{"lit-review":"active"}}`)
+
+	p, ok := parseDir(dir)
+	if !ok {
+		t.Fatal("expected persona to load")
+	}
+	if p.Name != "ml-researcher" {
+		t.Errorf("Name = %q", p.Name)
+	}
+	if p.Identity != "You are an ML researcher." {
+		t.Errorf("Identity = %q", p.Identity)
+	}
+	if p.Behavior != "Discuss like a peer." {
+		t.Errorf("Behavior = %q (want trimmed)", p.Behavior)
+	}
+	if p.Rules != "" {
+		t.Errorf("Rules = %q, want empty (no rules.md)", p.Rules)
+	}
+	if len(p.SkillDirs) != 1 {
+		t.Fatalf("SkillDirs = %v, want 1", p.SkillDirs)
+	}
+	if p.Description != "ML research" {
+		t.Errorf("Description = %q", p.Description)
+	}
+	if p.Settings == nil || p.Settings.Skills["lit-review"] != "active" {
+		t.Errorf("Settings.Skills not parsed: %+v", p.Settings)
+	}
+}
+
+func TestParseDir_SkipsEmptyDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parseDir(dir); ok {
+		t.Error("an empty directory should not be a persona")
+	}
+}
+
+func TestParseDir_SettingsOnlyIsValid(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cfg-only")
+	writeFile(t, filepath.Join(dir, "settings.json"), `{"description":"config overlay only"}`)
+	p, ok := parseDir(dir)
+	if !ok {
+		t.Fatal("settings-only persona should load")
+	}
+	if p.Description != "config overlay only" {
+		t.Errorf("Description = %q", p.Description)
+	}
+}
+
+func TestParseDir_ToleratesBrokenSettings(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "broken")
+	writeFile(t, filepath.Join(dir, "system", "identity.md"), "You are X.\n")
+	writeFile(t, filepath.Join(dir, "settings.json"), `{ not valid json `)
+	p, ok := parseDir(dir)
+	if !ok {
+		t.Fatal("persona with a system file should load despite broken settings.json")
+	}
+	if p.Settings != nil {
+		t.Error("broken settings.json should yield nil Settings")
+	}
+}
+
+func TestParseDir_OverlayFields(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "overlay")
+	writeFile(t, filepath.Join(dir, "settings.json"),
+		`{"description":"o","disabledTools":{"WebSearch":true},"permissions":{"allow":["Bash(pytest:*)"]}}`)
+	p, ok := parseDir(dir)
+	if !ok {
+		t.Fatal("expected persona to load")
+	}
+	if !p.Settings.DisabledTools["WebSearch"] {
+		t.Errorf("overlay disabledTools not parsed: %+v", p.Settings.DisabledTools)
+	}
+	if len(p.Settings.Permissions.Allow) != 1 || p.Settings.Permissions.Allow[0] != "Bash(pytest:*)" {
+		t.Errorf("overlay permissions not parsed: %+v", p.Settings.Permissions)
+	}
+}
+
+func TestRegistry_ProjectOverridesUser(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeFile(t, filepath.Join(home, ".san", "personas", "ml", "settings.json"),
+		`{"description":"user-level ml"}`)
+	writeFile(t, filepath.Join(cwd, ".san", "personas", "ml", "settings.json"),
+		`{"description":"project-level ml"}`)
+
+	r := NewRegistry(cwd)
+	got, ok := r.Get("ml")
+	if !ok {
+		t.Fatal("expected ml persona to be registered")
+	}
+	if got.Scope != ScopeProject {
+		t.Errorf("Scope = %v, want ScopeProject", got.Scope)
+	}
+	if got.Description != "project-level ml" {
+		t.Errorf("Description = %q, want project-level", got.Description)
+	}
+}
+
+func TestRegistry_ListDefaultFirst(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".san", "personas", "zeta", "settings.json"), `{"description":"z"}`)
+
+	r := NewRegistry("")
+	list := r.List()
+	if len(list) < 2 {
+		t.Fatalf("expected default + zeta, got %d", len(list))
+	}
+	if list[0].Name != DefaultName || !list[0].IsBuiltin() {
+		t.Errorf("first entry = %q, want builtin default", list[0].Name)
+	}
+}
+
+func TestRegistry_LoadDirSkipsDefaultName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".san", "personas", "default", "settings.json"), `{"description":"reserved"}`)
+
+	r := NewRegistry("")
+	got, _ := r.Get("default")
+	if got == nil || !got.IsBuiltin() {
+		t.Error("'default' must resolve to the virtual builtin, not a user directory")
+	}
+}
+
+func TestSortPersonas_DefaultProjectUser(t *testing.T) {
+	items := []*Persona{
+		{Name: "z-user", Scope: ScopeUser},
+		{Name: "a-project", Scope: ScopeProject},
+		{Name: "default", Scope: ScopeBuiltin},
+		{Name: "a-user", Scope: ScopeUser},
+	}
+	sortPersonas(items)
+	want := []string{"default", "a-project", "a-user", "z-user"}
+	for i, w := range want {
+		if items[i].Name != w {
+			t.Fatalf("pos %d = %q, want %q", i, items[i].Name, w)
+		}
+	}
+}
+
+func TestDefaultPersona_IsBuiltin(t *testing.T) {
+	p := DefaultPersona()
+	if !p.IsBuiltin() {
+		t.Error("DefaultPersona should report IsBuiltin() == true")
+	}
+	if p.Identity != "" || p.Behavior != "" || p.Rules != "" {
+		t.Error("DefaultPersona part overrides should be empty")
+	}
+}
+
+func TestIsPersonaFile(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	inside := []string{
+		filepath.Join(home, ".san", "personas", "ml", "system", "identity.md"),
+		filepath.Join(cwd, ".san", "personas", "go", "settings.json"),
+		filepath.Join(cwd, ".san", "personas", "go", "skills", "x", "SKILL.md"),
+	}
+	for _, p := range inside {
+		if !IsPersonaFile(cwd, p) {
+			t.Errorf("IsPersonaFile(%q) = false, want true", p)
+		}
+	}
+
+	outside := []string{
+		filepath.Join(home, ".san", "identities", "ml.md"),
+		filepath.Join(cwd, "personas", "go", "settings.json"), // not under .san
+		"",
+	}
+	for _, p := range outside {
+		if IsPersonaFile(cwd, p) {
+			t.Errorf("IsPersonaFile(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestEnsureUserDir_IsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureUserDir(); err != nil {
+		t.Fatalf("EnsureUserDir first call: %v", err)
+	}
+	readme := filepath.Join(home, ".san", "personas", "README.md")
+	custom := []byte("user-edited README\n")
+	if err := os.WriteFile(readme, custom, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := EnsureUserDir(); err != nil {
+		t.Fatalf("EnsureUserDir second call: %v", err)
+	}
+	got, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(custom) {
+		t.Error("README should not be overwritten on the second call")
+	}
+}

--- a/internal/persona/registry.go
+++ b/internal/persona/registry.go
@@ -1,0 +1,139 @@
+package persona
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/genai-io/san/internal/confdir"
+)
+
+var (
+	mu         sync.RWMutex
+	defaultReg *Registry
+)
+
+// Default returns the package-level Registry, or a registry holding only the
+// virtual default if Initialize has not been called.
+func Default() *Registry {
+	mu.RLock()
+	defer mu.RUnlock()
+	if defaultReg == nil {
+		def := DefaultPersona()
+		return &Registry{
+			byName:   map[string]*Persona{DefaultName: def},
+			personas: []*Persona{def},
+		}
+	}
+	return defaultReg
+}
+
+// SetDefault replaces the package-level singleton.
+func SetDefault(r *Registry) {
+	mu.Lock()
+	defer mu.Unlock()
+	defaultReg = r
+}
+
+// Initialize creates a Registry for the given cwd, ensures the user-level
+// personas directory exists with its README, and installs the result as the
+// default singleton. Safe to call repeatedly (e.g. on cwd change).
+func Initialize(cwd string) {
+	_ = EnsureUserDir() // best-effort; ignore errors on read-only homes
+	SetDefault(NewRegistry(cwd))
+}
+
+// Registry holds the personas discovered on disk plus the virtual default. It
+// scans both ~/.san/personas/ and <cwd>/.san/personas/.
+//
+// The Registry is read-only after construction; the active persona is stored
+// in settings, not in the registry.
+type Registry struct {
+	mu       sync.RWMutex
+	cwd      string
+	personas []*Persona // default + loaded, in display order
+	byName   map[string]*Persona
+}
+
+// NewRegistry creates a Registry and loads personas from disk. If cwd is
+// empty, only user-level personas are loaded.
+func NewRegistry(cwd string) *Registry {
+	r := &Registry{cwd: cwd}
+	r.reload()
+	return r
+}
+
+// Reload re-scans the user and project persona directories.
+func (r *Registry) Reload() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reload()
+}
+
+func (r *Registry) reload() {
+	items := []*Persona{DefaultPersona()}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		items = append(items, loadDir(filepath.Join(confdir.Dir(home), "personas"), ScopeUser)...)
+	}
+	if r.cwd != "" {
+		items = append(items, loadDir(filepath.Join(confdir.Dir(r.cwd), "personas"), ScopeProject)...)
+	}
+
+	// Project overrides user when names collide; keep the highest-priority entry.
+	byName := make(map[string]*Persona, len(items))
+	for _, it := range items {
+		if existing, ok := byName[it.Name]; !ok || it.Scope > existing.Scope {
+			byName[it.Name] = it
+		}
+	}
+	final := make([]*Persona, 0, len(byName))
+	for _, it := range byName {
+		final = append(final, it)
+	}
+	sortPersonas(final)
+
+	r.personas = final
+	r.byName = byName
+}
+
+// List returns all personas in display order (default first).
+func (r *Registry) List() []*Persona {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*Persona, len(r.personas))
+	copy(out, r.personas)
+	return out
+}
+
+// Get looks up a persona by name. Returns (nil, false) for unknown names.
+// "default" returns the virtual built-in.
+func (r *Registry) Get(name string) (*Persona, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.byName[name]
+	return p, ok
+}
+
+// loadDir scans a single personas root, treating each subdirectory as a
+// persona named after it. The reserved "default" name is skipped.
+func loadDir(root string, scope Scope) []*Persona {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []*Persona
+	for _, e := range entries {
+		if !e.IsDir() || strings.EqualFold(e.Name(), DefaultName) {
+			continue
+		}
+		p, ok := parseDir(filepath.Join(root, e.Name()))
+		if !ok {
+			continue
+		}
+		p.Scope = scope
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/persona/settings.go
+++ b/internal/persona/settings.go
@@ -1,0 +1,43 @@
+package persona
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/genai-io/san/internal/setting"
+)
+
+// Settings is a persona's settings.json: a description, per-skill states, and
+// a configuration overlay. The overlay reuses setting.Data so a persona can
+// override the same fields the layered settings files do (permissions,
+// disabled tools, model, …); the app layer applies it as the highest overlay
+// while the persona is selected.
+//
+// Skills maps a skill name to "active" / "enable" / "disable". These states
+// apply in-memory while the persona is selected and are never written to
+// skills.json.
+type Settings struct {
+	Description string            `json:"description,omitempty"`
+	Skills      map[string]string `json:"skills,omitempty"`
+
+	// Embedded so the overlay fields (permissions, disabledTools, model, …)
+	// sit at the top level of settings.json, e.g. {"disabledTools": {...}}.
+	setting.Data
+}
+
+// parseSettings reads and parses a persona's settings.json. It returns
+// (nil, false) when the file is missing or malformed — a persona with a broken
+// settings.json still loads from its system/ and skills/ contents.
+func parseSettings(path string) (*Settings, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var s Settings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, false
+	}
+	s.Description = strings.TrimSpace(s.Description)
+	return &s, true
+}

--- a/internal/persona/template.go
+++ b/internal/persona/template.go
@@ -1,0 +1,30 @@
+package persona
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+
+	"github.com/genai-io/san/internal/confdir"
+)
+
+//go:embed README.md.tmpl
+var readmeTemplate string
+
+// EnsureUserDir creates ~/.san/personas/ and writes README.md if missing.
+// Idempotent: an existing README is not overwritten.
+func EnsureUserDir() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(confdir.Dir(home), "personas")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	readme := filepath.Join(dir, "README.md")
+	if _, err := os.Stat(readme); err == nil {
+		return nil // already exists, do not overwrite
+	}
+	return os.WriteFile(readme, []byte(readmeTemplate), 0o644)
+}


### PR DESCRIPTION
## What

Phase 2 of the persona system (design: `notes/active/persona-system.md`). A new `internal/persona` package that **discovers, parses, and serves** personas — switchable bundles of a system prompt, a skill set, and a config overlay.

A persona is a directory under `~/.san/personas/<name>/` (user) or `.san/personas/<name>/` (project, wins on name collision):

    <name>/
      system/
        identity.md   # optional — overrides the identity part
        behavior.md   # optional — overrides the behavior part
        rules.md      # optional — overrides the rules part
      skills/
        <skill>/SKILL.md   # optional — bundled skills
      settings.json   # optional — description + skill states + config overlay

Every file is optional; the smallest useful persona is one `system/identity.md`.

## Design notes

- **Mirrors `internal/identity`**: scope-ranked dual-root scan (`ScopeBuiltin`/`User`/`Project`), virtual `default` entry, `EnsureUserDir` + embedded README, and `IsPersonaFile` for reload-on-edit. The difference is structural — a persona is a *directory* (parsed via `parseDir`), not a single `.md`.
- **`settings.json` embeds `setting.Data`**, so the config overlay reuses the existing settings shape (`permissions`, `disabledTools`, `model`, …) at the top level, plus `description` and a `skills` state map (`active`/`enable`/`disable`).
- **Tolerant parsing**: a directory with no `system/`, `skills/`, or `settings.json` is skipped; a malformed `settings.json` doesn't prevent the persona from loading its prompt/skills.

## Scope

**Discovery and parsing only.** Applying a persona — system-prompt override, skill activation, settings overlay, the `/persona` command — lands in later phases. Nothing imports this package yet, so it's inert.

## Verification

`go build`, `go vet`, `gofmt`, full `go test ./...` all pass; 12 package tests cover parsing, project-overrides-user, default-first ordering, the overlay fields, `IsPersonaFile`, and idempotent `EnsureUserDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)