### PR TITLE
test(selflearn): make TestConcurrentObserveIsRaceFree deterministic

### DIFF
--- a/internal/selflearn/concurrency_test.go
+++ b/internal/selflearn/concurrency_test.go
@@ -55,8 +55,13 @@ func TestSnapshotIsCopiedBeforeGoroutine(t *testing.T) {
 func TestConcurrentObserveIsRaceFree(t *testing.T) {
 	var fired atomic.Int64
 	hold := make(chan struct{})
+	fireSignal := make(chan struct{}, 1)
 	review := func(_ ReviewKind, _ []core.Message) {
 		fired.Add(1)
+		select {
+		case fireSignal <- struct{}{}: // announce the first fire
+		default:
+		}
 		<-hold // block until the test releases — keeps inFlight=true
 	}
 	r := New(Config{
@@ -76,11 +81,21 @@ func TestConcurrentObserveIsRaceFree(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	close(hold) // release the one in-flight review
 
-	// We do not assert an exact fire count — the point is that -race finds
-	// no races. But there should have been at least one fire (the first
-	// trigger always wins) and at most goroutines*perG (loose upper bound).
+	// The review that wins the in-flight slot runs in its own goroutine (see
+	// Reviewer.Observe), so wait for it to actually fire before reading the
+	// counter — otherwise this races the async review under load and can
+	// observe 0. The first trigger always wins, so a fire is guaranteed.
+	select {
+	case <-fireSignal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected at least one review to fire")
+	}
+	close(hold) // release the in-flight review
+
+	// We do not assert an exact fire count — the point is that -race finds no
+	// races. At least one fired (waited for above); the upper bound is a loose
+	// sanity check.
 	got := fired.Load()
 	if got < 1 || got > int64(goroutines*perG) {
 		t.Fatalf("fire count %d outside plausible bounds [1, %d]", got, goroutines*perG)


### PR DESCRIPTION
## Problem

`TestConcurrentObserveIsRaceFree` flakes in CI:

```
--- FAIL: TestConcurrentObserveIsRaceFree
    concurrency_test.go:86: fire count 0 outside plausible bounds [1, 160]
```

`Reviewer.Observe` spawns the review that wins the in-flight slot in **its own goroutine**, but the test read the fire counter immediately after `wg.Wait()`. `wg.Wait()` only waits for the `Observe` *calls* to return — not for that async review goroutine to run. Under CI load it may not have executed `fired.Add(1)` yet, so the counter reads `0` and the `[1, N]` sanity bound trips. Passes locally (even 300× with `-race`); only the loaded CI host hits the window.

## Fix

Signal the first fire from the `ReviewFunc` and wait for it (2s timeout) before reading the counter. The first trigger always wins the in-flight slot, so a fire is guaranteed — this just removes the race between the assertion and the async review. The `-race` coverage (the actual point of the test) is unchanged.

Test-only; no production change. Verified with `-race -count=300`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)