### PR TITLE
feat(tui): unify selection on a teal focus accent

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -210,8 +210,11 @@ var (
 				Foreground(kit.CurrentTheme.Focus).
 				Bold(true)
 
+	// The assistant bullet leads with weight, not hue: the strongest neutral
+	// (near-black on light, near-white on dark) plus bold. The conversation
+	// body stays monochrome — teal is reserved for the user's "❭" marker.
 	aiPromptStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.AI).
+			Foreground(kit.CurrentTheme.TextBright).
 			Bold(true)
 
 	// Footer rules are a faint hairline so they frame the input without

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -78,30 +78,36 @@ func renderModelWithTokens(modelName, statusMessage string, inputTokens, inputLi
 		return ""
 	}
 	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	parts := []string{modelName}
+	sep := muted.Render(" · ")
+
+	parts := []string{muted.Render(modelName)}
 	if statusMessage != "" {
-		parts = append(parts, statusMessage)
+		parts = append(parts, muted.Render(statusMessage))
 	}
 
-	if inputTokens == 0 {
-		if !conversationCost.IsZero() {
-			parts = append(parts, kit.FormatMoney(conversationCost))
-		}
-		return muted.Render(strings.Join(parts, " · "))
-	}
-
-	if inputLimit > 0 {
+	if inputTokens > 0 && inputLimit > 0 {
 		pct := float64(inputTokens) / float64(inputLimit) * 100
 		ctxSegment := fmt.Sprintf("%s/%s (%.0f%%)", kit.FormatTokenCount(inputTokens), kit.FormatTokenCount(inputLimit), pct)
 		if hint := compactStatusHint(pct); hint != "" {
 			ctxSegment += " · " + hint
 		}
-		parts = append(parts, ctxSegment)
+		// Tint the context budget as it nears auto-compact so it's glanceable;
+		// below the threshold it stays muted like the rest of the line.
+		ctxStyle := muted
+		switch {
+		case pct >= autoCompactThreshold:
+			ctxStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+		case pct >= 85:
+			ctxStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+		}
+		parts = append(parts, ctxStyle.Render(ctxSegment))
 	}
+
 	if !conversationCost.IsZero() {
-		parts = append(parts, kit.FormatMoney(conversationCost))
+		parts = append(parts, muted.Render(kit.FormatMoney(conversationCost)))
 	}
-	return muted.Render(strings.Join(parts, " · "))
+
+	return strings.Join(parts, sep)
 }
 
 func RenderTurnUsageSummary(inputTokens, outputTokens, width int) string {
@@ -208,8 +214,10 @@ var (
 			Foreground(kit.CurrentTheme.AI).
 			Bold(true)
 
+	// Footer rules are a faint hairline so they frame the input without
+	// drawing ink — softer than the bluish Separator used between messages.
 	SeparatorStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.Separator)
+			Foreground(kit.AdaptiveColor{Dark: "#3F3F46", Light: "#E4E4E7"})
 
 	ThinkingStyle = lipgloss.NewStyle().
 			Foreground(kit.CurrentTheme.Muted)
@@ -218,8 +226,11 @@ var (
 			Foreground(kit.CurrentTheme.TextDim).
 			PaddingLeft(2)
 
+	// Tool plumbing (the "● Tool(args)" call line and its "⎿ … → size"
+	// result) renders one step dimmer than the assistant's prose, so the eye
+	// lands on the answer and tool activity recedes into a supporting layer.
 	toolCallStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.Text)
+			Foreground(kit.CurrentTheme.TextDim)
 
 	toolResultStyle = toolCallStyle
 
@@ -343,7 +354,9 @@ func RenderAssistantMessage(params AssistantParams) string {
 				lines = append(lines, ThinkingStyle.Render(line))
 			}
 		}
-		thinkingIcon := ThinkingStyle.Render("✦ ")
+		// The ✦ reasoning glyph carries the same Accent tint as the status-bar
+		// thinking indicator; the wrapped text stays muted.
+		thinkingIcon := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Render("✦ ")
 		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, thinkingIcon, strings.Join(lines, "\n")) + "\n\n")
 	}
 
