### PR TITLE
feat(skill): load a persona's skills as an in-memory active set

### DIFF
--- a/internal/skill/persona.go
+++ b/internal/skill/persona.go
@@ -1,0 +1,116 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// personaSkill is the registry record for one skill loaded by the active
+// persona: the full name it occupies, plus the global skill (if any) that name
+// displaced. ClearPersona uses it to remove the persona skill and restore what
+// it shadowed.
+type personaSkill struct {
+	fullName string // registry key the persona skill occupies
+	shadowed *Skill // global skill displaced at that key, or nil if it was free
+}
+
+// LoadPersona loads a persona's bundled skills (the SKILL.md in each directory)
+// into the registry as an in-memory, active-by-default set, replacing any
+// previously loaded persona skills. States from the persona's settings.json
+// (skill name -> active/enable/disable) set each bundled skill's state; an
+// unlisted skill defaults to active — selecting a persona activates its skills.
+// Nothing is written to skills.json.
+func (r *Registry) LoadPersona(skillDirs []string, states map[string]string) {
+	bundled := parsePersonaSkills(skillDirs)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.clearPersonaLocked()
+	var loaded []personaSkill
+	for _, s := range bundled {
+		fn := s.FullName()
+		loaded = append(loaded, personaSkill{fullName: fn, shadowed: r.skills[fn]})
+		s.State = bundledState(states, s)
+		r.skills[fn] = s
+	}
+	r.personaSkills = loaded
+}
+
+// ClearPersona removes the active persona's skills and restores any global
+// skills they shadowed. No-op when no persona skills are loaded.
+func (r *Registry) ClearPersona() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearPersonaLocked()
+}
+
+func (r *Registry) clearPersonaLocked() {
+	for _, ps := range r.personaSkills {
+		if ps.shadowed != nil {
+			r.skills[ps.fullName] = ps.shadowed
+		} else {
+			delete(r.skills, ps.fullName)
+		}
+	}
+	r.personaSkills = nil
+}
+
+// parsePersonaSkills parses the SKILL.md in each directory into a *Skill,
+// tagged ScopePersona. Directories without a readable SKILL.md are skipped.
+func parsePersonaSkills(skillDirs []string) []*Skill {
+	if len(skillDirs) == 0 {
+		return nil
+	}
+	l := newLoader("")
+	var out []*Skill
+	for _, dir := range skillDirs {
+		path := findSkillFile(dir)
+		if path == "" {
+			continue
+		}
+		s, err := l.loadSkillFile(path, ScopePersona, "")
+		if err != nil {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// findSkillFile returns the path to the SKILL.md inside dir (case-insensitive),
+// or "" if there is none.
+func findSkillFile(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.EqualFold(e.Name(), "SKILL.md") {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	return ""
+}
+
+// bundledState resolves a persona-bundled skill's state from the persona's
+// settings.json skills map (keyed by full name or short name), defaulting to
+// active.
+func bundledState(states map[string]string, s *Skill) SkillState {
+	for _, key := range []string{s.FullName(), s.Name} {
+		if v, ok := states[key]; ok {
+			return parseSkillState(v)
+		}
+	}
+	return StateActive
+}
+
+func parseSkillState(v string) SkillState {
+	switch SkillState(v) {
+	case StateDisable, StateEnable, StateActive:
+		return SkillState(v)
+	default:
+		return StateActive
+	}
+}

--- a/internal/skill/persona_test.go
+++ b/internal/skill/persona_test.go
@@ -1,0 +1,124 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func writePersonaSkill(t *testing.T, base, name, body string) string {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + name + " skill\n---\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func activeFullNames(r *Registry) []string {
+	active := r.GetActive()
+	out := make([]string, len(active))
+	for i, s := range active {
+		out[i] = s.FullName()
+	}
+	return out
+}
+
+func TestLoadPersona_AddsSkillsActiveByDefault(t *testing.T) {
+	base := t.TempDir()
+	d1 := writePersonaSkill(t, base, "lit-review", "do a lit review")
+	d2 := writePersonaSkill(t, base, "run-experiment", "run an experiment")
+
+	r := NewRegistry()
+	r.LoadPersona([]string{d1, d2}, map[string]string{"run-experiment": "enable"})
+
+	active := activeFullNames(r)
+	if !slices.Contains(active, "lit-review") {
+		t.Errorf("lit-review should be active by default; active=%v", active)
+	}
+	if slices.Contains(active, "run-experiment") {
+		t.Errorf("run-experiment was set to enable, should not be active; active=%v", active)
+	}
+	if !r.IsEnabled("run-experiment") {
+		t.Error("run-experiment should be enabled (slash-visible)")
+	}
+	if sk, ok := r.Get("lit-review"); !ok || sk.Scope != ScopePersona {
+		t.Errorf("persona skill should carry ScopePersona; got %+v", sk)
+	}
+	if r.Count() != 2 {
+		t.Errorf("Count = %d, want 2", r.Count())
+	}
+}
+
+func TestClearPersona_RemovesAndRestoresShadowed(t *testing.T) {
+	base := t.TempDir()
+	d := writePersonaSkill(t, base, "lit-review", "persona version")
+
+	r := NewRegistry()
+	global := &Skill{Name: "lit-review", Description: "global", Scope: ScopeUser, State: StateDisable}
+	r.skills["lit-review"] = global
+
+	r.LoadPersona([]string{d}, nil)
+	if sk, _ := r.Get("lit-review"); sk == nil || sk.Scope != ScopePersona {
+		t.Fatalf("persona skill should shadow the global; got %+v", sk)
+	}
+
+	r.ClearPersona()
+	sk, ok := r.Get("lit-review")
+	if !ok || sk != global {
+		t.Errorf("ClearPersona should restore the shadowed global; got %+v", sk)
+	}
+	if sk.State != StateDisable {
+		t.Errorf("restored global state = %q, want disable", sk.State)
+	}
+}
+
+func TestClearPersona_RemovesAddedWithoutShadow(t *testing.T) {
+	base := t.TempDir()
+	d := writePersonaSkill(t, base, "solo", "")
+
+	r := NewRegistry()
+	r.LoadPersona([]string{d}, nil)
+	r.ClearPersona()
+
+	if _, ok := r.Get("solo"); ok {
+		t.Error("added persona skill should be removed on clear")
+	}
+	if r.Count() != 0 {
+		t.Errorf("Count = %d, want 0", r.Count())
+	}
+}
+
+func TestLoadPersona_ReplacesPrevious(t *testing.T) {
+	base := t.TempDir()
+	da := writePersonaSkill(t, base, "alpha", "")
+	db := writePersonaSkill(t, base, "beta", "")
+
+	r := NewRegistry()
+	r.LoadPersona([]string{da}, nil)
+	r.LoadPersona([]string{db}, nil) // second selection replaces the first
+
+	if _, ok := r.Get("alpha"); ok {
+		t.Error("first persona's skill 'alpha' should be gone after switching")
+	}
+	if _, ok := r.Get("beta"); !ok {
+		t.Error("second persona's skill 'beta' should be present")
+	}
+	if r.Count() != 1 {
+		t.Errorf("Count = %d, want 1", r.Count())
+	}
+}
+
+func TestLoadPersona_EmptyDirsIsNoop(t *testing.T) {
+	r := NewRegistry()
+	r.LoadPersona(nil, nil)
+	if r.Count() != 0 {
+		t.Errorf("Count = %d, want 0", r.Count())
+	}
+	r.ClearPersona() // safe with no persona loaded
+}

--- a/internal/skill/registry.go
+++ b/internal/skill/registry.go
@@ -31,6 +31,12 @@ type Registry struct {
 	// Used by the session recorder to emit skill.state.changed records.
 	// Called with the read lock NOT held — recorder may do I/O.
 	onStateChange func(name, previous, current, caller string)
+
+	// personaSkills records the skills the active persona loaded into the
+	// registry (each with the global skill its name displaced, if any), so
+	// ClearPersona removes exactly them and restores the shadowed ones without
+	// touching skills.json. nil when no persona skills are loaded.
+	personaSkills []personaSkill
 }
 
 // StateChangeObserver is the callback shape SetStateChangeObserver registers.

--- a/internal/skill/types.go
+++ b/internal/skill/types.go
@@ -56,6 +56,10 @@ const (
 
 	// ScopeProject is .san/skills/ (San project level, highest priority)
 	ScopeProject
+
+	// ScopePersona is the selected persona's skills/ — loaded in-memory at the
+	// highest priority and never persisted to skills.json.
+	ScopePersona
 )
 
 // String returns the display name for the scope.
@@ -73,6 +77,8 @@ func (s SkillScope) String() string {
 		return "project-plugin"
 	case ScopeProject:
 		return "project"
+	case ScopePersona:
+		return "persona"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
## What

Phase 5 of the persona system (design: `notes/active/persona-system.md`). Adds `Registry.LoadPersona` / `ClearPersona` so a selected persona's bundled skills (the `SKILL.md` in each `skills/<name>/` dir) appear in the registry — and therefore in `GetActive()` and the `skills-directory` system-reminder — **without ever being written to `skills.json`**.

- New **`ScopePersona`** (highest priority) tags persona skills.
- **`LoadPersona(dirs, states)`** parses each dir via the existing `loadSkillFile`, inserts the skills **active by default** (the persona's `settings.json` `skills` map can set `active`/`enable`/`disable` per skill), and records what it added plus any global skill it shadowed — so **`ClearPersona`** reverts exactly. Re-selecting a persona replaces the previous set.

## Decoupled

Takes plain dirs + a `map[string]string`, so `internal/skill` does **not** import `internal/persona` (same pattern as the prior phases). The app calls `LoadPersona` on switch and requeues the system-reminders in the wiring phase.

## Scope

Covers the persona's **own bundled** skills. Applying the `skills` state map to global (non-bundled) skills — e.g. a persona disabling a global skill while active — is a later refinement; it needs prior-state restore that's cleaner to add once the command wiring exists.

## Verification

`go build`, `go vet`, `gofmt`, full `go test ./...` pass. Tests cover: active-by-default + per-skill state, shadow-and-restore on clear, plain add/remove, re-select replaces, and empty/no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)