### PR TITLE
feat(app): add /persona command and hot-switch

### DIFF
--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -61,6 +61,7 @@ Configuration and supporting capabilities:
 | --- | --- | --- |
 | `internal/setting` | `feature` | Settings loading, merge, permissions, operation mode, workdir, env. |
 | `internal/identity` | `feature` | Identity/persona registry, template, paths. |
+| `internal/persona` | `feature` | Persona registry (system-prompt parts, skills, settings overlay), template, paths. |
 | `internal/search` | `feature` | Search provider implementations and factory. |
 | `internal/inspector` | `feature` | Transcript inspector server, replay, stream, embedded UI. |
 | `internal/worktree` | `feature` | Worktree operations and hook integration. |

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -29,9 +29,10 @@ type BuildParams struct {
 	// recursive spawning).
 	AgentDirectory func() string
 
-	// IdentityText, when non-empty, replaces the default identity slot with
-	// a user-defined persona. Sourced from ~/.san/identities/<name>.md.
-	IdentityText string
+	// Persona overrides the system-prompt parts (identity / behavior / rules)
+	// from the active persona — or just the Identity part from a user identity
+	// when no persona is selected. Empty fields keep San's built-in defaults.
+	Persona system.Persona
 
 	DisabledTools map[string]bool
 	MCPTools      []core.Tool
@@ -55,7 +56,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionBridge, error) {
 
 	sys := system.Build(core.ScopeMain,
 		system.WithProvider(client.Name()),
-		system.WithIdentity(p.IdentityText),
+		system.WithPersona(p.Persona),
 		system.WithGitGuidelines(p.IsGit),
 		system.WithEnvironment(system.Environment{
 			Cwd:     p.CWD,

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/session/transcript"
 	"github.com/genai-io/san/internal/setting"
@@ -55,6 +56,54 @@ func (m *model) activeIdentityBody() string {
 			zap.String("identity", snap.Identity))
 	}
 	return body
+}
+
+// activePersona returns the currently-selected persona, or nil for the
+// built-in default (no settings.persona, or it doesn't resolve). A configured
+// name that doesn't resolve logs a warning and falls back to the default.
+func (m *model) activePersona() *persona.Persona {
+	if m.services.Setting == nil || m.services.Persona == nil {
+		return nil
+	}
+	snap := m.services.Setting.Snapshot()
+	if snap == nil || snap.Persona == "" || snap.Persona == persona.DefaultName {
+		return nil
+	}
+	p, ok := m.services.Persona.Get(snap.Persona)
+	if !ok || p.IsBuiltin() {
+		log.Logger().Warn("configured persona not found; using built-in default",
+			zap.String("persona", snap.Persona))
+		return nil
+	}
+	return p
+}
+
+// personaPrompt resolves the system.Persona (prompt-part overrides) to build
+// with. The active persona supplies all three parts; with no persona selected,
+// only the identity part is set (from the active identity, preserving /identity).
+func (m *model) personaPrompt() system.Persona {
+	if p := m.activePersona(); p != nil {
+		return system.Persona{Identity: p.Identity, Behavior: p.Behavior, Rules: p.Rules}
+	}
+	return system.Persona{Identity: m.activeIdentityBody()}
+}
+
+// applyPersonaSkills loads the active persona's bundled skills into the skill
+// registry (in-memory, active by default), or clears them when no persona is
+// selected. The skills-directory reminder picks the set up on its next emit.
+func (m *model) applyPersonaSkills() {
+	if m.services.Skill == nil {
+		return
+	}
+	if p := m.activePersona(); p != nil {
+		var states map[string]string
+		if p.Settings != nil {
+			states = p.Settings.Skills
+		}
+		m.services.Skill.LoadPersona(p.SkillDirs, states)
+		return
+	}
+	m.services.Skill.ClearPersona()
 }
 
 func (m *model) buildAgentParams() agent.BuildParams {
@@ -109,7 +158,7 @@ func (m *model) buildAgentParams() agent.BuildParams {
 		IsGit:   m.env.IsGit,
 
 		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
-		IdentityText:   m.activeIdentityBody(),
+		Persona:        m.personaPrompt(),
 
 		DisabledTools: m.services.Setting.DisabledTools(),
 		MCPTools:      mcpTools,

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/setting"
@@ -88,6 +89,7 @@ func initExtensions(cwd string) {
 	}
 	skill.Initialize(skill.Options{CWD: cwd})
 	identity.Initialize(cwd)
+	persona.Initialize(cwd)
 	command.Initialize(command.Options{
 		CWD:                cwd,
 		DynamicProviders:   []func() []command.Info{skillCommandInfos},

--- a/internal/app/input/persona_command_test.go
+++ b/internal/app/input/persona_command_test.go
@@ -1,0 +1,54 @@
+package input
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/persona"
+)
+
+func TestHandlePersonaCommand_Switch(t *testing.T) {
+	var got string
+	c := NewSlashCommandController(SlashCommandEnv{
+		SetActivePersona: func(name string) error { got = name; return nil },
+	})
+	out, _, err := c.handlePersonaCommand(context.Background(), "  ml-researcher  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "ml-researcher" {
+		t.Errorf("SetActivePersona called with %q, want trimmed ml-researcher", got)
+	}
+	if !strings.Contains(out, "ml-researcher") {
+		t.Errorf("output = %q, want it to name the persona", out)
+	}
+}
+
+func TestHandlePersonaCommand_SwitchFailureSurfaced(t *testing.T) {
+	c := NewSlashCommandController(SlashCommandEnv{
+		SetActivePersona: func(string) error { return errors.New("boom") },
+	})
+	out, _, _ := c.handlePersonaCommand(context.Background(), "x")
+	if !strings.Contains(out, "Failed") || !strings.Contains(out, "boom") {
+		t.Errorf("output = %q, want the failure surfaced", out)
+	}
+}
+
+func TestHandlePersonaCommand_Unavailable(t *testing.T) {
+	c := NewSlashCommandController(SlashCommandEnv{}) // no SetActivePersona wired
+	out, _, _ := c.handlePersonaCommand(context.Background(), "x")
+	if !strings.Contains(out, "unavailable") {
+		t.Errorf("output = %q, want an unavailable message", out)
+	}
+}
+
+func TestHandlePersonaCommand_ListsDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	c := NewSlashCommandController(SlashCommandEnv{Persona: persona.NewRegistry("")})
+	out, _, _ := c.handlePersonaCommand(context.Background(), "")
+	if !strings.Contains(out, persona.DefaultName) {
+		t.Errorf("bare /persona should list the built-in default; got %q", out)
+	}
+}

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/genai-io/san/internal/cron"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/setting"
@@ -57,6 +58,7 @@ type SlashCommandEnv struct {
 	Cron    *cron.Scheduler
 	ToolSvc *tool.Registry
 	Command *command.Registry
+	Persona *persona.Registry
 
 	// Env-state callbacks. `m.env` lives in the parent app package and
 	// can't be imported here without a cycle, so its reads/writes are
@@ -82,6 +84,7 @@ type SlashCommandEnv struct {
 	ResetCronQueue          func()
 	ForkSession             func() (originalSessionID string, err error)
 	RunSelfLearnDemo        func()
+	SetActivePersona        func(name string) error
 }
 
 type SlashCommandController struct {
@@ -114,9 +117,57 @@ func builtinCommandHandlers() map[string]slashCommandHandler {
 		"loop":           (*SlashCommandController).handleLoopCommand,
 		"search":         (*SlashCommandController).handleSearchCommand,
 		"identity":       (*SlashCommandController).handleIdentityCommand,
+		"persona":        (*SlashCommandController).handlePersonaCommand,
 		"config":         (*SlashCommandController).handleConfigCommand,
 		"selflearn-demo": (*SlashCommandController).handleSelflearnDemoCommand,
 	}
+}
+
+// handlePersonaCommand switches the active persona. Bare /persona lists the
+// available personas; /persona <name> switches to one ("default" or empty
+// clears the override back to San's built-ins).
+func (c *SlashCommandController) handlePersonaCommand(_ context.Context, args string) (string, tea.Cmd, error) {
+	name := strings.TrimSpace(args)
+	if name == "" {
+		return c.personaList(), nil, nil
+	}
+	if c.env.SetActivePersona == nil {
+		return "Persona switching is unavailable.", nil, nil
+	}
+	if err := c.env.SetActivePersona(name); err != nil {
+		return "Failed to switch persona: " + err.Error(), nil, nil
+	}
+	if name == persona.DefaultName {
+		return "Persona cleared (built-in default).", nil, nil
+	}
+	return "Persona set to: " + name, nil, nil
+}
+
+// personaList renders the available personas, marking the active one.
+func (c *SlashCommandController) personaList() string {
+	if c.env.Persona == nil {
+		return "No personas available."
+	}
+	active := ""
+	if c.env.Setting != nil {
+		if snap := c.env.Setting.Snapshot(); snap != nil {
+			active = snap.Persona
+		}
+	}
+	var b strings.Builder
+	b.WriteString("Available personas (use /persona <name>):\n")
+	for _, p := range c.env.Persona.List() {
+		marker := "  "
+		if p.Name == active || (active == "" && p.IsBuiltin()) {
+			marker = "● "
+		}
+		b.WriteString(marker + p.Name)
+		if p.Description != "" {
+			b.WriteString(" — " + p.Description)
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 func (c SlashCommandController) Execute(ctx context.Context, inputText string) (string, tea.Cmd, bool) {

--- a/internal/app/model_actions.go
+++ b/internal/app/model_actions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core/system"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/setting"
 )
 
@@ -32,6 +33,55 @@ func (m *model) setActiveIdentity(name string) error {
 	if m.services.Agent != nil {
 		if sys := m.services.Agent.System(); sys != nil {
 			system.SwapIdentity(sys, m.activeIdentityBody())
+		}
+	}
+	m.ReconfigureAgentTool()
+	return nil
+}
+
+// setActivePersona persists the persona choice and applies it without
+// restarting the session. Immediate: the persona's skills swap in-memory and
+// the running main agent's prompt parts (identity / behavior / rules) are
+// hot-patched, both visible on the next inference. The persona's settings
+// overlay (disabled tools, permissions) takes effect on the next agent
+// rebuild. Empty name = no persona (built-in defaults).
+func (m *model) setActivePersona(name string) error {
+	if m.services.Setting != nil {
+		if snap := m.services.Setting.Snapshot(); snap != nil && snap.Persona == name {
+			return nil
+		}
+	}
+	// Save the selection at the scope where the persona lives: a project
+	// persona persists in .san/settings.json (the choice stays with the project
+	// and doesn't leak to others); user/builtin personas persist user-level.
+	userLevel := true
+	if m.services.Persona != nil {
+		if p, ok := m.services.Persona.Get(name); ok && p.Scope == persona.ScopeProject {
+			userLevel = false
+		}
+	}
+	if err := setting.SavePersonaAt(m.env.CWD, name, userLevel); err != nil {
+		return err
+	}
+	if m.services.Setting != nil {
+		_ = m.services.Setting.Reload(m.env.CWD)
+	}
+
+	// Skills (immediate): swap the in-memory persona skill set, then re-emit
+	// the skills-directory reminder so the model sees it on the next turn.
+	m.applyPersonaSkills()
+	if m.services.Reminder != nil {
+		m.services.Reminder.RequeueSystemReminders()
+	}
+
+	// Prompt (immediate): hot-patch the running main agent's parts.
+	if m.services.Agent != nil {
+		if sys := m.services.Agent.System(); sys != nil {
+			provider := ""
+			if m.env.LLMProvider != nil {
+				provider = m.env.LLMProvider.Name()
+			}
+			system.SwapPersona(sys, m.personaPrompt(), m.env.IsGit, provider)
 		}
 	}
 	m.ReconfigureAgentTool()

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/genai-io/san/internal/command"
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/skill"
@@ -39,6 +40,7 @@ func newModel(opts setting.RunOptions) (*model, error) {
 	m.configureAsyncHookCallback()
 	m.ensureMemoryContextLoaded()
 	m.ReconfigureAgentTool()
+	m.applyPersonaSkills()
 	m.wireReminderProviders()
 	m.InitTaskStorage()
 	if err := m.applyRunOptions(opts); err != nil {
@@ -113,6 +115,7 @@ func (m *model) ReloadPluginBackedState() error {
 	subagent.Initialize(subagent.Options{CWD: m.env.CWD, PluginAgentPaths: pluginAgentPaths})
 	mcp.Initialize(mcp.Options{CWD: m.env.CWD, PluginServers: pluginMCPServers})
 	setting.Initialize(setting.Options{CWD: m.env.CWD})
+	persona.Initialize(m.env.CWD)
 
 	m.services.refreshAfterReload()
 	m.userInput.Identity.SetRegistry(m.services.Identity)
@@ -122,6 +125,7 @@ func (m *model) ReloadPluginBackedState() error {
 	}
 	m.syncSettingsToHookEngine()
 	m.ReconfigureAgentTool()
+	m.applyPersonaSkills()
 
 	// Refresh skills/memory reminders so the LLM sees the updated skill set
 	// in the next user message instead of waiting for SessionStart/PostCompact.

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -11,6 +11,7 @@ import (
 	"github.com/genai-io/san/internal/identity"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/selflearn"
@@ -42,6 +43,7 @@ type services struct {
 	Plugin   *plugin.Registry
 	Agent    *agent.Task
 	Identity *identity.Registry
+	Persona  *persona.Registry
 	Reminder *reminder.Service
 
 	// SelfLearn groups the L1 self-learning state. Reviewer / Cancel / Live
@@ -94,6 +96,7 @@ func newServices() services {
 		Plugin:    plugin.Default(),
 		Agent:     agent.Default(),
 		Identity:  identity.Default(),
+		Persona:   persona.Default(),
 		Reminder:  reminder.NewService(),
 		SelfLearn: SelfLearnServices{Indicator: NewSelfLearnIndicator()},
 	}
@@ -110,4 +113,5 @@ func (s *services) refreshAfterReload() {
 	s.Subagent = subagent.Default()
 	s.MCP = mcp.DefaultRegistry()
 	s.Identity = identity.Default()
+	s.Persona = persona.Default()
 }

--- a/internal/app/update_command.go
+++ b/internal/app/update_command.go
@@ -32,6 +32,7 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 		Tracker: m.services.Tracker,
 		Cron:    m.services.Cron,
 		ToolSvc: m.services.Tool,
+		Persona: m.services.Persona,
 
 		// Env callbacks
 		GetThinkingEffort: func() string { return m.env.EffectiveThinkingEffort() },
@@ -54,6 +55,7 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 		ResetCronQueue:          m.ResetCronQueue,
 		ForkSession:             m.forkSession,
 		RunSelfLearnDemo:        m.runSelfLearnDemo,
+		SetActivePersona:        m.setActivePersona,
 	}
 }
 

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -36,6 +36,7 @@ func builtinCommands() []Info {
 		{Name: "skills", Description: "Manage skills (enable/disable/activate)"},
 		{Name: "agents", Description: "Manage available agents (enable/disable)"},
 		{Name: "identity", Description: "Switch active persona, or create/edit one (open selector, /identity create, /identity edit <name>)"},
+		{Name: "persona", Description: "Switch the active persona (/persona <name>, or /persona to list)"},
 		{Name: "tokenlimit", Description: "View or set token limits for current model"},
 		{Name: "compact", Description: "Summarize conversation to reduce context size"},
 		{Name: "init", Description: "Initialize memory files (SAN.md, local, rules)"},

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -439,3 +439,43 @@ func SaveIdentity(name string) error {
 	loadedSettingsMu.Unlock()
 	return nil
 }
+
+// SavePersonaAt persists the chosen persona name at the given scope: the
+// project file (.san/settings.json under cwd) when userLevel is false, or the
+// user file (~/.san/settings.json) when true. An empty name clears the field.
+// Like SaveIdentity it bypasses mergeSettings so an empty value can actually
+// clear the value on disk.
+//
+// Scope matters: a project-scoped persona should save project-level so the
+// selection lives with the persona (and doesn't leak to other projects, where
+// it wouldn't resolve); user-scoped personas save user-level to become the
+// default everywhere.
+func SavePersonaAt(cwd, name string, userLevel bool) error {
+	loader := NewLoader()
+	if cwd != "" {
+		loader = NewLoaderForCwd(cwd)
+	}
+	dir := loader.projectDir
+	if userLevel {
+		dir = loader.userDir
+	}
+	if dir == "" {
+		return os.ErrNotExist
+	}
+	path := filepath.Join(dir, "settings.json")
+
+	existing := NewData()
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, existing)
+	}
+	existing.Persona = name
+
+	if err := writeJSONAtomic(path, existing); err != nil {
+		return err
+	}
+
+	loadedSettingsMu.Lock()
+	loadedSettings = nil
+	loadedSettingsMu.Unlock()
+	return nil
+}

--- a/tools/layercheck/main.go
+++ b/tools/layercheck/main.go
@@ -45,6 +45,7 @@ var layerOf = map[string]string{
 	"internal/inspector": "feature",
 	"internal/llm":       "feature",
 	"internal/mcp":       "feature",
+	"internal/persona":   "feature",
 	"internal/plugin":    "feature",
 	"internal/reminder":  "feature",
 	"internal/search":    "feature",


### PR DESCRIPTION
## What

Phase 6 of the persona system (design: `notes/active/persona-system.md`) — the integration phase that wires the prior building blocks into the app so a persona is selectable and takes effect **live**.

- **`persona.Registry` is a DI service**; `persona.Initialize` runs at startup and on plugin/cwd reload (mirrors `identity`).
- **Build wiring**: `buildAgentParams` resolves the active persona (`settings.persona`) into the system-prompt parts via `WithPersona`, and loads its bundled skills via `Skill.LoadPersona`. With no persona selected it falls back to the active identity as the identity part — so `/identity` keeps working. (`BuildParams.IdentityText` → `Parts system.Persona`; identity now flows through the same path.)
- **`/persona` command**: `/persona <name>` switches, bare `/persona` lists. `setActivePersona` persists the choice, then **immediately** hot-patches the running prompt (`SwapPersona`) and the in-memory skill set, requeues the `skills-directory` reminder, and reconfigures subagents — no session restart.

## Scope

Deferred (follow-ups):
- **Settings overlay application** (the persona's `disabledTools`/permissions). The `setting.ApplyPersonaOverlay` mechanism exists (merged in the settings phase); hooking it into the live `Setting` snapshot is a focused next step. Per the design, these take effect on the next agent rebuild anyway.
- **Interactive selector UI** — folds in naturally when persona *absorbs identity* (next phase), reusing that selector rather than building a parallel one.

So this PR delivers the headline switch: **prompt + skills change live when you `/persona <name>`**.

## Verification

`go build`, `go vet`, `gofmt`, full `go test ./...` pass. New unit tests cover the command handler (switch, trimmed name, failure surfaced, unavailable, bare-list). Existing behavior is unchanged when no persona is set (identity still flows through `Parts.Identity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)