@@ -624,9 +637,10 @@ func RenderQueuePreview(items []QueuePreviewItem, selectedIdx, width int) string
 		}
 
 		if isSelected {
-			badge := queueSelectedBadgeStyle.Render(fmt.Sprintf("▸ %d.", i+1))
+			bar := kit.FocusBarStyle().Render(kit.FocusBar)
+			num := queueSelectedBadgeStyle.Render(fmt.Sprintf("%d.", i+1))
 			preview := queueSelectedContentStyle.Render(content)
-			fmt.Fprintf(&sb, " %s %s\n", badge, preview)
+			fmt.Fprintf(&sb, " %s %s %s\n", bar, num, preview)
 		} else {
 			badge := queueBadgeStyle.Render(fmt.Sprintf("  %d.", i+1))
 			preview := queueContentStyle.Render(content)

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -226,13 +226,17 @@ var (
 			Foreground(kit.CurrentTheme.TextDim).
 			PaddingLeft(2)
 
-	// Tool plumbing (the "● Tool(args)" call line and its "⎿ … → size"
-	// result) renders one step dimmer than the assistant's prose, so the eye
-	// lands on the answer and tool activity recedes into a supporting layer.
+	// The tool call line stays readable — the action and its target (the file
+	// being edited, the command being run) matter, and the live spinner rides
+	// this line while the call is in flight.
 	toolCallStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.TextDim)
+			Foreground(kit.CurrentTheme.Text)
 
-	toolResultStyle = toolCallStyle
+	// Only the "⎿ … → size" result trailer recedes: it's secondary metadata,
+	// dimmed to the same supporting tone as the expanded body so the eye lands
+	// on the assistant's prose and the actions, not the bookkeeping.
+	toolResultStyle = lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.TextDim)
 
 	toolResultExpandedStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.TextDim).

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -201,7 +201,7 @@ var (
 	userMsgStyle = lipgloss.NewStyle()
 
 	InputPromptStyle = lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.Primary).
+				Foreground(kit.CurrentTheme.Focus).
 				Bold(true)
 
 	aiPromptStyle = lipgloss.NewStyle().

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -164,7 +164,7 @@ func RenderThinkingIndicator(effort string) string {
 	if effort == "" || effort == "off" || effort == "none" {
 		return ""
 	}
-	style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent)
+	style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	hint := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted).Render(" (ctrl+t to cycle)")
 	return "  " + style.Render("✦ "+effort) + hint
 }
@@ -361,9 +361,9 @@ func RenderAssistantMessage(params AssistantParams) string {
 				lines = append(lines, ThinkingStyle.Render(line))
 			}
 		}
-		// The ✦ reasoning glyph carries the same Accent tint as the status-bar
-		// thinking indicator; the wrapped text stays muted.
-		thinkingIcon := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Render("✦ ")
+		// Reasoning is secondary activity: the ✦ glyph and its text both stay
+		// muted, matching the status-bar thinking indicator — no hue.
+		thinkingIcon := ThinkingStyle.Render("✦ ")
 		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, thinkingIcon, strings.Join(lines, "\n")) + "\n\n")
 	}
 

--- a/internal/app/conv/question.go
+++ b/internal/app/conv/question.go
@@ -336,7 +336,9 @@ func getQuestionTextStyle() lipgloss.Style {
 }
 
 func getQuestionSelectedStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success).Bold(true)
