### PR TITLE
docs: split installation instructions by platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,11 @@ San is a terminal-native **unified runtime for specialized agents** — coding a
 
 ## Installation
 
+**macOS / Linux**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 ```
-
-Re-run to upgrade. To uninstall:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash -s uninstall
-```
-
-<details>
-<summary><b>Other methods</b></summary>
 
 **Windows (PowerShell)**
 
@@ -71,9 +64,20 @@ curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex
 ```
 
-Re-run to upgrade. To uninstall:
+Re-run to upgrade.
+
+<details>
+<summary><b>Other methods</b></summary>
+
+**Uninstall**
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash -s uninstall
+```
 
 ```powershell
+# Windows (PowerShell)
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1))) uninstall
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,18 +52,11 @@ San 是面向终端的**专用 Agent 统一运行时**（Unified Specialized Age
 
 ## 安装
 
+**macOS / Linux**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 ```
-
-升级直接重新执行同样的命令。卸载：
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash -s uninstall
-```
-
-<details>
-<summary><b>其他安装方式</b></summary>
 
 **Windows (PowerShell)**
 
@@ -71,9 +64,20 @@ curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex
 ```
 
-升级直接重新执行同样的命令。卸载：
+升级直接重新执行同样的命令。
+
+<details>
+<summary><b>其他方式</b></summary>
+
+**卸载**
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash -s uninstall
+```
 
 ```powershell
+# Windows (PowerShell)
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1))) uninstall
 ```
 

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -47,11 +47,18 @@
         <div class="num">1</div>
         <div class="step-body">
           <h3>Install</h3>
-          <p>One command on macOS or Linux. Re-run anytime to upgrade.</p>
+          <p>One command. Re-run anytime to upgrade.</p>
+          <p style="margin-top:14px;"><b>macOS / Linux</b></p>
           <div class="cmd">
             <span class="prompt">$</span>
             <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
             <button class="copy-btn" onclick="copyEl('install-cmd', this)">Copy</button>
+          </div>
+          <p style="margin-top:14px;"><b>Windows (PowerShell)</b></p>
+          <div class="cmd">
+            <span class="prompt">&gt;</span>
+            <code id="install-cmd-win">irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex</code>
+            <button class="copy-btn" onclick="copyEl('install-cmd-win', this)">Copy</button>
           </div>
           <p style="margin-top:14px;">Prefer Go? <code class="inline">go install github.com/genai-io/san/cmd/san@latest</code></p>
         </div>


### PR DESCRIPTION
Surface the Windows PowerShell installer alongside macOS/Linux as top-level options in README, README.zh, and the site getting-started page, instead of hiding it under the collapsed "Other methods" section. Uninstall commands move into that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)