### PR TITLE
feat(hook): run PreToolUse hooks before main-session tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.20.1] - 2026-06-11
+
+### Added
+- Volcengine Ark LLM provider ([@zhfeng](https://github.com/zhfeng) in [#178](https://github.com/genai-io/san/pull/178))
+- Windows PowerShell installer and zip release artifacts ([@yanmxa](https://github.com/yanmxa) in [#159](https://github.com/genai-io/san/pull/159))
+- Appearance panel to switch color theme in TUI ([@yanmxa](https://github.com/yanmxa) in [#149](https://github.com/genai-io/san/pull/149))
+- Ctrl+D to remove API key with confirmation ([@zhfeng](https://github.com/zhfeng) in [#158](https://github.com/genai-io/san/pull/158))
+- Ctrl+E to edit API key in place ([@laisongls](https://github.com/laisongls) in [#154](https://github.com/genai-io/san/pull/154))
+- Windows builds in release artifacts ([@zhfeng](https://github.com/zhfeng) in [#148](https://github.com/genai-io/san/pull/148))
+- Persona system design documentation ([@yanmxa](https://github.com/yanmxa) in [#144](https://github.com/genai-io/san/pull/144))
+
+### Changed
+- Simplify system prompt to four-part structure ([@yanmxa](https://github.com/yanmxa) in [#171](https://github.com/genai-io/san/pull/171))
+- Derive provider list from LLM registry instead of embedded catalog ([@zhfeng](https://github.com/zhfeng) in [#151](https://github.com/genai-io/san/pull/151))
+- Unify and deduplicate message, agent, and tool types across the codebase ([@yanmxa](https://github.com/yanmxa) in [#132](https://github.com/genai-io/san/pull/132), [#138](https://github.com/genai-io/san/pull/138), [#139](https://github.com/genai-io/san/pull/139), [#141](https://github.com/genai-io/san/pull/141))
+- Remove dead fields: `Config.Color`, `Message.Meta`, `HookInput.IsInterrupt`, `SessionPermissions.IsBypassAvailable` ([@yanmxa](https://github.com/yanmxa) in [#140](https://github.com/genai-io/san/pull/140), [#137](https://github.com/genai-io/san/pull/137), [#146](https://github.com/genai-io/san/pull/146), [#142](https://github.com/genai-io/san/pull/142))
+- Unify token-usage naming; report agent input/output separately ([@yanmxa](https://github.com/yanmxa) in [#136](https://github.com/genai-io/san/pull/136))
+- Rename compaction `Focus` to `SummaryFocus` ([@yanmxa](https://github.com/yanmxa) in [#143](https://github.com/genai-io/san/pull/143))
+- Drop `Message.From`, pass agent ID to `MessageEvent` explicitly ([@yanmxa](https://github.com/yanmxa) in [#147](https://github.com/genai-io/san/pull/147))
+- Update provider documentation ([@wangke19](https://github.com/wangke19) in [#174](https://github.com/genai-io/san/pull/174))
+
+### Fixed
+- Sync install.ps1 logic with install.sh ([@lonicerae](https://github.com/lonicerae) in [cd8f81d](https://github.com/genai-io/san/commit/cd8f81d))
+- Install script hardening ([@lonicerae](https://github.com/lonicerae) in [#162](https://github.com/genai-io/san/pull/162))
+- Clear runtime model/provider state on credential removal ([@skeeey](https://github.com/skeeey) in [#161](https://github.com/genai-io/san/pull/161))
+- Persist OLLAMA_BASE_URL across sessions ([@lonicerae](https://github.com/lonicerae) in [#122](https://github.com/genai-io/san/pull/122))
+- Add Mimo provider to UI list and resolve base URL from secrets ([@zhfeng](https://github.com/zhfeng) in [#150](https://github.com/genai-io/san/pull/150))
+- Update welcome header model name on model switch ([@zhfeng](https://github.com/zhfeng) in [#153](https://github.com/genai-io/san/pull/153))
+- Skip pages deploy workflow in forked repos ([@zhfeng](https://github.com/zhfeng) in [#145](https://github.com/genai-io/san/pull/145))
+- Fix flaky concurrency-cap retry test hang ([@yanmxa](https://github.com/yanmxa) in [#135](https://github.com/genai-io/san/pull/135))
+
 ## [v1.20.0] - 2026-06-06
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.0"
+var version = "1.20.1"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/core/system"
+	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/tool"
 )
@@ -37,6 +38,7 @@ type BuildParams struct {
 	MCPTools      []core.Tool
 
 	PermissionDecider PermDecisionFunc
+	HookEngine        hook.Handler
 	InteractionFunc   tool.InteractionFunc
 	ToolProgress      func(toolCallID string, msg string)
 
@@ -112,7 +114,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 		ID:          "main",
 		LLM:         client,
 		System:      sys,
-		Tools:       tool.WithPermission(tools, pb.PermissionFunc()),
+		Tools:       tool.WithPreToolUseHooks(tools, p.HookEngine, pb.PermissionFunc(), pb.ForcePromptFunc()),
 		CompactFunc: compactFunc,
 		CWD:         p.CWD,
 		OnEvent:     p.OnEvent,

--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 
+	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
 )
 
@@ -68,26 +69,42 @@ func (pb *PermissionBridge) PermissionFunc() perm.PermissionFunc {
 			return false, decision.Reason
 		}
 
-		req := &PermBridgeRequest{
+		return pb.prompt(ctx, &PermBridgeRequest{
 			RequestID:   decision.RequestID,
 			ToolName:    decision.ToolName,
 			Description: decision.Description,
 			Input:       input,
-			Response:    make(chan PermBridgeResponse, 1),
-		}
+		})
+	}
+}
 
-		select {
-		case pb.requests <- req:
-		case <-ctx.Done():
-			return false, "cancelled"
-		}
+// ForcePromptFunc returns a prompt that asks the user directly, skipping
+// the configured decider. Used when a PreToolUse hook answers "ask": the
+// hook's reason becomes the prompt description.
+func (pb *PermissionBridge) ForcePromptFunc() tool.ForcePromptFunc {
+	return func(ctx context.Context, name string, input map[string]any, reason string) (bool, string) {
+		return pb.prompt(ctx, &PermBridgeRequest{
+			ToolName:    name,
+			Description: reason,
+			Input:       input,
+		})
+	}
+}
 
-		select {
-		case <-ctx.Done():
-			return false, "cancelled"
-		case resp := <-req.Response:
-			return resp.Allow, resp.Reason
-		}
+func (pb *PermissionBridge) prompt(ctx context.Context, req *PermBridgeRequest) (bool, string) {
+	req.Response = make(chan PermBridgeResponse, 1)
+
+	select {
+	case pb.requests <- req:
+	case <-ctx.Done():
+		return false, "cancelled"
+	}
+
+	select {
+	case <-ctx.Done():
+		return false, "cancelled"
+	case resp := <-req.Response:
+		return resp.Allow, resp.Reason
 	}
 }
 

--- a/internal/agent/permission_test.go
+++ b/internal/agent/permission_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/tool/perm"
+)
+
+func TestForcePromptFuncBypassesDecider(t *testing.T) {
+	bridge := NewPermissionBridge(func(name string, args map[string]any) PermDecisionResult {
+		t.Fatal("decider should not run for a forced prompt")
+		return PermDecisionResult{Decision: perm.Permit}
+	})
+	defer bridge.Close()
+
+	type promptResult struct {
+		allow  bool
+		reason string
+	}
+	result := make(chan promptResult, 1)
+	go func() {
+		allow, reason := bridge.ForcePromptFunc()(context.Background(), "Bash", map[string]any{"command": "git push"}, "requested by PreToolUse hook")
+		result <- promptResult{allow: allow, reason: reason}
+	}()
+
+	req, ok := bridge.Recv()
+	if !ok {
+		t.Fatal("permission bridge closed unexpectedly")
+	}
+	if req.ToolName != "Bash" || req.Input["command"] != "git push" {
+		t.Fatalf("unexpected permission request: %#v", req)
+	}
+	if req.Description != "requested by PreToolUse hook" {
+		t.Fatalf("prompt description = %q, want hook reason", req.Description)
+	}
+	req.Response <- PermBridgeResponse{Allow: true, Reason: "approved"}
+
+	got := <-result
+	if !got.allow || got.reason != "approved" {
+		t.Fatalf("unexpected prompt result: %#v", got)
+	}
+}

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -113,6 +113,7 @@ func (m *model) buildAgentParams() agent.BuildParams {
 
 		DisabledTools: m.services.Setting.DisabledTools(),
 		MCPTools:      mcpTools,
+		HookEngine:    m.services.Hook,
 
 		InteractionFunc: func(ctx context.Context, req *tool.QuestionRequest) (*tool.QuestionResponse, error) {
 			return m.conv.ProgressHub.Ask(ctx, 0, req)

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -52,7 +52,9 @@ type runConfig struct {
 }
 
 // NewExecutor creates a new agent executor. parentModelID is used for model
-// inheritance; hookEngine, when non-nil, fires PreToolUse hooks during runs.
+// inheritance; hookEngine, when non-nil, fires SubagentStart/SubagentStop
+// hooks around runs. PreToolUse hooks do not yet fire for subagent tool
+// calls — only the main session runs them (see tool.WithPreToolUseHooks).
 func NewExecutor(llmProvider llm.Provider, cwd string, parentModelID string, hookEngine hook.Handler) *Executor {
 	return &Executor{
 		provider:      llmProvider,

--- a/internal/tool/pretool_hook.go
+++ b/internal/tool/pretool_hook.go
@@ -1,0 +1,99 @@
+package tool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/tool/perm"
+)
+
+// ForcePromptFunc asks the user to approve a tool call directly, bypassing
+// the configured permission decider. Used when a PreToolUse hook answers
+// "ask". reason is shown to the user as the prompt description.
+type ForcePromptFunc func(ctx context.Context, name string, input map[string]any, reason string) (allow bool, denyReason string)
+
+// WithPreToolUseHooks wraps core.Tools so every Execute runs PreToolUse
+// hooks ahead of the permission check. A hook can block the call, rewrite
+// its input (the permission check then sees the rewritten input),
+// pre-approve it (skips the permission check), or force a user prompt via
+// forcePrompt (skips the configured rules and asks directly; falls back to
+// the normal check when forcePrompt is nil).
+//
+// Hook decisions are consumed within this call's stack frame — they are
+// never attached to the context — so a decision for one tool call cannot
+// leak into nested tool calls such as a subagent run.
+func WithPreToolUseHooks(inner core.Tools, hooks hook.Handler, check perm.PermissionFunc, forcePrompt ForcePromptFunc) core.Tools {
+	if hooks == nil {
+		return WithPermission(inner, check)
+	}
+	return &preToolHookTools{inner: inner, hooks: hooks, check: check, forcePrompt: forcePrompt}
+}
+
+type preToolHookTools struct {
+	inner       core.Tools
+	hooks       hook.Handler
+	check       perm.PermissionFunc
+	forcePrompt ForcePromptFunc
+}
+
+func (pt *preToolHookTools) Get(name string) core.Tool {
+	t := pt.inner.Get(name)
+	if t == nil {
+		return nil
+	}
+	return &preToolHookTool{inner: t, gate: pt}
+}
+
+func (pt *preToolHookTools) All() []core.Tool                      { return pt.inner.All() }
+func (pt *preToolHookTools) Add(tool core.Tool, caller string)     { pt.inner.Add(tool, caller) }
+func (pt *preToolHookTools) Remove(name, caller string)            { pt.inner.Remove(name, caller) }
+func (pt *preToolHookTools) Schemas() []core.ToolSchema            { return pt.inner.Schemas() }
+func (pt *preToolHookTools) SetObserver(fn func(core.ToolsChange)) { pt.inner.SetObserver(fn) }
+
+type preToolHookTool struct {
+	inner core.Tool
+	gate  *preToolHookTools
+}
+
+func (pt *preToolHookTool) Name() string            { return pt.inner.Name() }
+func (pt *preToolHookTool) Description() string     { return pt.inner.Description() }
+func (pt *preToolHookTool) Schema() core.ToolSchema { return pt.inner.Schema() }
+
+func (pt *preToolHookTool) Execute(ctx context.Context, input map[string]any) (string, error) {
+	name := pt.inner.Name()
+	if pt.gate.hooks.HasHooks(hook.PreToolUse) {
+		outcome := pt.gate.hooks.Execute(ctx, hook.PreToolUse, hook.HookInput{
+			ToolName:  name,
+			ToolInput: input,
+		})
+		if outcome.ShouldBlock {
+			reason := outcome.BlockReason
+			if reason == "" {
+				reason = "blocked by PreToolUse hook"
+			}
+			return "", fmt.Errorf("blocked: %s", reason)
+		}
+		if outcome.UpdatedInput != nil {
+			input = outcome.UpdatedInput
+		}
+		// ForceAsk takes precedence over PermissionAllow when distinct
+		// hooks answered "ask" and "allow" for the same call.
+		switch {
+		case outcome.ForceAsk && pt.gate.forcePrompt != nil:
+			if allow, reason := pt.gate.forcePrompt(ctx, name, input, "requested by PreToolUse hook"); !allow {
+				return "", fmt.Errorf("blocked: %s", reason)
+			}
+			return pt.inner.Execute(ctx, input)
+		case outcome.PermissionAllow && !outcome.ForceAsk:
+			return pt.inner.Execute(ctx, input)
+		}
+	}
+	if pt.gate.check != nil {
+		if allow, reason := pt.gate.check(ctx, name, input); !allow {
+			return "", fmt.Errorf("blocked: %s", reason)
+		}
+	}
+	return pt.inner.Execute(ctx, input)
+}

--- a/internal/tool/pretool_hook_test.go
+++ b/internal/tool/pretool_hook_test.go
@@ -1,0 +1,193 @@
+package tool
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+)
+
+type fakeCoreTool struct {
+	name     string
+	executed bool
+	input    map[string]any
+	execute  func(ctx context.Context, input map[string]any) (string, error)
+}
+
+func (t *fakeCoreTool) Name() string            { return t.name }
+func (t *fakeCoreTool) Description() string     { return "test" }
+func (t *fakeCoreTool) Schema() core.ToolSchema { return core.ToolSchema{Name: t.name} }
+func (t *fakeCoreTool) Execute(ctx context.Context, input map[string]any) (string, error) {
+	t.executed = true
+	t.input = input
+	if t.execute != nil {
+		return t.execute(ctx, input)
+	}
+	return "ok", nil
+}
+
+type fakeHookHandler struct {
+	outcomeFor func(input hook.HookInput) hook.HookOutcome
+	inputs     []hook.HookInput
+}
+
+func (h *fakeHookHandler) Execute(ctx context.Context, event hook.EventType, input hook.HookInput) hook.HookOutcome {
+	h.inputs = append(h.inputs, input)
+	return h.outcomeFor(input)
+}
+func (h *fakeHookHandler) ExecuteAsync(event hook.EventType, input hook.HookInput) {}
+func (h *fakeHookHandler) HasHooks(event hook.EventType) bool                      { return event == hook.PreToolUse }
+func (h *fakeHookHandler) StopHookActive() *bool                                   { return nil }
+
+func staticOutcome(outcome hook.HookOutcome) *fakeHookHandler {
+	return &fakeHookHandler{outcomeFor: func(hook.HookInput) hook.HookOutcome { return outcome }}
+}
+
+func TestPreToolUseUpdatedInputSeenByCheckAndTool(t *testing.T) {
+	inner := &fakeCoreTool{name: "Bash"}
+	hooks := staticOutcome(hook.HookOutcome{UpdatedInput: map[string]any{"command": "rtk git status"}})
+	var checkedInput map[string]any
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			checkedInput = input
+			return true, ""
+		}, nil)
+
+	if _, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got := hooks.inputs[0].ToolInput["command"]; got != "git status" {
+		t.Fatalf("hook saw input %v, want original", got)
+	}
+	if got := checkedInput["command"]; got != "rtk git status" {
+		t.Fatalf("permission check saw input %v, want updated", got)
+	}
+	if got := inner.input["command"]; got != "rtk git status" {
+		t.Fatalf("tool executed with input %v, want updated", got)
+	}
+}
+
+func TestPreToolUseBlockSkipsCheckAndTool(t *testing.T) {
+	inner := &fakeCoreTool{name: "Bash"}
+	hooks := staticOutcome(hook.HookOutcome{ShouldBlock: true, BlockReason: "not allowed"})
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			t.Fatal("check should not run when hook blocks")
+			return true, ""
+		}, nil)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "rm -rf /"})
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("Execute error = %v, want block reason", err)
+	}
+	if inner.executed {
+		t.Fatal("tool should not execute when hook blocks")
+	}
+}
+
+func TestPreToolUseAllowSkipsCheck(t *testing.T) {
+	inner := &fakeCoreTool{name: "Bash"}
+	hooks := staticOutcome(hook.HookOutcome{PermissionAllow: true})
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			t.Fatal("check should not run after hook allow")
+			return false, ""
+		}, nil)
+
+	if _, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git status"}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !inner.executed {
+		t.Fatal("tool should execute after hook allow")
+	}
+}
+
+func TestPreToolUseForceAskRoutesToPrompt(t *testing.T) {
+	inner := &fakeCoreTool{name: "Bash"}
+	// "ask" wins even when another hook answered "allow" for the same call.
+	hooks := staticOutcome(hook.HookOutcome{ForceAsk: true, PermissionAllow: true})
+	var promptedReason string
+	allowNext := true
+	tools := WithPreToolUseHooks(core.NewTools(inner), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			t.Fatal("check should not run when hook forces a prompt")
+			return false, ""
+		},
+		func(ctx context.Context, name string, input map[string]any, reason string) (bool, string) {
+			promptedReason = reason
+			return allowNext, "denied by user"
+		})
+
+	if _, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git push"}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !inner.executed {
+		t.Fatal("tool should execute after user approves prompt")
+	}
+	if promptedReason == "" {
+		t.Fatal("prompt should receive the hook reason")
+	}
+
+	inner.executed = false
+	allowNext = false
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git push"})
+	if err == nil || !strings.Contains(err.Error(), "denied by user") {
+		t.Fatalf("Execute error = %v, want user denial", err)
+	}
+	if inner.executed {
+		t.Fatal("tool should not execute after user denies prompt")
+	}
+}
+
+// A hook "allow" for one tool call must not leak into tool calls nested
+// under it (e.g. a subagent run sharing the parent's context).
+func TestPreToolUseAllowDoesNotLeakIntoNestedCalls(t *testing.T) {
+	nestedChecked := false
+	nested := &fakeCoreTool{name: "Bash"}
+	hooks := &fakeHookHandler{outcomeFor: func(input hook.HookInput) hook.HookOutcome {
+		if input.ToolName == "Agent" {
+			return hook.HookOutcome{PermissionAllow: true}
+		}
+		return hook.HookOutcome{}
+	}}
+	nestedTools := WithPreToolUseHooks(core.NewTools(nested), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			nestedChecked = true
+			return false, "nested check ran"
+		}, nil)
+
+	outer := &fakeCoreTool{name: "Agent", execute: func(ctx context.Context, input map[string]any) (string, error) {
+		// Simulates a subagent executing its own tools with the parent ctx.
+		return nestedTools.Get("Bash").Execute(ctx, map[string]any{"command": "git push"})
+	}}
+	outerTools := WithPreToolUseHooks(core.NewTools(outer), hooks,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			return true, ""
+		}, nil)
+
+	_, err := outerTools.Get("Agent").Execute(context.Background(), map[string]any{"prompt": "do it"})
+	if !nestedChecked {
+		t.Fatal("nested permission check must run despite outer hook allow")
+	}
+	if err == nil || !strings.Contains(err.Error(), "nested check ran") {
+		t.Fatalf("nested Execute error = %v, want nested check denial", err)
+	}
+	if nested.executed {
+		t.Fatal("nested tool should not execute when its check denies")
+	}
+}
+
+func TestPreToolUseNilHooksFallsBackToPermission(t *testing.T) {
+	inner := &fakeCoreTool{name: "Bash"}
+	tools := WithPreToolUseHooks(core.NewTools(inner), nil,
+		func(ctx context.Context, name string, input map[string]any) (bool, string) {
+			return false, "checked"
+		}, nil)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "git push"})
+	if err == nil || !strings.Contains(err.Error(), "checked") {
+		t.Fatalf("Execute error = %v, want permission denial", err)
+	}
+}


### PR DESCRIPTION
Run PreToolUse hooks ahead of permission checks for main-session tool execution. Alternative to #187 (thanks @zhfeng for the groundwork) that addresses the review feedback there: hook decisions are handled with local control flow in a single wrapper instead of being passed through context, so a hook "allow" on an Agent call cannot leak into the subagent's permission checks.

- One gate wrapper runs hook → block / input rewrite / allow / force-ask → permission check; `WithPermission` is unchanged for subagents
- "ask" goes through an explicit `PermissionBridge.ForcePromptFunc` that shows the hook's reason in the prompt; "ask" wins over "allow" when both are returned
- Regression test asserts a hook allow on an outer call does not bypass nested tool calls' permission checks