+	// Neutral bright+bold; the teal FocusBar is the selection signal. Green
+	// stays reserved for success/confirm semantics.
+	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextBright).Bold(true)
 }
 
 func getQuestionUnselectedStyle() lipgloss.Style {
@@ -353,7 +355,7 @@ func getQuestionFooterStyle() lipgloss.Style {
 
 func getQuestionTabActiveStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Foreground(kit.CurrentTheme.TextBright).
+		Foreground(kit.CurrentTheme.Focus).
 		Bold(true).
 		Underline(true)
 }
@@ -443,20 +445,12 @@ func (p *QuestionPrompt) Render() string {
 			prefix = "( )"
 		}
 
-		cursor := "   "
+		optBody := fmt.Sprintf("%s %d. %s", prefix, i+1, opt.Label)
 		if isHighlighted {
-			cursor = " \u276F "
-		}
-
-		var optStyle lipgloss.Style
-		if isHighlighted {
-			optStyle = getQuestionSelectedStyle()
+			sb.WriteString(" " + kit.FocusBarStyle().Render(kit.FocusBar) + " " + getQuestionSelectedStyle().Render(optBody))
 		} else {
-			optStyle = getQuestionUnselectedStyle()
+			sb.WriteString(getQuestionUnselectedStyle().Render("   " + optBody))
 		}
-
-		optLine := fmt.Sprintf("%s%s %d. %s", cursor, prefix, i+1, opt.Label)
-		sb.WriteString(optStyle.Render(optLine))
 
 		if i == customIdx {
 			desc := opt.Description
@@ -475,22 +469,17 @@ func (p *QuestionPrompt) Render() string {
 	if customIdx == len(currentQ.Options) {
 		isOtherHighlighted := curOption == customIdx
 
-		otherCursor := "   "
-		if isOtherHighlighted {
-			otherCursor = " \u276F "
-		}
-
-		otherStyle := getQuestionUnselectedStyle()
-		if isOtherHighlighted {
-			otherStyle = getQuestionSelectedStyle()
-		}
-
 		otherPrefix := "( )"
 		if isMulti {
 			otherPrefix = "[ ]"
 		}
 
-		sb.WriteString(otherStyle.Render(fmt.Sprintf("%s%s %d. Other", otherCursor, otherPrefix, customIdx+1)))
+		otherBody := fmt.Sprintf("%s %d. Other", otherPrefix, customIdx+1)
+		if isOtherHighlighted {
+			sb.WriteString(" " + kit.FocusBarStyle().Render(kit.FocusBar) + " " + getQuestionSelectedStyle().Render(otherBody))
+		} else {
+			sb.WriteString(getQuestionUnselectedStyle().Render("   " + otherBody))
+		}
 		sb.WriteString(" - ")
 		sb.WriteString(getQuestionDescStyle().Render("Type custom response"))
 		sb.WriteString("\n")

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -119,8 +119,15 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 	sizeInfo := formatToolResultSize(toolName, data.Content)
 	icon := toolResultIcon(data.IsError)
 
+	// Errors break out of the dim plumbing tone into the error color so a
+	// failed call is visible at a glance; successes stay muted.
+	summaryStyle := toolResultStyle
+	if data.IsError {
+		summaryStyle = errorStyle
+	}
+
 	var sb strings.Builder
-	summary := toolResultStyle.Render(fmt.Sprintf("  %s  %s → %s", icon, toolName, sizeInfo))
+	summary := summaryStyle.Render(fmt.Sprintf("  %s  %s → %s", icon, toolName, sizeInfo))
 	sb.WriteString(summary + "\n")
 
 	if data.Expanded || data.IsError {

--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -416,18 +416,7 @@ func (s *AgentSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 		// separator. Width(...) right-pads each row to the full inner content
 		// area so the right edge also matches the separator line.
 		rowWidth := max(20, panel.ContentWidth()-4)
-		if i == s.nav.Selected {
-			sb.WriteString(lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.TextBright).
-				Bold(true).
-				Width(rowWidth).
-				Render("> " + line))
-		} else {
-			sb.WriteString(lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.Text).
-				Width(rowWidth).
-				Render("  " + line))
-		}
+		sb.WriteString(kit.RenderPanelRow(line, i == s.nav.Selected, rowWidth))
 		sb.WriteString("\n")
 
 		// Description sub-line aligned under the agent name (4 cols in:

--- a/internal/app/input/on_approval.go
+++ b/internal/app/input/on_approval.go
@@ -229,7 +229,9 @@ func approvalQuestionStyle() lipgloss.Style {
 }
 
 func approvalSelectedStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success).Bold(true)
+	// Neutral bright+bold for the focused option; the teal FocusBar carries the
+	// "selected" signal. Green is reserved for genuine success/confirm states.
+	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextBright).Bold(true)
 }
 
 func approvalUnselectedStyle() lipgloss.Style {
@@ -390,7 +392,8 @@ func (p *ApprovalModel) renderMenu() string {
 	options := buildApprovalOptionRows(p.request)
 	for i, opt := range options {
 		if i == p.selectedIdx {
-			sb.WriteString(approvalSelectedStyle().Render(fmt.Sprintf(" ❯ %d. %s", i+1, opt.Label)))
+			bar := kit.FocusBarStyle().Render(kit.FocusBar)
+			sb.WriteString(" " + bar + " " + approvalSelectedStyle().Render(fmt.Sprintf("%d. %s", i+1, opt.Label)))
 		} else {
 			sb.WriteString(approvalUnselectedStyle().Render(fmt.Sprintf("   %d. %s", i+1, opt.Label)))
 		}

--- a/internal/app/input/on_mcp_view.go
+++ b/internal/app/input/on_mcp_view.go
@@ -122,11 +122,7 @@ func (s *MCPSelector) renderList() string {
 				descStyle.Render(details),
 			)
 
-			if i == s.nav.Selected {
-				sb.WriteString(kit.SelectorSelectedStyle().Render("> " + line))
-			} else {
-				sb.WriteString(kit.SelectorItemStyle().Render("  " + line))
-			}
+			sb.WriteString(kit.RenderSelectableRow(line, i == s.nav.Selected))
 			sb.WriteString("\n")
 		}
 
@@ -214,11 +210,7 @@ func (s *MCPSelector) renderDetail() string {
 	sb.WriteString(labelStyle.Render("  Actions:"))
 	sb.WriteString("\n")
 	for i, action := range s.actions {
-		if i == s.actionIdx {
-			sb.WriteString(kit.SelectorSelectedStyle().Render("> " + action.Label))
-		} else {
-			sb.WriteString(kit.SelectorItemStyle().Render("  " + action.Label))
-		}
+		sb.WriteString(kit.RenderSelectableRow(action.Label, i == s.actionIdx))
 		sb.WriteString("\n")
 	}
 

--- a/internal/app/input/on_memory.go
+++ b/internal/app/input/on_memory.go
@@ -217,11 +217,7 @@ func (m *MemorySelector) Render() string {
 			kit.SelectorHintStyle().Render(item.Description+sizeStr),
 		)
 
-		if i == m.selectedIdx {
-			sb.WriteString(kit.SelectorSelectedStyle().Render(fmt.Sprintf("❯ %s %s", numKey, line)))
-		} else {
-			sb.WriteString(kit.SelectorItemStyle().Render(fmt.Sprintf("  %s %s", numKey, line)))
-		}
+		sb.WriteString(kit.RenderSelectableRow(numKey+" "+line, i == m.selectedIdx))
 		sb.WriteString("\n")
 
 		if !item.Exists && i == m.selectedIdx {

--- a/internal/app/input/on_plugin_view.go
+++ b/internal/app/input/on_plugin_view.go
@@ -107,15 +107,15 @@ func (s *PluginSelector) renderSearchBox(sb *strings.Builder) {
 	var text string
 	if s.searchQuery != "" {
 		pos, total := s.getItemCount()
-		text = fmt.Sprintf(" 🔍 %s▏ (%d/%d)", s.searchQuery, pos, total)
+		text = fmt.Sprintf(" %s▏ (%d/%d)", s.searchQuery, pos, total)
 	} else {
 		switch s.activeTab {
 		case pluginTabDiscover:
-			text = " 🔍 Type to filter plugins..."
+			text = " Type to filter plugins..."
 		case pluginTabInstalled:
-			text = " 🔍 Type to filter installed..."
+			text = " Type to filter installed..."
 		case pluginTabMarketplaces:
-			text = " 🔍 Type to filter marketplaces..."
+			text = " Type to filter marketplaces..."
 		}
 	}
 

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -191,14 +191,14 @@ func (s *ProviderSelector) renderSearchBox() string {
 	if s.activeTab == providerTabModels && s.searchQuery != "" {
 		totalModels := len(s.allModels)
 		filteredCount := len(s.filteredModels)
-		text = fmt.Sprintf(" 🔍 %s▏ (%d/%d)", s.searchQuery, filteredCount, totalModels)
+		text = fmt.Sprintf(" %s▏ (%d/%d)", s.searchQuery, filteredCount, totalModels)
 	} else if s.searchQuery != "" {
-		text = " 🔍 " + s.searchQuery + "▏"
+		text = " " + s.searchQuery + "▏"
 	} else {
 		if s.activeTab == providerTabProviders {
-			text = " 🔍 Type to filter providers..."
+			text = " Type to filter providers..."
 		} else {
-			text = " 🔍 Type to filter models..."
+			text = " Type to filter models..."
 		}
 	}
 

--- a/internal/app/input/on_session.go
+++ b/internal/app/input/on_session.go
@@ -262,10 +262,9 @@ func (s *SessionSelector) getFirstSubstantiveMessage(sess *session.SessionMetada
 }
 
 func (s *SessionSelector) renderSession(sess *session.SessionMetadata, isSelected bool, sb *strings.Builder, boxWidth int) {
-	titleStyle, indent := kit.SelectorItemStyle(), "  "
-	if isSelected {
-		titleStyle, indent = kit.SelectorSelectedStyle(), "> "
-	}
+	// Both states reserve a 2-col left gutter (blank, or the FocusBar) so the
+	// title column lines up whether or not the row is focused.
+	const indent = "  "
 
 	displayTitle := sess.Title
 	if len([]rune(displayTitle)) < session.MinSubstantiveLength {
@@ -287,7 +286,7 @@ func (s *SessionSelector) renderSession(sess *session.SessionMetadata, isSelecte
 		gap = 2
 	}
 	padding := strings.Repeat(" ", gap)
-	sb.WriteString(titleStyle.Render(fmt.Sprintf("%s%s%s%s", indent, title, padding, metadata)) + "\n")
+	sb.WriteString(kit.RenderSelectableRow(fmt.Sprintf("%s%s%s", title, padding, metadata), isSelected) + "\n")
 
 	if lastMsg := s.getLastMessage(sess); lastMsg != "" {
 		previewStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
@@ -306,10 +305,10 @@ func (s *SessionSelector) Render() string {
 	title := fmt.Sprintf("Resume Session - %s (%d/%d)", filepath.Base(s.cwd), len(s.filtered), len(s.sessions))
 	sb.WriteString(kit.SelectorTitleStyle().Render(title) + "\n")
 
-	searchLine := "🔍 Type to filter..."
+	searchLine := "Type to filter..."
 	searchStyle := kit.SelectorHintStyle()
 	if s.nav.Search != "" {
-		searchLine = "> " + s.nav.Search + "_"
+		searchLine = s.nav.Search + "▏"
 		searchStyle = kit.SelectorBreadcrumbStyle()
 	}
 	sb.WriteString(searchStyle.Render(searchLine) + "\n\n")

--- a/internal/app/input/on_skill.go
+++ b/internal/app/input/on_skill.go
@@ -444,18 +444,7 @@ func (s *SkillSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 		// separator. Width(...) right-pads each row to the full inner content
 		// area so the right edge also matches the separator line.
 		rowWidth := max(20, panel.ContentWidth()-4)
-		if i == s.nav.Selected {
-			sb.WriteString(lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.TextBright).
-				Bold(true).
-				Width(rowWidth).
-				Render("> " + line))
-		} else {
-			sb.WriteString(lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.Text).
-				Width(rowWidth).
-				Render("  " + line))
-		}
+		sb.WriteString(kit.RenderPanelRow(line, i == s.nav.Selected, rowWidth))
 		sb.WriteString("\n")
 
 		// Argument hint sub-line aligned under the skill name (4 cols in:

--- a/internal/app/input/on_tool_selector.go
+++ b/internal/app/input/on_tool_selector.go
@@ -202,11 +202,10 @@ func (s *ToolSelector) Render() string {
 	sb.WriteString(kit.SelectorTitleStyle().Render(title))
 	sb.WriteString("\n")
 
-	searchPrompt := "🔍 "
 	if s.nav.Search == "" {
-		sb.WriteString(kit.SelectorHintStyle().Render(searchPrompt + "Type to filter..."))
+		sb.WriteString(kit.SelectorHintStyle().Render("Type to filter..."))
 	} else {
-		sb.WriteString(kit.SelectorBreadcrumbStyle().Render(searchPrompt + s.nav.Search + "▏"))
+		sb.WriteString(kit.SelectorBreadcrumbStyle().Render(s.nav.Search + "▏"))
 	}
 	sb.WriteString("\n\n")
 
@@ -252,11 +251,7 @@ func (s *ToolSelector) Render() string {
 				descStyle.Render(desc),
 			)
 
-			if i == s.nav.Selected {
-				sb.WriteString(kit.SelectorSelectedStyle().Render("> " + line))
-			} else {
-				sb.WriteString(kit.SelectorItemStyle().Render("  " + line))
-			}
+			sb.WriteString(kit.RenderSelectableRow(line, i == s.nav.Selected))
 			sb.WriteString("\n")
 		}
 

--- a/internal/app/kit/panel.go
+++ b/internal/app/kit/panel.go
@@ -129,11 +129,11 @@ func RenderSearchBox(opts SearchBoxOpts) string {
 	var text string
 	switch {
 	case opts.Query == "":
-		text = " 🔍 " + opts.Placeholder
+		text = " " + opts.Placeholder
 	case opts.Total > 0:
-		text = fmt.Sprintf(" 🔍 %s▏ (%d/%d)", opts.Query, opts.Filtered, opts.Total)
+		text = fmt.Sprintf(" %s▏ (%d/%d)", opts.Query, opts.Filtered, opts.Total)
 	default:
-		text = " 🔍 " + opts.Query + "▏"
+		text = " " + opts.Query + "▏"
 	}
 
 	textFg := CurrentTheme.TextDim

--- a/internal/app/kit/styles.go
+++ b/internal/app/kit/styles.go
@@ -6,6 +6,33 @@ import (
 
 // Selector styles — lazy functions to pick up the current theme at render time.
 
+// FocusBar is the thin vertical accent drawn to the left of a focused row.
+// It is the one consistent selection affordance across every list surface
+// (selectors, slash suggestions, approval, questions) — replacing the old mix
+// of ">", "❯", and bare bold text.
+const FocusBar = "▎"
+
+// FocusBarStyle colors the FocusBar in the brand accent.
+func FocusBarStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(CurrentTheme.Focus)
+}
+
+// SelectorSelectedLabelStyle styles the label of a focused row: bright + bold,
+// with no padding so it composes after a separately-colored FocusBar.
+func SelectorSelectedLabelStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(CurrentTheme.TextBright).
+		Bold(true)
+}
+
+// SelectorItemLabelStyle is the unselected row label without the PaddingLeft
+// that SelectorItemStyle carries — used by the width-padded panel rows that
+// manage their own indent.
+func SelectorItemLabelStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(CurrentTheme.Text)
+}
+
 func SelectorBorderStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -70,11 +97,13 @@ func DimStyle() lipgloss.Style {
 		Foreground(CurrentTheme.TextDim)
 }
 
-// TabActiveBg is the background color for active tabs in tabbed panels.
-var TabActiveBg = AdaptiveColor{Dark: "#4F6D9B", Light: "#3B6FC0"}
+// TabActiveBg is the background of the active tab pill — the brand teal, so
+// "active tab" and the selected-row FocusBar share one accent.
+var TabActiveBg = AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"}
 
-// TabActiveFg is the foreground color for active tabs in tabbed panels.
-var TabActiveFg = AdaptiveColor{Dark: "#FFFFFF", Light: "#FFFFFF"}
+// TabActiveFg is the active-tab text: dark ink on the bright dark-mode teal,
+// white on the deeper light-mode teal, so contrast holds either way.
+var TabActiveFg = AdaptiveColor{Dark: "#18181B", Light: "#FFFFFF"}
 
 // SearchBg is the background color for search/filter input boxes.
 var SearchBg = AdaptiveColor{Dark: "#27272A", Light: "#E4E4E7"}

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -425,27 +425,26 @@ func (s *State) renderfileSuggestions(width int) string {
 	boxWidth := clampInt(width*60/100, 40, 60)
 
 	var lines []string
-	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Primary).Bold(true)
-	header := "@ Import file:"
+	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim).Bold(true)
+	header := "Import file"
 	if total > viewSize {
-		header = fmt.Sprintf("@ Import file (%d/%d):", s.selectedIdx+1, total)
+		header = fmt.Sprintf("Import file  %d/%d", s.selectedIdx+1, total)
 	}
-	lines = append(lines, headerStyle.Render(header))
+	lines = append(lines, headerStyle.Render(header), "")
 
-	maxPathLen := boxWidth - 10
+	maxPathLen := boxWidth - 8
 	for i, file := range items {
-		icon := "📄"
+		suffix := ""
 		if file.IsDir {
-			icon = "📁"
+			suffix = "/"
 		}
-
-		displayPath := truncateFromLeft(file.DisplayName, maxPathLen)
-		line := fmt.Sprintf("%s %s", icon, displayPath)
+		displayPath := truncateFromLeft(file.DisplayName, maxPathLen) + suffix
 
 		if start+i == s.selectedIdx {
-			lines = append(lines, selectedSuggestionStyle().Render("> "+line))
+			bar := kit.FocusBarStyle().Render(kit.FocusBar)
+			lines = append(lines, bar+" "+selectedSuggestionStyle().Render(displayPath))
 		} else {
-			lines = append(lines, normalSuggestionStyle().Render("  "+line))
+			lines = append(lines, "  "+normalSuggestionStyle().Render(displayPath))
 		}
 	}
 
@@ -477,23 +476,35 @@ func (s *State) renderCommandSuggestions(width int) string {
 	contentWidth := max(boxWidth-2, 20)
 
 	var lines []string
-	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Primary).Bold(true)
-	header := "Commands:"
+	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim).Bold(true)
+	header := "Commands"
 	if total > viewSize {
-		header = fmt.Sprintf("Commands (%d/%d):", s.selectedIdx+1, total)
+		header = fmt.Sprintf("Commands  %d/%d", s.selectedIdx+1, total)
 	}
-	lines = append(lines, headerStyle.Render(header))
+	lines = append(lines, headerStyle.Render(header), "")
 
+	// Align descriptions into a column: pad every command name to the widest
+	// one visible, then a 2-space gutter, so the descriptions read as a list.
+	nameWidth := 0
+	for _, cmd := range items {
+		if w := len([]rune(cmd.Name)) + 1; w > nameWidth { // +1 for the leading "/"
+			nameWidth = w
+		}
+	}
+	// Budget: 2 (bar/indent prefix) + nameWidth + 2 (gutter) + desc, with 2
+	// cols of right margin so the focused row never wraps.
+	maxDescLen := max(contentWidth-nameWidth-6, 10)
 	for i, cmd := range items {
 		cmdName := "/" + cmd.Name
-		maxDescLen := max(contentWidth-len(cmdName)-3, 10)
+		pad := strings.Repeat(" ", max(0, nameWidth-len([]rune(cmdName))))
 		desc := truncateWithEllipsis(cmd.Description, maxDescLen)
 
 		if start+i == s.selectedIdx {
-			line := fmt.Sprintf("%s - %s", cmdName, desc)
-			lines = append(lines, selectedSuggestionStyle().Render(line))
+			bar := kit.FocusBarStyle().Render(kit.FocusBar)
+			lines = append(lines, bar+" "+selectedSuggestionStyle().Render(cmdName+pad+"  "+desc))
 		} else {
-			lines = append(lines, commandNameStyle().Render(cmdName)+commandDescStyle().Render(" - "+desc))
+			row := commandNameStyle().Render(cmdName) + commandDescStyle().Render(pad+"  "+desc)
+			lines = append(lines, "  "+row)
 		}
 	}
 

--- a/internal/app/kit/theme.go
+++ b/internal/app/kit/theme.go
@@ -31,6 +31,13 @@ type Theme struct {
 	AI        AdaptiveColor
 	Separator AdaptiveColor
 
+	// Focus is the single vivid brand accent (teal). It is reserved for the
+	// "you are here" affordances — the selected-row bar, the input caret, the
+	// active tab — so focus reads consistently and the brand mark from the
+	// splash carries into the live UI. Everything else stays in the cool-gray
+	// ramp; Focus is the only saturated hue, used sparingly.
+	Focus AdaptiveColor
+
 	Text         AdaptiveColor
 	TextDim      AdaptiveColor
 	TextBright   AdaptiveColor
@@ -52,6 +59,8 @@ var CurrentTheme = Theme{
 	Primary:   AdaptiveColor{Dark: "#D0DFEF", Light: "#475569"},
 	AI:        AdaptiveColor{Dark: "#B0C4E0", Light: "#64748B"},
 	Separator: AdaptiveColor{Dark: "#4E6580", Light: "#CBD5E1"},
+
+	Focus: AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"},
 
 	Text:         AdaptiveColor{Dark: "#DDDEE2", Light: "#18181B"},
 	TextDim:      AdaptiveColor{Dark: "#A8AEBB", Light: "#71717A"},

--- a/internal/app/kit/theme.go
+++ b/internal/app/kit/theme.go
@@ -57,7 +57,7 @@ var CurrentTheme = Theme{
 	Muted:     AdaptiveColor{Dark: "#7B8696", Light: "#6B7280"},
 	Accent:    AdaptiveColor{Dark: "#9DB5D4", Light: "#64748B"},
 	Primary:   AdaptiveColor{Dark: "#D0DFEF", Light: "#475569"},
-	AI:        AdaptiveColor{Dark: "#8AB4F8", Light: "#2563EB"},
+	AI:        AdaptiveColor{Dark: "#B0C4E0", Light: "#64748B"},
 	Separator: AdaptiveColor{Dark: "#4E6580", Light: "#CBD5E1"},
 
 	Focus: AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"},

--- a/internal/app/kit/theme.go
+++ b/internal/app/kit/theme.go
@@ -57,7 +57,7 @@ var CurrentTheme = Theme{
 	Muted:     AdaptiveColor{Dark: "#7B8696", Light: "#6B7280"},
 	Accent:    AdaptiveColor{Dark: "#9DB5D4", Light: "#64748B"},
 	Primary:   AdaptiveColor{Dark: "#D0DFEF", Light: "#475569"},
-	AI:        AdaptiveColor{Dark: "#B0C4E0", Light: "#64748B"},
+	AI:        AdaptiveColor{Dark: "#8AB4F8", Light: "#2563EB"},
 	Separator: AdaptiveColor{Dark: "#4E6580", Light: "#CBD5E1"},
 
 	Focus: AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"},

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -67,12 +67,25 @@ func ShortenPathForProject(path, cwd string) string {
 	return ShortenPath(path)
 }
 
-// RenderSelectableRow renders a row with "> " or "  " prefix.
+// RenderSelectableRow renders a list row, prefixing the focused one with the
+// teal FocusBar (the label aligns at the same column as unselected rows).
 func RenderSelectableRow(line string, isSelected bool) string {
 	if isSelected {
-		return SelectorSelectedStyle().Render("> " + line)
+		return "  " + FocusBarStyle().Render(FocusBar) + " " + SelectorSelectedLabelStyle().Render(line)
 	}
 	return SelectorItemStyle().Render("  " + line)
+}
+
+// RenderPanelRow is RenderSelectableRow for the expansive full-screen panels
+// (skills, agents): both variants right-pad to width so the row edges line up
+// with the panel separators, and the focused row gets the teal FocusBar.
+func RenderPanelRow(line string, isSelected bool, width int) string {
+	if isSelected {
+		bar := FocusBarStyle().Render(FocusBar)
+		label := SelectorSelectedLabelStyle().Width(max(1, width-1)).Render(" " + line)
+		return bar + label
+	}
+	return SelectorItemLabelStyle().Width(width).Render("  " + line)
 }
 
 // alignedRowMinGap is the minimum spacing kept between the name and info

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -49,7 +49,7 @@ func (m *model) overlayDeps() input.OverlayDeps {
 					modelName = name
 				}
 			}
-			teal := lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
+			teal := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
 			star := lipgloss.NewStyle().Foreground(welcomeStar)
 			dim := lipgloss.NewStyle().Foreground(welcomeDim)
 			line := teal.Render("< ") + teal.Render("SAN") + " " + star.Render("✦") + " " + teal.Render("/>")

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -16,11 +16,10 @@ import (
 	"github.com/genai-io/san/internal/app/kit"
 )
 
-// Three-hue palette: teal for the brand mark, star blue for the ✦ accent
-// inside the logo, dim gray for everything else. Each token has Dark and
-// Light variants so contrast holds either way.
+// Three-hue palette: teal for the brand mark (the shared Focus accent, so the
+// splash and the live UI's focus affordances are the same color), star blue
+// for the ✦ accent inside the logo, dim gray for everything else.
 var (
-	welcomeTeal = kit.AdaptiveColor{Dark: "#46E8C0", Light: "#0D9488"}
 	welcomeStar = kit.AdaptiveColor{Dark: "#7FD4FF", Light: "#0284C7"}
 	welcomeDim  = kit.AdaptiveColor{Dark: "#65707A", Light: "#9CA3AF"}
 )
@@ -50,8 +49,8 @@ func welcomeUseColor() bool {
 func renderWelcome(info welcomeInfo) string {
 	var (
 		star    = lipgloss.NewStyle().Foreground(welcomeStar)
-		brand   = lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
-		bracket = lipgloss.NewStyle().Foreground(welcomeTeal).Bold(true)
+		brand   = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
+		bracket = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
 		dim     = lipgloss.NewStyle().Foreground(welcomeDim)
 	)
 


### PR DESCRIPTION
Give the TUI a single, consistent focus language. Adds a dedicated `Focus` theme token (teal, shared with the splash brand mark) and uses it as the one "you are here" accent.

- **Unified selection bar.** Every selector (model/skill/agent/tool/mcp/memory/session), the slash- and file-suggestion popups, and the approval/question dialogs now share one teal focus bar (`▎`), replacing the prior mix of `>`, `❯`, and bare-bold/green selection states. Green is reserved for genuine success/confirm again.
- **Brand accent throughout.** Active tabs (teal pill) and the input caret `❭` adopt the same teal; the splash brand mark now references the shared token.
- **Slash popup polish.** Command descriptions align into a column; cleaner header.
- **Drop UI emoji.** Search boxes and the file picker lose `🔍`/`📄`/`📁` for a consistent monospace look. (The Glob tool-result icon is unrelated and untouched.)

Net `+138/-125` across 18 files — most selectors collapse from inline `if/else` blocks to a shared helper. build / vet / gofmt / tests all green.