### PR TITLE
chore: bump version to 1.20.2

### DIFF
--- a/.san/skills/release/SKILL.md
+++ b/.san/skills/release/SKILL.md
@@ -24,7 +24,23 @@ Create a new release with a structured changelog and author attribution.
 
 If no version is given, detect the current version and suggest the next one (see Step 1).
 
+## Constraints
+
+- Only **patch** (`x.y.Z`) or **minor** (`x.Y.0`) bumps. Never bump major — the
+  module path has no `/vN` suffix, so a major bump would violate Go v2+ rules.
+- All version tags use the `v` prefix (e.g. `v1.20.0`).
+
 ## Workflow
+
+### 0. Pull from upstream
+
+Always pull the latest upstream codebase first:
+
+```bash
+git pull upstream main --rebase
+```
+
+If there are merge conflicts, resolve them before proceeding.
 
 ### 1. Detect current version and suggest the next
 
@@ -95,6 +111,20 @@ Add a new `CHANGELOG.md` section for the target version. Keep older sections in 
 
 Use the commit log from Step 1 as source material. Group entries under `Added`, `Changed`, or `Fixed` based on conventional commit prefixes.
 
+**Contributor attribution:** Every changelog entry must include the author's GitHub handle and a link to the PR or commit, matching the existing format:
+
+```markdown
+- Description of change ([@username](https://github.com/username) in [#NNN](https://github.com/genai-io/san/pull/NNN))
+```
+
+For direct commits without a PR, use the commit hash:
+
+```markdown
+- Description of change ([@username](https://github.com/username) in [abcdef1](https://github.com/genai-io/san/commit/abcdef1))
+```
+
+**Exclude:** OWNERS updates, dependabot bumps, and other purely administrative chore commits. Do not list them in the changelog.
+
 Write only the current version section in `CHANGELOG.md`. Do not pass the entire file as manual release notes later; the GitHub Actions workflow extracts the current version section automatically.
 
 ### 3. Bump the version in source code
@@ -105,7 +135,7 @@ Update the version string in `cmd/san/main.go`:
 var version = "<new_version>"
 ```
 
-### 4. Commit, tag, and push
+### 4. Commit and push
 
 Stage the version bump and changelog update, then commit with sign-off:
 
@@ -114,13 +144,52 @@ git add cmd/san/main.go CHANGELOG.md
 git commit -s -m "chore: bump version to <new_version>"
 ```
 
-Push the release using the Makefile helper:
+**If the canonical repo is `upstream` and its `main` is protected**, pushing
+directly will fail. Use this PR-based path instead:
+
+a. Push the commit to the fork (`origin`):
+   ```bash
+   git push origin main
+   ```
+
+b. Create a PR from fork `main` to upstream `main`:
+   ```bash
+   gh pr create --base main --head <fork-owner>:main \
+     --title "chore: bump version to <new_version>" \
+     --body "Bump code version..."
+   ```
+
+c. Wait for required CI checks (DCO, test, lint) to pass on the PR.
+
+d. **Check DCO.** If the DCO check fails on upstream commits that lack a
+   sign-off (common after rebasing onto upstream), add sign-offs to all PR
+   commits:
+   ```bash
+   git rebase --signoff upstream/main
+   git push --force-with-lease origin main
+   ```
+
+e. Merge the PR (this repo requires squash-merge):
+   ```bash
+   gh pr merge <number> --squash --subject "chore: bump version to <new_version>"
+   ```
+
+f. Pull the merged result, tag, and push the tag to upstream:
+   ```bash
+   git fetch upstream && git checkout main && git reset --hard upstream/main
+   git tag v<new_version>
+   git push upstream v<new_version>
+   ```
+
+**If pushing directly to upstream is allowed**, use the Makefile helper:
 
 ```bash
 make release-push VERSION=v<new_version>
 ```
 
