### PR TITLE
refactor(app): unify overlay routing and rendering behind one registry

### DIFF
--- a/internal/app/conv/question.go
+++ b/internal/app/conv/question.go
@@ -88,8 +88,23 @@ func customOptionIndex(q tool.Question) int {
 	return len(q.Options)
 }
 
-// HandleKeypress handles keyboard input for the question prompt.
-func (p *QuestionPrompt) HandleKeypress(msg tea.KeyMsg) (tea.Cmd, *QuestionResponseMsg) {
+// HandleKeypress consumes a keypress while the prompt is open. When the user
+// finishes (answers or cancels) it emits the QuestionResponseMsg as a command,
+// so the root model handles the result in Update like any other message. That
+// keeps the modal a uniform overlayPanel rather than a special case in the key
+// router.
+func (p *QuestionPrompt) HandleKeypress(msg tea.KeyMsg) tea.Cmd {
+	cmd, resp := p.handleKeypress(msg)
+	if resp == nil {
+		return cmd
+	}
+	out := *resp
+	return tea.Batch(cmd, func() tea.Msg { return out })
+}
+
+// handleKeypress advances prompt state for a keypress, returning a response
+// once the user has answered or cancelled.
+func (p *QuestionPrompt) handleKeypress(msg tea.KeyMsg) (tea.Cmd, *QuestionResponseMsg) {
 	if !p.active || p.request == nil {
 		return nil, nil
 	}

--- a/internal/app/input/on_approval.go
+++ b/internal/app/input/on_approval.go
@@ -111,9 +111,22 @@ type ApprovalResponseMsg struct {
 	Request  *perm.PermissionRequest
 }
 
-// HandleKeypress handles keyboard input for the permission prompt.
-// Returns (cmd, response): cmd for UI updates, response when user makes a decision.
-func (p *ApprovalModel) HandleKeypress(msg tea.KeyMsg) (tea.Cmd, *ApprovalResponseMsg) {
+// HandleKeypress consumes a keypress while the modal is open. When the user
+// makes a decision it emits the ApprovalResponseMsg as a command, so the root
+// model handles the result in Update like any other message. That keeps the
+// modal a uniform overlayPanel rather than a special case in the key router.
+func (p *ApprovalModel) HandleKeypress(msg tea.KeyMsg) tea.Cmd {
+	cmd, resp := p.handleKeypress(msg)
+	if resp == nil {
+		return cmd
+	}
+	out := *resp
+	return tea.Batch(cmd, func() tea.Msg { return out })
+}
+
+// handleKeypress advances modal state for a keypress, returning a response
+// once the user has made a decision.
+func (p *ApprovalModel) handleKeypress(msg tea.KeyMsg) (tea.Cmd, *ApprovalResponseMsg) {
 	if !p.active {
 		return nil, nil
 	}

--- a/internal/app/input/on_approval_test.go
+++ b/internal/app/input/on_approval_test.go
@@ -31,7 +31,7 @@ func TestApprovalModalDigitKeysFollowOptionOrder(t *testing.T) {
 	}
 	for _, tc := range cases {
 		model.active = true
-		_, resp := model.HandleKeypress(tea.KeyPressMsg{Code: tc.key, Text: string(tc.key)})
+		_, resp := model.handleKeypress(tea.KeyPressMsg{Code: tc.key, Text: string(tc.key)})
 		if resp == nil {
 			t.Fatalf("digit %q produced no response", string(tc.key))
 		}
@@ -77,7 +77,7 @@ func TestApprovalModalShiftTabFindsAllowAllByFlag(t *testing.T) {
 		active:  true,
 		request: &perm.PermissionRequest{ToolName: "Skill"},
 	}
-	_, resp := model.HandleKeypress(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	_, resp := model.handleKeypress(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 	if resp == nil {
 		t.Fatal("ShiftTab produced no response")
 	}
@@ -94,7 +94,7 @@ func TestApprovalModalEscFindsRejectByFlag(t *testing.T) {
 		active:  true,
 		request: &perm.PermissionRequest{ToolName: "Bash"},
 	}
-	_, resp := model.HandleKeypress(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, resp := model.handleKeypress(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if resp == nil {
 		t.Fatal("Esc produced no response")
 	}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -25,23 +25,28 @@ import (
 	"github.com/genai-io/san/internal/log"
 )
 
-// popup is a UI element that pops up over the input area and, while
-// active, consumes keypresses before the textarea sees them. Includes
-// the slash-command pickers (/model, /tools, /skills, ...) but not the
-// question / approval modals — those are checked separately in
-// tryActivePopup before the picker list.
-type popup interface {
+// overlayPanel is a UI element that, while active, takes over both the
+// keyboard (consuming keypresses before the textarea sees them) and the
+// screen. It covers the slash-command pickers (/model, /tools, /skills, ...)
+// and the two docked modals (Question, Approval).
+//
+// overlayPanels is the single source of truth for which panel is in front,
+// so key routing (routeKeypress) and rendering (viewString) can never
+// disagree about who owns the foreground.
+type overlayPanel interface {
 	IsActive() bool
 	HandleKeypress(tea.KeyMsg) tea.Cmd
 	Render() string
 }
 
-// popups lists every slash-command picker that may be active. Order
-// only matters at most one of them is active at a time; the first one
-// reporting IsActive() wins the keypress.
-func (m *model) popups() []popup {
-	return []popup{
-		&m.userInput.Provider.Selector,
+// overlayPanels lists every panel that may be in front, in keyboard-priority
+// order: the docked modals win over the slash-command pickers. At most one is
+// active at a time; activeOverlay returns the first that reports IsActive().
+func (m *model) overlayPanels() []overlayPanel {
+	return []overlayPanel{
+		m.conv.Modal.Question, // docked modals (rendered between separators)
+		&m.userInput.Approval,
+		&m.userInput.Provider.Selector, // fullscreen slash-command pickers
 		&m.userInput.Tool,
 		&m.userInput.Skill.Selector,
 		&m.userInput.Agent,
@@ -53,6 +58,16 @@ func (m *model) popups() []popup {
 		&m.userInput.Search,
 		&m.userInput.Config,
 	}
+}
+
+// activeOverlay returns the foreground panel, if any.
+func (m *model) activeOverlay() (overlayPanel, bool) {
+	for _, ov := range m.overlayPanels() {
+		if ov.IsActive() {
+			return ov, true
+		}
+	}
+	return nil, false
 }
 
 type initialPromptMsg string
@@ -149,6 +164,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Logger().Warn("async session persist failed", zap.Error(msg.err))
 		}
 		return m, nil
+	case conv.QuestionResponseMsg:
+		return m, m.handleQuestionResponse(msg)
+	case input.ApprovalResponseMsg:
+		return m, m.handlePermBridgeDecision(permissionDecision{
+			Approved: msg.Approved, AllowAll: msg.AllowAll, Persist: msg.Persist, Request: msg.Request,
+		})
 	case stopHookResultMsg:
 		return m, m.handleStopHookResult(msg)
 	case mainEventMsg:

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -1,7 +1,8 @@
-// Keyboard handling: routes a tea.KeyMsg first to any active modal, then
-// to image/suggestion/queue overlays, then to the textarea-level shortcuts
-// (Ctrl+C/D/L/E/O, Tab, Enter, etc.). Also owns the Ctrl+O double-tap
-// detection and the per-keystroke thinking-effort cycle.
+// Keyboard handling: routes a tea.KeyMsg first to the active overlay (modal
+// or slash-command picker, via activeOverlay), then to image/suggestion/queue
+// overlays, then to the textarea-level shortcuts (Ctrl+C/D/L/E/O, Tab, Enter,
+// etc.). Also owns the Ctrl+O double-tap detection and the per-keystroke
+// thinking-effort cycle.
 package app
 
 import (
@@ -22,7 +23,7 @@ type ctrlOSingleTickMsg struct{}
 // routeKeypress is the priority dispatcher for tea.KeyMsg. A keypress
 // flows through these layers in order; the first one that claims it wins:
 //
-//  1. tryActivePopup           — any open modal or slash-command picker
+//  1. activeOverlay            — any open modal or slash-command picker
 //  2. HandleImageSelectKey     — image picker overlay inside textarea
 //  3. HandleSuggestionKey      — prompt-suggestion overlay inside textarea
 //  4. HandleQueueSelectKey     — queue-navigation mode inside textarea
@@ -32,8 +33,8 @@ type ctrlOSingleTickMsg struct{}
 // means "let the textarea consume it as text" — that's handled in
 // updateTextarea, not here.
 func (m *model) routeKeypress(msg tea.KeyMsg) (tea.Cmd, bool) {
-	if active, cmd := m.tryActivePopup(msg); active {
-		return cmd, true
+	if ov, ok := m.activeOverlay(); ok {
+		return ov.HandleKeypress(msg), true
 	}
 
 	if c, ok := m.userInput.HandleImageSelectKey(msg); ok {
@@ -189,37 +190,6 @@ func (m *model) cycleThinkingEffort() tea.Cmd {
 	}
 	token := m.userInput.Provider.SetStatusMessage(status)
 	return kit.StatusTimer(3*time.Second, token)
-}
-
-// tryActivePopup hands the keypress to whichever popup is currently
-// visible — the question modal, the approval modal, or one of the
-// slash-command pickers (provider, tools, skills, ...). At most one
-// popup is active at a time. Returns (true, cmd) if a popup consumed
-// the key.
-func (m *model) tryActivePopup(msg tea.KeyMsg) (bool, tea.Cmd) {
-	if m.conv.Modal.Question.IsActive() {
-		cmd, resp := m.conv.Modal.Question.HandleKeypress(msg)
-		if resp != nil {
-			return true, tea.Batch(cmd, m.handleQuestionResponse(*resp))
-		}
-		return true, cmd
-	}
-	if m.userInput.Approval.IsActive() {
-		cmd, resp := m.userInput.Approval.HandleKeypress(msg)
-		if resp != nil {
-			return true, tea.Batch(cmd, m.handlePermBridgeDecision(permissionDecision{
-				Approved: resp.Approved, AllowAll: resp.AllowAll, Persist: resp.Persist, Request: resp.Request,
-			}))
-		}
-		return true, cmd
-	}
-	for _, s := range m.popups() {
-		if s.IsActive() {
-			return true, s.HandleKeypress(msg)
-		}
-	}
-
-	return false, nil
 }
 
 func (m *model) handleCtrlO() tea.Cmd {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/subagent"
@@ -19,9 +20,13 @@ var ghostTextStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
 // View dispatches to one of four layouts, top-down:
 //
 //  1. Loading splash (env not ready yet)
-//  2. Active popup (slash-command picker / etc.) — fullscreen
-//  3. Active modal (Question / Approval) — wrapped between separators
+//  2. Active fullscreen overlay (slash-command picker / etc.)
+//  3. Active docked modal (Question / Approval) — wrapped between separators
 //  4. Normal mode — chat section + status + input strip
+//
+// The active overlay (cases 2 & 3) comes from activeOverlay — the same
+// source the key router uses — so the panel that owns the keyboard is always
+// the one drawn on screen.
 func (m *model) View() tea.View {
 	return tea.NewView(m.viewString())
 }
@@ -31,21 +36,35 @@ func (m *model) viewString() string {
 	if !m.env.Ready {
 		return "\n  Loading..."
 	}
-	if popupView := m.renderActivePopup(); popupView != "" {
-		return popupView
+
+	ov, hasOverlay := m.activeOverlay()
+	if hasOverlay && !isDockedModal(ov) {
+		return ov.Render() // fullscreen slash-command picker
 	}
 
 	separator := conv.SeparatorStyle.Render(strings.Repeat("─", m.env.Width))
 	trackerView := m.renderTrackerList()
-	trackerPrefix := ""
-	if trackerView != "" {
-		trackerPrefix = "\n" + strings.TrimSuffix(trackerView, "\n") + "\n"
-	}
 
-	if modalView := m.renderActiveModal(separator, trackerPrefix); modalView != "" {
-		return modalView
+	if hasOverlay { // docked modal (Question / Approval)
+		trackerPrefix := ""
+		if trackerView != "" {
+			trackerPrefix = "\n" + strings.TrimSuffix(trackerView, "\n") + "\n"
+		}
+		return separatorWrapped(trackerPrefix, separator, ov.Render())
 	}
 	return m.renderNormalView(separator, trackerView)
+}
+
+// isDockedModal reports whether the active overlay docks above the input area
+// — rendered between separators with the task tracker still visible — rather
+// than taking over the full screen like the slash-command pickers do. Only
+// the Question and Approval modals dock.
+func isDockedModal(ov overlayPanel) bool {
+	switch ov.(type) {
+	case *conv.QuestionPrompt, *input.ApprovalModel:
+		return true
+	}
+	return false
 }
 
 // renderNormalView composes the standard layout: chat scrollback area,
@@ -121,26 +140,6 @@ func (m *model) renderFooter(separator string) string {
 		b.WriteString(" ")
 	}
 	return b.String()
-}
-
-func (m *model) renderActivePopup() string {
-	for _, s := range m.popups() {
-		if s.IsActive() {
-			return s.Render()
-		}
-	}
-	return ""
-}
-
-func (m *model) renderActiveModal(separator, trackerPrefix string) string {
-	switch {
-	case m.userInput.Approval.IsActive():
-		return separatorWrapped(trackerPrefix, separator, m.userInput.Approval.Render())
-	case m.conv.Modal.Question.IsActive():
-		return separatorWrapped(trackerPrefix, separator, m.conv.Modal.Question.Render())
-	default:
-		return ""
-	}
 }
 
 func separatorWrapped(trackerPrefix, separator, content string) string {


### PR DESCRIPTION
Fold the slash-command pickers and the Question/Approval modals into a single `overlayPanel` interface + ordered `overlayPanels()` registry, with one `activeOverlay()` accessor shared by both key routing (`routeKeypress`) and rendering (`viewString`).

- Removes three hand-maintained overlay enumerations with mismatched orderings (routing checked modals first, rendering checked pickers first — kept consistent only by the unenforced "at most one active" invariant). The panel that owns the keyboard is now always the one drawn.
- The two modals' `HandleKeypress` now returns `tea.Cmd` and emits its response as a message handled in the top-level `Update`, matching the bubbletea v2 idiom (one-event-loop deferral, imperceptible to the waiting tool goroutine).

Net +106/-88; `go build`, `go vet`, and the full test suite pass.