### PR TITLE
feat(hook): run PreToolUse before main tools

### DIFF
--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/core/system"
+	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/tool"
 )
@@ -37,6 +38,7 @@ type BuildParams struct {
 	MCPTools      []core.Tool
 
 	PermissionDecider PermDecisionFunc
+	HookEngine        hook.Handler
 	InteractionFunc   tool.InteractionFunc
 	ToolProgress      func(toolCallID string, msg string)
 
@@ -112,7 +114,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 		ID:          "main",
 		LLM:         client,
 		System:      sys,
-		Tools:       tool.WithPermission(tools, pb.PermissionFunc()),
+		Tools:       tool.WithPreToolUseAndPermission(tools, p.HookEngine, pb),
 		CompactFunc: compactFunc,
 		CWD:         p.CWD,
 		OnEvent:     p.OnEvent,

--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -59,35 +59,49 @@ func NewPermissionBridge(decideFn PermDecisionFunc) *PermissionBridge {
 
 func (pb *PermissionBridge) PermissionFunc() perm.PermissionFunc {
 	return func(ctx context.Context, name string, input map[string]any) (bool, string) {
-		decision := pb.decideFn(name, input)
+		return pb.Check(ctx, name, input, false, "")
+	}
+}
 
-		switch decision.Decision {
-		case perm.Permit:
-			return true, decision.Reason
-		case perm.Reject:
-			return false, decision.Reason
-		}
+func (pb *PermissionBridge) Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string) {
+	decision := pb.decideFn(name, input)
+	if forcePrompt {
+		decision = PermDecisionResult{Decision: perm.Prompt, Reason: reason, ToolName: name, Description: reason}
+	}
 
-		req := &PermBridgeRequest{
-			RequestID:   decision.RequestID,
-			ToolName:    decision.ToolName,
-			Description: decision.Description,
-			Input:       input,
-			Response:    make(chan PermBridgeResponse, 1),
-		}
+	switch decision.Decision {
+	case perm.Permit:
+		return true, decision.Reason
+	case perm.Reject:
+		return false, decision.Reason
+	}
 
-		select {
-		case pb.requests <- req:
-		case <-ctx.Done():
-			return false, "cancelled"
-		}
+	if decision.ToolName == "" {
+		decision.ToolName = name
+	}
+	if decision.Description == "" {
+		decision.Description = decision.Reason
+	}
 
-		select {
-		case <-ctx.Done():
-			return false, "cancelled"
-		case resp := <-req.Response:
-			return resp.Allow, resp.Reason
-		}
+	req := &PermBridgeRequest{
+		RequestID:   decision.RequestID,
+		ToolName:    decision.ToolName,
+		Description: decision.Description,
+		Input:       input,
+		Response:    make(chan PermBridgeResponse, 1),
+	}
+
+	select {
+	case pb.requests <- req:
+	case <-ctx.Done():
+		return false, "cancelled"
+	}
+
+	select {
+	case <-ctx.Done():
+		return false, "cancelled"
+	case resp := <-req.Response:
+		return resp.Allow, resp.Reason
 	}
 }
 

--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -64,10 +64,14 @@ func (pb *PermissionBridge) PermissionFunc() perm.PermissionFunc {
 }
 
 func (pb *PermissionBridge) Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string) {
-	decision := pb.decideFn(name, input)
+	// When a hook forces a prompt we skip decideFn entirely: its result is
+	// discarded anyway, and calling it would emit a misleading "decided"
+	// audit record for a call that actually goes to the user.
 	if forcePrompt {
-		decision = PermDecisionResult{Decision: perm.Prompt, Reason: reason, ToolName: name, Description: reason}
+		return pb.prompt(ctx, &PermBridgeRequest{ToolName: name, Description: reason, Input: input})
 	}
+
+	decision := pb.decideFn(name, input)
 
 	switch decision.Decision {
 	case perm.Permit:
@@ -83,13 +87,18 @@ func (pb *PermissionBridge) Check(ctx context.Context, name string, input map[st
 		decision.Description = decision.Reason
 	}
 
-	req := &PermBridgeRequest{
+	return pb.prompt(ctx, &PermBridgeRequest{
 		RequestID:   decision.RequestID,
 		ToolName:    decision.ToolName,
 		Description: decision.Description,
 		Input:       input,
-		Response:    make(chan PermBridgeResponse, 1),
-	}
+	})
+}
+
+// prompt sends a permission request to the resolver (TUI) and blocks until
+// it responds or ctx is cancelled.
+func (pb *PermissionBridge) prompt(ctx context.Context, req *PermBridgeRequest) (bool, string) {
+	req.Response = make(chan PermBridgeResponse, 1)
 
 	select {
 	case pb.requests <- req:

--- a/internal/agent/permission_test.go
+++ b/internal/agent/permission_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/tool/perm"
+)
+
+func TestPermissionBridgeForcedPromptUsesHookReason(t *testing.T) {
+	bridge := NewPermissionBridge(func(name string, args map[string]any) PermDecisionResult {
+		return PermDecisionResult{Decision: perm.Permit, Reason: "allowed by settings"}
+	})
+	defer bridge.Close()
+
+	result := make(chan struct {
+		allow  bool
+		reason string
+	}, 1)
+	go func() {
+		allow, reason := bridge.Check(context.Background(), "Bash", map[string]any{"command": "git status"}, true, "explain this command")
+		result <- struct {
+			allow  bool
+			reason string
+		}{allow: allow, reason: reason}
+	}()
+
+	req, ok := bridge.Recv()
+	if !ok {
+		t.Fatal("permission bridge closed unexpectedly")
+	}
+	if req.ToolName != "Bash" || req.Description != "explain this command" || req.Input["command"] != "git status" {
+		t.Fatalf("unexpected permission request: %#v", req)
+	}
+	req.Response <- PermBridgeResponse{Allow: true, Reason: "approved"}
+
+	got := <-result
+	if !got.allow || got.reason != "approved" {
+		t.Fatalf("unexpected permission result: %#v", got)
+	}
+}

--- a/internal/agent/permission_test.go
+++ b/internal/agent/permission_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestPermissionBridgeForcedPromptUsesHookReason(t *testing.T) {
+	deciderCalled := false
 	bridge := NewPermissionBridge(func(name string, args map[string]any) PermDecisionResult {
+		deciderCalled = true
 		return PermDecisionResult{Decision: perm.Permit, Reason: "allowed by settings"}
 	})
 	defer bridge.Close()
@@ -37,5 +39,8 @@ func TestPermissionBridgeForcedPromptUsesHookReason(t *testing.T) {
 	got := <-result
 	if !got.allow || got.reason != "approved" {
 		t.Fatalf("unexpected permission result: %#v", got)
+	}
+	if deciderCalled {
+		t.Fatal("decider must be skipped when a hook forces a prompt (avoids a spurious audit record)")
 	}
 }

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -150,6 +150,7 @@ func (m *model) buildAgentParams() agent.BuildParams {
 
 		DisabledTools: m.services.Setting.DisabledTools(),
 		MCPTools:      mcpTools,
+		HookEngine:    m.services.Hook,
 
 		InteractionFunc: func(ctx context.Context, req *tool.QuestionRequest) (*tool.QuestionResponse, error) {
 			return m.conv.ProgressHub.Ask(ctx, 0, req)

--- a/internal/hook/executor.go
+++ b/internal/hook/executor.go
@@ -193,9 +193,11 @@ func (e *Engine) applySpecificOutput(outcome HookOutcome, hso *HookSpecificOutpu
 		outcome.BlockReason = hso.PermissionDecisionReason
 	case "allow":
 		outcome.PermissionAllow = true
+		outcome.PermissionReason = hso.PermissionDecisionReason
 		outcome.HookSource = "PreToolUse"
 	case "ask":
 		outcome.ForceAsk = true
+		outcome.PermissionReason = hso.PermissionDecisionReason
 	}
 
 	if hso.UpdatedInput != nil {

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -169,6 +169,7 @@ type HookOutcome struct {
 	AdditionalContext  string
 	UpdatedInput       map[string]any
 	PermissionAllow    bool               // Hook explicitly granted permission (allow path)
+	PermissionReason   string             // Reason attached to the hook permission decision
 	ForceAsk           bool               // Hook explicitly requests permission prompt (PreToolUse "ask")
 	UpdatedPermissions []PermissionUpdate // Structured permission changes from hook (PermissionRequest only)
 	HookSource         string             // Which hook made the decision (for logging)

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -52,7 +52,7 @@ type runConfig struct {
 }
 
 // NewExecutor creates a new agent executor. parentModelID is used for model
-// inheritance; hookEngine, when non-nil, fires PreToolUse hooks during runs.
+// inheritance; hookEngine, when non-nil, fires subagent lifecycle hooks.
 func NewExecutor(llmProvider llm.Provider, cwd string, parentModelID string, hookEngine hook.Handler) *Executor {
 	return &Executor{
 		provider:      llmProvider,

--- a/internal/tool/pretool_hook.go
+++ b/internal/tool/pretool_hook.go
@@ -1,0 +1,103 @@
+package tool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+)
+
+func WithPreToolUseHooks(inner core.Tools, hooks hook.Handler) core.Tools {
+	if inner == nil || hooks == nil {
+		return inner
+	}
+	return &preToolHookTools{inner: inner, hooks: hooks}
+}
+
+type PreToolPermissionChecker interface {
+	Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string)
+}
+
+func WithPreToolUseAndPermission(inner core.Tools, hooks hook.Handler, check PreToolPermissionChecker) core.Tools {
+	if check == nil {
+		return WithPreToolUseHooks(inner, hooks)
+	}
+	if inner == nil {
+		return nil
+	}
+	return &preToolHookTools{inner: inner, hooks: hooks, check: check}
+}
+
+type preToolHookTools struct {
+	inner core.Tools
+	hooks hook.Handler
+	check PreToolPermissionChecker
+}
+
+func (pt *preToolHookTools) Get(name string) core.Tool {
+	t := pt.inner.Get(name)
+	if t == nil {
+		return nil
+	}
+	return &preToolHookTool{inner: t, hooks: pt.hooks, check: pt.check}
+}
+
+func (pt *preToolHookTools) All() []core.Tool {
+	tools := pt.inner.All()
+	out := make([]core.Tool, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, &preToolHookTool{inner: t, hooks: pt.hooks, check: pt.check})
+	}
+	return out
+}
+
+func (pt *preToolHookTools) Add(tool core.Tool, caller string)     { pt.inner.Add(tool, caller) }
+func (pt *preToolHookTools) Remove(name, caller string)            { pt.inner.Remove(name, caller) }
+func (pt *preToolHookTools) Schemas() []core.ToolSchema            { return pt.inner.Schemas() }
+func (pt *preToolHookTools) SetObserver(fn func(core.ToolsChange)) { pt.inner.SetObserver(fn) }
+
+type preToolHookTool struct {
+	inner core.Tool
+	hooks hook.Handler
+	check PreToolPermissionChecker
+}
+
+func (pt *preToolHookTool) Name() string            { return pt.inner.Name() }
+func (pt *preToolHookTool) Description() string     { return pt.inner.Description() }
+func (pt *preToolHookTool) Schema() core.ToolSchema { return pt.inner.Schema() }
+
+func (pt *preToolHookTool) Execute(ctx context.Context, input map[string]any) (string, error) {
+	allowByHook := false
+	forceAsk := false
+	permissionReason := ""
+	if pt.hooks != nil && pt.hooks.HasHooks(hook.PreToolUse) {
+		outcome := pt.hooks.Execute(ctx, hook.PreToolUse, hook.HookInput{
+			ToolName:  pt.inner.Name(),
+			ToolInput: input,
+		})
+		if !outcome.ShouldContinue || outcome.ShouldBlock {
+			reason := outcome.BlockReason
+			if reason == "" {
+				reason = outcome.AdditionalContext
+			}
+			if reason == "" {
+				reason = "blocked by PreToolUse hook"
+			}
+			return "", fmt.Errorf("%s", reason)
+		}
+		if outcome.UpdatedInput != nil {
+			input = outcome.UpdatedInput
+		}
+		allowByHook = outcome.PermissionAllow
+		forceAsk = outcome.ForceAsk
+		permissionReason = outcome.PermissionReason
+	}
+
+	if pt.check != nil && !allowByHook {
+		if allow, reason := pt.check.Check(ctx, pt.inner.Name(), input, forceAsk, permissionReason); !allow {
+			return "", fmt.Errorf("blocked: %s", reason)
+		}
+	}
+	return pt.inner.Execute(ctx, input)
+}

--- a/internal/tool/pretool_hook.go
+++ b/internal/tool/pretool_hook.go
@@ -84,7 +84,7 @@ func (pt *preToolHookTool) Execute(ctx context.Context, input map[string]any) (s
 			if reason == "" {
 				reason = "blocked by PreToolUse hook"
 			}
-			return "", fmt.Errorf("%s", reason)
+			return "", fmt.Errorf("blocked: %s", reason)
 		}
 		if outcome.UpdatedInput != nil {
 			input = outcome.UpdatedInput
@@ -94,7 +94,9 @@ func (pt *preToolHookTool) Execute(ctx context.Context, input map[string]any) (s
 		permissionReason = outcome.PermissionReason
 	}
 
-	if pt.check != nil && !allowByHook {
+	// A hook "ask" always reaches the user, even if another hook also
+	// answered "allow": prompting is the safe resolution of the conflict.
+	if pt.check != nil && (!allowByHook || forceAsk) {
 		if allow, reason := pt.check.Check(ctx, pt.inner.Name(), input, forceAsk, permissionReason); !allow {
 			return "", fmt.Errorf("blocked: %s", reason)
 		}

--- a/internal/tool/pretool_hook_test.go
+++ b/internal/tool/pretool_hook_test.go
@@ -109,7 +109,23 @@ func TestPreToolUseContinueFalseBlocksWithSystemMessage(t *testing.T) {
 	tools := WithPreToolUseHooks(core.NewTools(inner), hooks)
 
 	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
-	if err == nil || err.Error() != "stop here" {
+	if err == nil || err.Error() != "blocked: stop here" {
 		t.Fatalf("Execute returned error %v", err)
+	}
+}
+
+func TestPreToolUseAskWinsOverAllow(t *testing.T) {
+	inner := &captureCoreTool{}
+	// Two hooks disagree: one allows, one asks. The user must still be prompted.
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{PermissionAllow: true, ForceAsk: true, PermissionReason: "double-check"}}
+	checker := &fakePreToolPermissionChecker{allow: true}
+	tools := WithPreToolUseAndPermission(core.NewTools(inner), hooks, checker)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !checker.called || !checker.forcePrompt {
+		t.Fatalf("expected a forced prompt despite allow; called=%v forcePrompt=%v", checker.called, checker.forcePrompt)
 	}
 }

--- a/internal/tool/pretool_hook_test.go
+++ b/internal/tool/pretool_hook_test.go
@@ -1,0 +1,115 @@
+package tool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+)
+
+type captureCoreTool struct {
+	input map[string]any
+}
+
+func (t *captureCoreTool) Name() string            { return "Bash" }
+func (t *captureCoreTool) Description() string     { return "test" }
+func (t *captureCoreTool) Schema() core.ToolSchema { return core.ToolSchema{Name: t.Name()} }
+func (t *captureCoreTool) Execute(ctx context.Context, input map[string]any) (string, error) {
+	t.input = input
+	return "ok", nil
+}
+
+type fakeHookHandler struct {
+	outcome hook.HookOutcome
+	input   hook.HookInput
+}
+
+func (h *fakeHookHandler) Execute(ctx context.Context, event hook.EventType, input hook.HookInput) hook.HookOutcome {
+	h.input = input
+	outcome := h.outcome
+	if !outcome.ShouldBlock {
+		outcome.ShouldContinue = true
+	}
+	return outcome
+}
+func (h *fakeHookHandler) ExecuteAsync(event hook.EventType, input hook.HookInput) {}
+func (h *fakeHookHandler) HasHooks(event hook.EventType) bool                      { return event == hook.PreToolUse }
+func (h *fakeHookHandler) StopHookActive() *bool                                   { return nil }
+
+func TestWithPreToolUseHooksAppliesUpdatedInput(t *testing.T) {
+	inner := &captureCoreTool{}
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{
+		UpdatedInput: map[string]any{"command": "rtk git status"},
+	}}
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if hooks.input.ToolName != "Bash" || hooks.input.ToolInput["command"] != "git status" {
+		t.Fatalf("hook received unexpected input: %#v", hooks.input)
+	}
+	if inner.input["command"] != "rtk git status" {
+		t.Fatalf("tool executed with input %#v", inner.input)
+	}
+}
+
+type fakePreToolPermissionChecker struct {
+	called      bool
+	forcePrompt bool
+	reason      string
+	allow       bool
+}
+
+func (c *fakePreToolPermissionChecker) Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string) {
+	c.called = true
+	c.forcePrompt = forcePrompt
+	c.reason = reason
+	if c.allow {
+		return true, ""
+	}
+	return false, "should not be used"
+}
+
+func TestPreToolUseAllowOverridesPermissionPrompt(t *testing.T) {
+	inner := &captureCoreTool{}
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{PermissionAllow: true}}
+	checker := &fakePreToolPermissionChecker{}
+	tools := WithPreToolUseAndPermission(core.NewTools(inner), hooks, checker)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if checker.called {
+		t.Fatal("permission checker should not run after PreToolUse allow")
+	}
+}
+
+func TestPreToolUseAskForcesPermissionPrompt(t *testing.T) {
+	inner := &captureCoreTool{}
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{ForceAsk: true, PermissionReason: "explain this command"}}
+	checker := &fakePreToolPermissionChecker{allow: true}
+	tools := WithPreToolUseAndPermission(core.NewTools(inner), hooks, checker)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !checker.called || !checker.forcePrompt || checker.reason != "explain this command" {
+		t.Fatalf("permission checker received forcePrompt=%v reason=%q called=%v", checker.forcePrompt, checker.reason, checker.called)
+	}
+}
+
+func TestPreToolUseContinueFalseBlocksWithSystemMessage(t *testing.T) {
+	inner := &captureCoreTool{}
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{ShouldContinue: false, ShouldBlock: true, AdditionalContext: "stop here"}}
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"})
+	if err == nil || err.Error() != "stop here" {
+		t.Fatalf("Execute returned error %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Run PreToolUse hooks in the main-session tool execution path
- Apply hook-updated tool input before permission checks and execution
- Honor PreToolUse permission allow/ask decisions and cover them with tests

## Test plan
- [x] go test ./internal/tool ./internal/tool/perm ./internal/agent ./internal/app ./internal/setting ./internal/hook ./tests/integration/hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)