-This target validates that the working tree is clean, the tag does not already exist, and `CHANGELOG.md` contains the matching section before it pushes `main` and the tag.
+This target validates that the working tree is clean, the tag does not already
+exist, and `CHANGELOG.md` contains the matching section before it pushes `main`
+and the tag.
 
 The tag push triggers the GitHub Actions release workflow (`.github/workflows/release.yml`) which builds binaries, creates the GitHub release, and uses only the current changelog section as release notes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.20.2] - 2026-06-13
+
+### Added
+- Persona system: switchable bundles of custom prompt parts (identity/behavior/rules), bundled skills, settings overlay, and a subagent allow-list. `/persona <name>` switches directly; bare `/persona` opens an interactive picker (Enter to switch, Ctrl+O to open files, Ctrl+D to delete). `/identity` is now a `/persona` alias. ([@yanmxa](https://github.com/yanmxa) in [f4947cf](https://github.com/genai-io/san/commit/f4947cf), [9ff746f](https://github.com/genai-io/san/commit/9ff746f), [317c9fd](https://github.com/genai-io/san/commit/317c9fd), [5f0cf63](https://github.com/genai-io/san/commit/5f0cf63), [33ebb6f](https://github.com/genai-io/san/commit/33ebb6f), [cc2fa45](https://github.com/genai-io/san/commit/cc2fa45), [befb2fa](https://github.com/genai-io/san/commit/befb2fa), [ef9b407](https://github.com/genai-io/san/commit/ef9b407), [ac90b90](https://github.com/genai-io/san/commit/ac90b90), [f262ed3](https://github.com/genai-io/san/commit/f262ed3)))
+- PreToolUse hook: run hooks in the main-session tool path before permission checks and execution ([@zhfeng](https://github.com/zhfeng) in [cdaee75](https://github.com/genai-io/san/commit/cdaee75))
+
+### Changed
+- Split monolithic `on_provider.go` into convention-named siblings by concern (select, credentials, connect, nav, data, types) ([@yanmxa](https://github.com/yanmxa) in [9e239ca](https://github.com/genai-io/san/commit/9e239ca))
+- Merge prompt template files to mirror the four system-prompt parts ([@yanmxa](https://github.com/yanmxa) in [a2cbaec](https://github.com/genai-io/san/commit/a2cbaec))
+- Tune system-prompt content: align security stance, deduplicate reversibility rules, rename "Behavior" to "Honesty" ([@yanmxa](https://github.com/yanmxa) in [4be9d29](https://github.com/genai-io/san/commit/4be9d29))
+- Drop legacy identity back-compat and remove dead identity selector / `internal/identity` package ([@yanmxa](https://github.com/yanmxa) in [029e021](https://github.com/genai-io/san/commit/029e021), [6bbdc21](https://github.com/genai-io/san/commit/6bbdc21))
+- Split installation instructions by platform in README and site ([@yanmxa](https://github.com/yanmxa) in [80a452f](https://github.com/genai-io/san/commit/80a452f))
+- Move persona design note from active notes into `docs/concepts` ([@yanmxa](https://github.com/yanmxa) in [0901aa9](https://github.com/genai-io/san/commit/0901aa9))
+
+### Fixed
+- PreToolUse permission edge cases: skip decider when hook forces a prompt, let "ask" reach the user, consistent "blocked:" error prefix ([@yanmxa](https://github.com/yanmxa) in [c73525e](https://github.com/genai-io/san/commit/c73525e))
+- `make install` replaces the binary via a fresh inode to fix macOS AMFI code-signature cache rejection ([@yanmxa](https://github.com/yanmxa) in [6bf0277](https://github.com/genai-io/san/commit/6bf0277))
+- Persona switch persists at the correct scope when a project-pinned persona is active ([@yanmxa](https://github.com/yanmxa) in [99473ab](https://github.com/genai-io/san/commit/99473ab))
+
 ## [v1.20.1] - 2026-06-11
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.1"
+var version = "1.20.2"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {


### PR DESCRIPTION
Bump code version to 1.20.2 and add changelog entries for persona system, PreToolUse hook, and bug fixes.