### PR TITLE
feat(system): make all prompt parts persona-overridable

### DIFF
--- a/internal/core/system/builder.go
+++ b/internal/core/system/builder.go
@@ -15,6 +15,16 @@ import (
 // Option configures a buildConfig during Build. Options are applied in order.
 type Option func(*buildConfig)
 
+// Persona holds the prompt-part overrides a persona supplies — identity,
+// behavior, and rules. An empty field means "keep San's built-in default for
+// that part". This is the system layer's view of a persona (just the prompt
+// bodies); the full on-disk bundle lives in internal/persona.Persona.
+type Persona struct {
+	Identity string
+	Behavior string
+	Rules    string
+}
+
 // buildConfig accumulates everything Build needs to render the prompt parts.
 // Options populate it; Build then constructs each part once from the resolved
 // values.
@@ -23,7 +33,7 @@ type buildConfig struct {
 	isGit    bool
 	provider string
 	env      *Environment   // volatile footer; nil when not supplied
-	identity string         // persona/user identity override; "" = built-in default
+	persona  Persona        // per-part overrides; empty fields use the default
 	subagent *SubagentBrief // non-nil for a subagent charter
 }
 
@@ -46,18 +56,18 @@ func Build(scope core.Scope, opts ...Option) core.System {
 	if cfg.subagent != nil {
 		sys.Use(subagentIdentitySection(*cfg.subagent), caller)
 	} else {
-		sys.Use(identitySection(cfg.identity), caller)
+		sys.Use(identitySection(cfg.persona.Identity), caller)
 	}
 
 	// Behavior (slot 1): communication style + engineering defaults. Main
 	// agent only — subagents carry their working style in their charter.
 	if scope == core.ScopeMain {
-		sys.Use(behaviorSection(), caller)
+		sys.Use(behaviorSection(cfg.persona.Behavior), caller)
 	}
 
 	// Rules (slot 2): safety contract + tool/task/git protocols, scope-aware,
 	// with git folded in when isGit and any provider quirks appended.
-	sys.Use(rulesSection(scope, cfg.isGit, cfg.provider), caller)
+	sys.Use(rulesSection(scope, cfg.isGit, cfg.provider, cfg.persona.Rules), caller)
 
 	// Environment (slot 3): volatile footer, only when supplied.
 	if cfg.env != nil {

--- a/internal/core/system/catalog.go
+++ b/internal/core/system/catalog.go
@@ -131,10 +131,21 @@ func identitySection(override string) core.Section {
 // the communication style (Tone / Updates / Behavior) and the engineering
 // defaults (Restraint / Code conventions / Error handling). Main-agent only;
 // subagents carry their working style in their charter.
-func behaviorSection() core.Section {
+func behaviorSection(override string) core.Section {
+	override = strings.TrimSpace(override)
+	source := core.Predefined
+	if override != "" {
+		source = core.FromFile
+	}
 	return core.Section{
-		Slot: core.SlotBehavior, Name: "behavior", Source: core.Predefined,
-		Render: func() string { return wrap("behavior", nil, cachedBehavior) },
+		Slot: core.SlotBehavior, Name: "behavior", Source: source,
+		Render: func() string {
+			body := override
+			if body == "" {
+				body = cachedBehavior
+			}
+			return wrap("behavior", nil, body)
+		},
 	}
 }
 
@@ -144,11 +155,20 @@ func behaviorSection() core.Section {
 // (tools and system-reminders always; task tracking and interactive questions
 // for the main agent), with git safety folded in when isGit and any provider
 // quirks appended last. Subagents get the safety + tool subset.
-func rulesSection(scope core.Scope, isGit bool, provider string) core.Section {
+func rulesSection(scope core.Scope, isGit bool, provider, override string) core.Section {
+	override = strings.TrimSpace(override)
+	source := core.Predefined
+	if override != "" {
+		source = core.FromFile
+	}
 	return core.Section{
-		Slot: core.SlotRules, Name: "rules", Source: core.Predefined,
+		Slot: core.SlotRules, Name: "rules", Source: source,
 		Render: func() string {
-			return wrap("rules", nil, assembleRules(scope, isGit, provider))
+			body := override
+			if body == "" {
+				body = assembleRules(scope, isGit, provider)
+			}
+			return wrap("rules", nil, body)
 		},
 	}
 }
@@ -177,13 +197,32 @@ func assembleRules(scope core.Scope, isGit bool, provider string) string {
 // WithIdentity replaces the default identity with a persona/user-defined one,
 // e.g. an "ML engineer" charter. An empty string keeps the default.
 func WithIdentity(text string) Option {
-	return func(cfg *buildConfig) { cfg.identity = strings.TrimSpace(text) }
+	return func(cfg *buildConfig) { cfg.persona.Identity = strings.TrimSpace(text) }
+}
+
+// WithPersona overrides any of the identity / behavior / rules parts at build
+// time from a persona. Empty fields keep San's built-in default for that part.
+// Applied wholesale, so pass every part the persona provides.
+func WithPersona(p Persona) Option {
+	return func(cfg *buildConfig) { cfg.persona = p }
 }
 
 // SwapIdentity replaces the identity part on an already-built system. Empty
 // text reverts to the built-in default. Visible on the next sys.Prompt().
 func SwapIdentity(sys core.System, text string) {
 	sys.Use(identitySection(text), "command:identity")
+}
+
+// SwapPersona replaces the identity / behavior / rules parts on an already-built
+// main-agent system — e.g. a mid-session persona switch. Empty fields revert
+// that part to the built-in default. isGit and provider are the current
+// environment facts needed to rebuild a reverted rules part. Visible on the
+// next sys.Prompt().
+func SwapPersona(sys core.System, p Persona, isGit bool, provider string) {
+	const caller = "command:persona"
+	sys.Use(identitySection(p.Identity), caller)
+	sys.Use(behaviorSection(p.Behavior), caller)
+	sys.Use(rulesSection(core.ScopeMain, isGit, provider, p.Rules), caller)
 }
 
 // WithProvider folds provider-specific quirks (prompts/providers/<name>.txt,

--- a/internal/core/system/persona_test.go
+++ b/internal/core/system/persona_test.go
@@ -1,0 +1,93 @@
+package system
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+func TestWithPersona_OverridesEachPart(t *testing.T) {
+	sys := Build(core.ScopeMain,
+		WithPersona(Persona{
+			Identity: "You are a custom persona.",
+			Behavior: "Speak in haiku.",
+			Rules:    "Follow the custom rulebook.",
+		}),
+		WithGitGuidelines(true),
+		WithEnvironment(Environment{Cwd: "/tmp/test", IsGit: true}),
+	)
+	p := sys.Prompt()
+
+	for _, want := range []string{
+		"You are a custom persona.",
+		"<behavior>\nSpeak in haiku.\n</behavior>",
+		"<rules>\nFollow the custom rulebook.\n</rules>",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing override %q\n---\n%s", want, p)
+		}
+	}
+	// Built-in defaults must be gone for the overridden parts.
+	for _, gone := range []string{"interactive AI assistant", "## Tone", "## Safety", "## Git safety"} {
+		if strings.Contains(p, gone) {
+			t.Errorf("prompt still contains default %q after override", gone)
+		}
+	}
+}
+
+func TestWithPersona_EmptyFieldsKeepDefaults(t *testing.T) {
+	sys := Build(core.ScopeMain,
+		WithPersona(Persona{Behavior: "Only behavior overridden."}),
+		WithEnvironment(Environment{Cwd: "/tmp/test"}),
+	)
+	p := sys.Prompt()
+
+	if !strings.Contains(p, "Only behavior overridden.") {
+		t.Error("behavior override missing")
+	}
+	if strings.Contains(p, "## Tone") {
+		t.Error("default behavior should be replaced by the override")
+	}
+	// Identity and rules keep their built-in defaults.
+	if !strings.Contains(p, "interactive AI assistant") {
+		t.Error("identity should keep its default")
+	}
+	if !strings.Contains(p, "## Safety") {
+		t.Error("rules should keep their default")
+	}
+}
+
+func TestSwapPersona_HotSwapAndRevert(t *testing.T) {
+	sys := Build(core.ScopeMain,
+		WithGitGuidelines(true),
+		WithEnvironment(Environment{Cwd: "/tmp/test", IsGit: true}),
+	)
+	def := sys.Prompt()
+	if !strings.Contains(def, "interactive AI assistant") || !strings.Contains(def, "## Safety") {
+		t.Fatal("baseline prompt is missing defaults")
+	}
+
+	SwapPersona(sys, Persona{
+		Identity: "Persona identity.",
+		Rules:    "Persona rules.",
+	}, true, "")
+	swapped := sys.Prompt()
+
+	if !strings.Contains(swapped, "Persona identity.") || !strings.Contains(swapped, "Persona rules.") {
+		t.Error("swap did not apply the overrides")
+	}
+	if strings.Contains(swapped, "interactive AI assistant") || strings.Contains(swapped, "## Safety") {
+		t.Error("defaults should be replaced after the swap")
+	}
+	// Behavior was not overridden → still the default.
+	if !strings.Contains(swapped, "## Tone") {
+		t.Error("un-overridden behavior should remain the default")
+	}
+
+	// Revert: empty parts restore the exact built-in prompt.
+	SwapPersona(sys, Persona{}, true, "")
+	if reverted := sys.Prompt(); reverted != def {
+		t.Errorf("revert should restore the default prompt byte-for-byte")
+	}
+}


### PR DESCRIPTION
## What

Phase 3 of the persona system (design: `notes/active/persona-system.md`). Generalizes the existing identity-only override to **all three overridable parts** — identity / behavior / rules — and adds a hot-swap path.

- `behaviorSection` / `rulesSection` now take an override body; empty = the built-in default (mirroring `identitySection`).
- New `system.Persona{Identity, Behavior, Rules}` carries the overrides — the **system-layer view** of a persona (just the prompt bodies). The full on-disk bundle stays `internal/persona.Persona`.
- `WithPersona(Persona)` sets the overrides at build time; `SwapPersona(sys, Persona, isGit, provider)` replaces them on a running main-agent system and reverts empty fields to the default.

## Decoupled by design

`WithPersona`/`SwapPersona` take **plain strings**, so `internal/core/system` does **not** import `internal/persona` (same pattern as `WithIdentity`). The app-side wiring — read the active persona, pass its parts — lands in a later phase.

## Not a behavior change (yet)

Nothing calls `WithPersona`/`SwapPersona` outside tests, so the default prompt is unaffected: **golden files are unchanged** after `-update`. The override path is purely additive.

## Verification

`go build`, `go vet`, `gofmt`, full `go test ./...` all pass. New tests cover: each part overridden, empty fields keeping defaults, and `SwapPersona` hot-swapping then reverting byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)