### PR TITLE
refactor(app): drop dead nil-guards on always-non-nil services

### DIFF
--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -36,9 +36,6 @@ import (
 // built-in default (no settings.persona, or it doesn't resolve). A configured
 // name that doesn't resolve logs a warning and falls back to the default.
 func (m *model) activePersona() *persona.Persona {
-	if m.services.Setting == nil || m.services.Persona == nil {
-		return nil
-	}
 	snap := m.services.Setting.Snapshot()
 	if snap == nil || snap.Persona == "" || snap.Persona == persona.DefaultName {
 		return nil
@@ -66,9 +63,6 @@ func (m *model) personaPrompt() system.Persona {
 // registry (in-memory, active by default), or clears them when no persona is
 // selected. The skills-directory reminder picks the set up on its next emit.
 func (m *model) applyPersonaSkills() {
-	if m.services.Skill == nil {
-		return
-	}
 	if p := m.activePersona(); p != nil {
 		var states map[string]string
 		if p.Settings != nil {
@@ -84,9 +78,6 @@ func (m *model) applyPersonaSkills() {
 // `agents` allow-list (empty/none = all visible), or clears the restriction
 // when no persona is selected. In-memory, mirroring applyPersonaSkills.
 func (m *model) applyPersonaAgents() {
-	if m.services.Subagent == nil {
-		return
-	}
 	if p := m.activePersona(); p != nil && p.Settings != nil && len(p.Settings.Agents) > 0 {
 		m.services.Subagent.LoadPersona(p.Settings.Agents)
 		return
@@ -95,43 +86,32 @@ func (m *model) applyPersonaAgents() {
 }
 
 func (m *model) buildAgentParams() agent.BuildParams {
-	var mcpTools []core.Tool
-	if m.services.MCP != nil {
-		schemas := m.services.MCP.GetToolSchemas()
-		mcpTools = mcp.AsCoreTools(schemas, mcp.NewCaller(m.services.MCP))
-	}
+	schemas := m.services.MCP.GetToolSchemas()
+	mcpTools := mcp.AsCoreTools(schemas, mcp.NewCaller(m.services.MCP))
 
 	maxTokens := kit.GetMaxTokens(m.services.LLM.Store(), m.env.CurrentModel, setting.DefaultMaxTokens)
 	var onEvent func(core.Event)
 	rec := m.services.Session.NewRecorder("main", m.env.LLMProvider.Name(), m.env.GetModelID(), maxTokens)
 	if rec != nil {
 		onEvent = rec.OnAgentEvent
-		if m.services.Hook != nil {
-			if eng := m.services.Hook; eng != nil {
-				eng.SetAuditCallback(func(a hook.HookFiredAudit) {
-					rec.RecordHook(transcript.HookRecord{
-						Event:     a.Event,
-						Source:    a.Source,
-						Matcher:   a.Matcher,
-						Outcome:   a.Outcome,
-						Reason:    a.Reason,
-						LatencyMs: a.Duration.Milliseconds(),
-					})
-				})
-			}
-		}
-		if m.services.Skill != nil {
-			if reg := m.services.Skill; reg != nil {
-				reg.SetStateChangeObserver(func(name, previous, current, caller string) {
-					rec.RecordSkillState(transcript.SkillRecord{
-						Name:     name,
-						Previous: previous,
-						Current:  current,
-						Caller:   caller,
-					})
-				})
-			}
-		}
+		m.services.Hook.SetAuditCallback(func(a hook.HookFiredAudit) {
+			rec.RecordHook(transcript.HookRecord{
+				Event:     a.Event,
+				Source:    a.Source,
+				Matcher:   a.Matcher,
+				Outcome:   a.Outcome,
+				Reason:    a.Reason,
+				LatencyMs: a.Duration.Milliseconds(),
+			})
+		})
+		m.services.Skill.SetStateChangeObserver(func(name, previous, current, caller string) {
+			rec.RecordSkillState(transcript.SkillRecord{
+				Name:     name,
+				Previous: previous,
+				Current:  current,
+				Caller:   caller,
+			})
+		})
 	}
 
 	return agent.BuildParams{
@@ -269,9 +249,6 @@ func (m *model) sendToAgent(content string, images []core.Image) tea.Cmd {
 // channel to deliver session/project context (skills, memory, one-time notices)
 // without invalidating the system-prompt cache prefix.
 func (m *model) attachPendingReminders(content string) string {
-	if m.services.Reminder == nil {
-		return content
-	}
 	pending := m.services.Reminder.Drain()
 	if len(pending) == 0 {
 		return content
@@ -285,17 +262,10 @@ func (m *model) attachPendingReminders(content string) string {
 // — that way settings reload and skill toggles surface in the next emission
 // without ever mutating the cached system prompt.
 func (m *model) wireReminderProviders() {
-	if m.services.Reminder == nil {
-		return
-	}
-
 	// Skill.PromptSection already produces a self-introduced body
 	// ("Use the Skill tool to invoke these capabilities: ...") so it goes
 	// inside <system-reminder> verbatim, matching Claude Code's shape.
 	m.services.Reminder.Register(reminder.NewProvider(reminder.ProviderSkillsDirectory, func() string {
-		if m.services.Skill == nil {
-			return ""
-		}
 		return m.services.Skill.PromptSection()
 	}))
 	m.services.Reminder.Register(reminder.NewProvider(reminder.ProviderMemoryUser, func() string {
@@ -424,19 +394,13 @@ func (m *model) ReconfigureAgentTool() {
 	}
 	m.ensureMemoryContextLoaded()
 
-	var hookEngine *hook.Engine
-	if m.services.Hook != nil {
-		hookEngine = m.services.Hook
-	}
-	executor := subagent.NewExecutor(m.env.LLMProvider, m.env.CWD, m.env.GetModelID(), hookEngine)
+	executor := subagent.NewExecutor(m.env.LLMProvider, m.env.CWD, m.env.GetModelID(), m.services.Hook)
 	if m.services.Session.GetStore() != nil && m.services.Session.ID() != "" {
 		executor.SetSessionStore(m.services.Session.GetStore(), m.services.Session.ID())
 	}
 	executor.SetContext(m.env.IsGit)
 	executor.SetCapabilities(m.services.Skill.PromptSection(), m.services.Subagent.PromptSection())
-	if m.services.MCP != nil {
-		executor.SetMCP(m.services.MCP, m.services.MCP)
-	}
+	executor.SetMCP(m.services.MCP, m.services.MCP)
 
 	adapter := subagent.NewExecutorAdapter(executor)
 	type executorSetter interface{ SetExecutor(tool.AgentExecutor) }

--- a/internal/app/hooks.go
+++ b/internal/app/hooks.go
@@ -16,9 +16,6 @@ import (
 )
 
 func (m *model) firePostToolHook(tr core.ToolResult, sideEffect any) {
-	if m.services.Hook == nil {
-		return
-	}
 	eventType := hook.PostToolUse
 	if tr.IsError {
 		eventType = hook.PostToolUseFailure
@@ -39,9 +36,6 @@ func (m *model) firePostToolHook(tr core.ToolResult, sideEffect any) {
 }
 
 func (m *model) fireStopFailureHook(lastAssistantContent string, err error) {
-	if m.services.Hook == nil {
-		return
-	}
 	m.services.Hook.ExecuteAsync(hook.StopFailure, hook.HookInput{
 		LastAssistantMessage: lastAssistantContent,
 		Error:                err.Error(),
@@ -50,9 +44,6 @@ func (m *model) fireStopFailureHook(lastAssistantContent string, err error) {
 }
 
 func (m *model) executeStartupHooks(ctx context.Context) hook.HookOutcome {
-	if m.services.Hook == nil {
-		return hook.HookOutcome{}
-	}
 	m.services.Hook.ExecuteAsync(hook.Setup, hook.HookInput{
 		Trigger: "init",
 	})
@@ -63,9 +54,7 @@ func (m *model) executeStartupHooks(ctx context.Context) hook.HookOutcome {
 	// Enqueue session-level reminders (skills directory, memory, etc.) so
 	// they ride on the first user message of this session. The system-prompt
 	// cache prefix stays untouched.
-	if m.services.Reminder != nil {
-		m.services.Reminder.RequeueSystemReminders()
-	}
+	m.services.Reminder.RequeueSystemReminders()
 	return m.services.Hook.Execute(ctx, hook.SessionStart, hook.HookInput{
 		Source: source,
 		Model:  m.env.GetModelID(),
@@ -80,11 +69,6 @@ type stopHookResultMsg struct {
 
 func (m *model) fireIdleHooksCmd(result core.Result) tea.Cmd {
 	hookEngine := m.services.Hook
-	if hookEngine == nil {
-		return func() tea.Msg {
-			return stopHookResultMsg{Result: result}
-		}
-	}
 
 	lastContent := core.LastAssistantChatContent(m.conv.Messages)
 	hasStopHooks := hookEngine.HasHooks(hook.Stop)
@@ -112,14 +96,11 @@ func (m *model) fireIdleHooksCmd(result core.Result) tea.Cmd {
 }
 
 func (m *model) checkPromptHook(ctx context.Context, prompt string) (bool, string) {
-	if m.services.Hook == nil {
-		return false, ""
-	}
 	outcome := m.services.Hook.Execute(ctx, hook.UserPromptSubmit, hook.HookInput{Prompt: prompt})
 	// UserPromptSubmit hooks may return additionalContext to inject into the
 	// next turn. Enqueue as a <system-reminder> so it rides on the user
 	// message that's about to go out (which is the same prompt being checked).
-	if outcome.AdditionalContext != "" && m.services.Reminder != nil {
+	if outcome.AdditionalContext != "" {
 		m.services.Reminder.Enqueue(outcome.AdditionalContext)
 	}
 	return outcome.ShouldBlock, outcome.BlockReason
@@ -127,9 +108,7 @@ func (m *model) checkPromptHook(ctx context.Context, prompt string) (bool, strin
 
 func (m *model) switchProvider(p llm.Provider) {
 	m.env.LLMProvider = p
-	if m.services.Hook != nil {
-		m.services.Hook.SetLLMCompleter(buildHookCompleter(p), m.env.GetModelID())
-	}
+	m.services.Hook.SetLLMCompleter(buildHookCompleter(p), m.env.GetModelID())
 }
 
 func (m *model) refreshMemoryContext(cwd, loadReason string) {
@@ -142,22 +121,18 @@ func (m *model) refreshMemoryContext(cwd, loadReason string) {
 		case "project", "local":
 			projectParts = append(projectParts, f.Content)
 		}
-		if m.services.Hook != nil {
-			m.services.Hook.ExecuteAsync(hook.InstructionsLoaded, hook.HookInput{
-				FilePath:   f.Path,
-				MemoryType: memoryTypeForLevel(f.Level),
-				LoadReason: loadReason,
-			})
-		}
+		m.services.Hook.ExecuteAsync(hook.InstructionsLoaded, hook.HookInput{
+			FilePath:   f.Path,
+			MemoryType: memoryTypeForLevel(f.Level),
+			LoadReason: loadReason,
+		})
 	}
 	m.env.CachedUserInstructions = joinSections(userParts)
 	m.env.CachedProjectInstructions = joinSections(projectParts)
 }
 
 func (m *model) syncSettingsToHookEngine() {
-	if m.services.Hook != nil && m.services.Setting != nil {
-		m.services.Hook.SetSettings(m.services.Setting.Snapshot())
-	}
+	m.services.Hook.SetSettings(m.services.Setting.Snapshot())
 }
 
 func memoryTypeForLevel(level string) string {

--- a/internal/app/model_actions.go
+++ b/internal/app/model_actions.go
@@ -24,10 +24,8 @@ import (
 // overlay (disabled tools, permissions) takes effect on the next agent
 // rebuild. Empty name = no persona (built-in defaults).
 func (m *model) setActivePersona(name string) error {
-	if m.services.Setting != nil {
-		if snap := m.services.Setting.Snapshot(); snap != nil && snap.Persona == name {
-			return nil
-		}
+	if snap := m.services.Setting.Snapshot(); snap != nil && snap.Persona == name {
+		return nil
 	}
 	// Persist the selection at a scope that actually wins the merge. Project
 	// scope overrides user scope, so write project scope when the project
@@ -36,10 +34,8 @@ func (m *model) setActivePersona(name string) error {
 	// a project persona to the built-in default) — or when the target is itself
 	// a project persona. Otherwise persist user-level.
 	userLevel := true
-	if m.services.Persona != nil {
-		if p, ok := m.services.Persona.Get(name); ok && p.Scope == persona.ScopeProject {
-			userLevel = false
-		}
+	if p, ok := m.services.Persona.Get(name); ok && p.Scope == persona.ScopeProject {
+		userLevel = false
 	}
 	if setting.PersonaAt(m.env.CWD, false) != "" {
 		userLevel = false
@@ -47,27 +43,21 @@ func (m *model) setActivePersona(name string) error {
 	if err := setting.SavePersonaAt(m.env.CWD, name, userLevel); err != nil {
 		return err
 	}
-	if m.services.Setting != nil {
-		_ = m.services.Setting.Reload(m.env.CWD)
-	}
+	_ = m.services.Setting.Reload(m.env.CWD)
 
 	// Skills (immediate): swap the in-memory persona skill set, then re-emit
 	// the skills-directory reminder so the model sees it on the next turn.
 	m.applyPersonaSkills()
 	m.applyPersonaAgents()
-	if m.services.Reminder != nil {
-		m.services.Reminder.RequeueSystemReminders()
-	}
+	m.services.Reminder.RequeueSystemReminders()
 
 	// Prompt (immediate): hot-patch the running main agent's parts.
-	if m.services.Agent != nil {
-		if sys := m.services.Agent.System(); sys != nil {
-			provider := ""
-			if m.env.LLMProvider != nil {
-				provider = m.env.LLMProvider.Name()
-			}
-			system.SwapPersona(sys, m.personaPrompt(), m.env.IsGit, provider)
+	if sys := m.services.Agent.System(); sys != nil {
+		provider := ""
+		if m.env.LLMProvider != nil {
+			provider = m.env.LLMProvider.Name()
 		}
+		system.SwapPersona(sys, m.personaPrompt(), m.env.IsGit, provider)
 	}
 	m.ReconfigureAgentTool()
 	return nil
@@ -78,9 +68,6 @@ func (m *model) setActivePersona(name string) error {
 // TUI. Opens the identity prompt if present, else settings.json, else the
 // directory. The built-in default has no files to open.
 func (m *model) openPersona(name string) tea.Cmd {
-	if m.services.Persona == nil {
-		return nil
-	}
 	p, ok := m.services.Persona.Get(name)
 	if !ok || p.IsBuiltin() || p.Dir == "" {
 		return nil
@@ -124,18 +111,13 @@ func openInOS(path string, isFile bool) error {
 // session never points at a directory that's about to disappear. The built-in
 // default cannot be deleted.
 func (m *model) deletePersona(name string) error {
-	if m.services.Persona == nil {
-		return fmt.Errorf("persona registry unavailable")
-	}
 	p, ok := m.services.Persona.Get(name)
 	if !ok || p.IsBuiltin() || p.Dir == "" {
 		return fmt.Errorf("cannot delete %q", name)
 	}
 
-	if m.services.Setting != nil {
-		if snap := m.services.Setting.Snapshot(); snap != nil && snap.Persona == name {
-			_ = m.setActivePersona(persona.DefaultName)
-		}
+	if snap := m.services.Setting.Snapshot(); snap != nil && snap.Persona == name {
+		_ = m.setActivePersona(persona.DefaultName)
 	}
 	if err := os.RemoveAll(p.Dir); err != nil {
 		return err

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -20,16 +20,12 @@ import (
 )
 
 func (m *model) BuildCompactRequest(focus, trigger string) conv.CompactRequest {
-	var hookEngine *hook.Engine
-	if m.services.Hook != nil {
-		hookEngine = m.services.Hook
-	}
 	return conv.CompactRequest{
 		Ctx:          context.Background(),
 		Client:       m.buildLLMClient(),
 		Messages:     m.conv.ConvertToProvider(),
 		SummaryFocus: focus,
-		HookEngine:   hookEngine,
+		HookEngine:   m.services.Hook,
 		Trigger:      trigger,
 	}
 }
@@ -66,28 +62,24 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	if trigger == "manual" {
 		m.conv.Compact.Complete(fmt.Sprintf("Condensed %d earlier messages.", info.OriginalCount), false)
 	}
-	if m.services.Hook != nil {
-		m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: trigger})
-	}
+	m.services.Hook.ExecuteAsync(hook.PostCompact, hook.HookInput{Trigger: trigger})
 
 	// Compaction summarized away the system-reminder content that rode on the
 	// old user messages. Re-read memory from disk (a provider renders from the
 	// cached instructions, so an edited memory file would otherwise re-inject
 	// stale content), drop now-irrelevant one-time notices, and re-emit the
 	// providers so skills/memory reattach to the next user turn.
-	if m.services.Reminder != nil {
-		m.refreshMemoryContext(m.env.CWD, "post_compact")
-		m.services.Reminder.DiscardPendingNotices()
-		m.services.Reminder.RequeueSystemReminders()
+	m.refreshMemoryContext(m.env.CWD, "post_compact")
+	m.services.Reminder.DiscardPendingNotices()
+	m.services.Reminder.RequeueSystemReminders()
 
-		// Manual /compact restores recently-accessed files as a one-time notice
-		// so they ride on the next user turn. Enqueued AFTER DiscardPendingNotices
-		// so it survives. Auto-compaction happens mid-task and skips this.
-		if trigger == "manual" && m.env.FileCache != nil {
-			if restored, _ := m.env.FileCache.RestoreRecent(); len(restored) > 0 {
-				m.services.Reminder.Enqueue(filecache.FormatRestoredFiles(restored))
-				m.conv.AddNotice(fmt.Sprintf("Restored %d recently accessed file(s) for context.", len(restored)))
-			}
+	// Manual /compact restores recently-accessed files as a one-time notice
+	// so they ride on the next user turn. Enqueued AFTER DiscardPendingNotices
+	// so it survives. Auto-compaction happens mid-task and skips this.
+	if trigger == "manual" && m.env.FileCache != nil {
+		if restored, _ := m.env.FileCache.RestoreRecent(); len(restored) > 0 {
+			m.services.Reminder.Enqueue(filecache.FormatRestoredFiles(restored))
+			m.conv.AddNotice(fmt.Sprintf("Restored %d recently accessed file(s) for context.", len(restored)))
 		}
 	}
 

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -31,11 +31,7 @@ func newModel(opts setting.RunOptions) (*model, error) {
 	m.agentEventHub.Register("main", func(e hub.Event) { m.mainEvents <- e })
 
 	// Wire task completion: closure captures hub + hooks + tracker directly.
-	var hookEngine *hook.Engine
-	if m.services.Hook != nil {
-		hookEngine = m.services.Hook
-	}
-	m.wireTaskLifecycle(hookEngine)
+	m.wireTaskLifecycle(m.services.Hook)
 
 	m.configureAsyncHookCallback()
 	m.ensureMemoryContextLoaded()
@@ -92,10 +88,8 @@ func (m *model) applyRunOptions(opts setting.RunOptions) error {
 	}
 
 	if opts.Persona != "" {
-		if m.services.Persona != nil {
-			if err := m.services.Persona.Validate(opts.Persona); err != nil {
-				return err
-			}
+		if err := m.services.Persona.Validate(opts.Persona); err != nil {
+			return err
 		}
 		if err := m.setActivePersona(opts.Persona); err != nil {
 			return err
@@ -131,9 +125,7 @@ func (m *model) ReloadPluginBackedState() error {
 
 	m.services.refreshAfterReload()
 
-	if m.services.Hook != nil {
-		plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
-	}
+	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()
 	m.ReconfigureAgentTool()
 	m.applyPersonaSkills()
@@ -141,9 +133,7 @@ func (m *model) ReloadPluginBackedState() error {
 
 	// Refresh skills/memory reminders so the LLM sees the updated skill set
 	// in the next user message instead of waiting for SessionStart/PostCompact.
-	if m.services.Reminder != nil {
-		m.services.Reminder.RequeueSystemReminders()
-	}
+	m.services.Reminder.RequeueSystemReminders()
 
 	return nil
 }
@@ -236,12 +226,10 @@ func (f taskLifecycleFunc) TaskCreated(info task.TaskInfo)   { f.onCreated(info)
 func (f taskLifecycleFunc) TaskCompleted(info task.TaskInfo) { f.onCompleted(info) }
 
 func (m *model) FireSessionEnd(reason string) {
-	if m.services.Hook != nil {
-		m.services.Hook.Execute(context.Background(), hook.SessionEnd, hook.HookInput{
-			Reason: reason,
-		})
-		m.services.Hook.ClearSessionHooks()
-	}
+	m.services.Hook.Execute(context.Background(), hook.SessionEnd, hook.HookInput{
+		Reason: reason,
+	})
+	m.services.Hook.ClearSessionHooks()
 	if m.systemInput.FileWatcher != nil {
 		m.systemInput.FileWatcher.Stop()
 	}

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -62,9 +62,7 @@ func (m *model) PersistSession() error {
 	m.services.Session.SetID(sess.Metadata.ID)
 	m.initTaskStorage(m.services.Session.ID())
 
-	if m.services.Hook != nil {
-		m.services.Hook.SetTranscriptPath(m.services.Session.GetStore().SessionPath(sess.Metadata.ID))
-	}
+	m.services.Hook.SetTranscriptPath(m.services.Session.GetStore().SessionPath(sess.Metadata.ID))
 	m.ReconfigureAgentTool()
 
 	return nil

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -44,10 +44,8 @@ func (m *model) overlayDeps() input.OverlayDeps {
 		},
 		PrintWelcome: func(modelID string) tea.Cmd {
 			modelName := modelID
-			if m.services.LLM != nil {
-				if name := m.services.LLM.Store().CachedModelDisplayName(modelID); name != "" {
-					modelName = name
-				}
+			if name := m.services.LLM.Store().CachedModelDisplayName(modelID); name != "" {
+				modelName = name
 			}
 			teal := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
 			star := lipgloss.NewStyle().Foreground(welcomeStar)

--- a/internal/app/model_workspace.go
+++ b/internal/app/model_workspace.go
@@ -24,14 +24,12 @@ func (m *model) changeCwd(newCwd string) {
 	m.refreshMemoryContext(newCwd, "cwd_changed")
 	m.ReloadProjectContext(newCwd)
 	m.ReconfigureAgentTool()
-	if m.services.Hook != nil {
-		m.services.Hook.SetCwd(newCwd)
-		m.services.Hook.ExecuteAsync(hook.CwdChanged, hook.HookInput{OldCwd: oldCwd, NewCwd: newCwd})
-	}
+	m.services.Hook.SetCwd(newCwd)
+	m.services.Hook.ExecuteAsync(hook.CwdChanged, hook.HookInput{OldCwd: oldCwd, NewCwd: newCwd})
 }
 
 func (m *model) fireFileChanged(filePath, source string) {
-	if m.services.Hook == nil || filePath == "" {
+	if filePath == "" {
 		return
 	}
 	m.services.Hook.ExecuteAsync(hook.FileChanged, hook.HookInput{FilePath: filePath, Source: source, Event: "change"})
@@ -41,14 +39,12 @@ func (m *model) ReloadProjectContext(cwd string) {
 	initExtensions(cwd)
 	setting.Initialize(setting.Options{CWD: cwd})
 	m.services.refreshAfterReload()
-	if m.services.Hook != nil {
-		plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
-	}
+	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()
 }
 
 func (m *model) reloadPersonasIfChanged(filePath string) {
-	if m.services.Persona == nil || !persona.IsPersonaFile(m.env.CWD, filePath) {
+	if !persona.IsPersonaFile(m.env.CWD, filePath) {
 		return
 	}
 	m.services.Persona.Reload()

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -73,7 +73,7 @@ func initModel(opts setting.RunOptions) (*model, error) {
 }
 
 func (m *model) configureAsyncHookCallback() {
-	if m.services.Hook == nil || m.systemInput.AsyncHookQueue == nil {
+	if m.systemInput.AsyncHookQueue == nil {
 		return
 	}
 	queue := m.systemInput.AsyncHookQueue
@@ -98,7 +98,7 @@ func (m *model) fireStartupHooks() {
 	// <system-reminder>, not appended as a standalone user message. This
 	// keeps SessionStart context out of the visible chat and lets it
 	// re-emerge after PostCompact alongside other harness reminders.
-	if outcome.AdditionalContext != "" && m.services.Reminder != nil {
+	if outcome.AdditionalContext != "" {
 		m.services.Reminder.Enqueue(outcome.AdditionalContext)
 	}
 }

--- a/internal/app/selflearn.go
+++ b/internal/app/selflearn.go
@@ -54,9 +54,6 @@ func (m *model) wireSelfLearn(params agent.BuildParams, pendingSend string) {
 	// context and pinning the old fork for up to forkDeadline.
 	m.teardownSelfLearn()
 
-	if m.services.Setting == nil {
-		return
-	}
 	// Env override wins: documented as the hard kill switch (§3.1).
 	if v := setting.Getenv(selfLearnDisableEnvSuffix); v == "1" || strings.EqualFold(v, "true") {
 		m.services.SelfLearn.Reviewer = nil
@@ -254,9 +251,6 @@ func (m *model) runSelfLearnDemo() {
 // learns about the override instead of seeing a "saved" confirmation
 // while the behavior stays unchanged.
 func (m *model) notifySelfLearnOverride(msg input.ConfigSavedMsg) {
-	if m.services.Setting == nil {
-		return
-	}
 	snap := m.services.Setting.Snapshot()
 	if snap == nil {
 		return

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -113,10 +113,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Refresh the in-memory settings handle so re-opening /config (and any
 		// in-session reader) sees the just-saved values rather than the stale
 		// pre-save snapshot. The panel already persisted to disk.
-		if m.services.Setting != nil {
-			if err := m.services.Setting.Reload(m.env.CWD); err != nil {
-				log.Logger().Warn("reload settings after config save failed", zap.Error(err))
-			}
+		if err := m.services.Setting.Reload(m.env.CWD); err != nil {
+			log.Logger().Warn("reload settings after config save failed", zap.Error(err))
 		}
 		m.conv.AddNotice("Self-learning config saved (" + msg.Scope + ")")
 		m.notifySelfLearnOverride(msg)
@@ -124,17 +122,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// effect on the running session instead of silently waiting for
 		// the next agent restart. Wire only when the agent is already
 		// active; an inactive session will wire on the first user turn.
-		if m.services.Agent != nil && m.services.Agent.Active() {
+		if m.services.Agent.Active() {
 			m.wireSelfLearn(m.buildAgentParams(), "")
 		}
 		return m, nil
 	case input.ThemeSavedMsg:
 		// The panel already applied (kit.InitTheme) and persisted the theme;
 		// refresh the in-memory handle so re-opening /config reflects it.
-		if m.services.Setting != nil {
-			if err := m.services.Setting.Reload(m.env.CWD); err != nil {
-				log.Logger().Warn("reload settings after theme save failed", zap.Error(err))
-			}
+		if err := m.services.Setting.Reload(m.env.CWD); err != nil {
+			log.Logger().Warn("reload settings after theme save failed", zap.Error(err))
 		}
 		m.conv.AddNotice("Theme set to " + msg.Theme)
 		return m, nil
@@ -143,9 +139,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// <system-reminder>, which is only refreshed at SessionStart and
 		// PostCompact. Without this nudge the LLM sees stale state until
 		// one of those fires.
-		if m.services.Reminder != nil {
-			m.services.Reminder.RequeueSystemReminders()
-		}
+		m.services.Reminder.RequeueSystemReminders()
 		return m, nil
 	case input.AgentToggleMsg:
 		// Why stop on toggle: the agents directory lives in the Agent tool's
@@ -155,7 +149,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// orphan in-flight tool calls and the partial assistant turn —
 		// leave the toggle pending; ensureAgentSession will see the updated
 		// store the next time it actually rebuilds.
-		if m.services.Agent != nil && m.services.Agent.Active() && !m.conv.Stream.Active {
+		if m.services.Agent.Active() && !m.conv.Stream.Active {
 			m.services.Agent.Stop()
 		}
 		return m, nil

--- a/internal/app/update_approval.go
+++ b/internal/app/update_approval.go
@@ -12,7 +12,6 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
-	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/mcp"
 	"github.com/genai-io/san/internal/session/transcript"
 	"github.com/genai-io/san/internal/setting"
@@ -20,14 +19,10 @@ import (
 )
 
 func (m *model) approvalDeps() input.ApprovalFlowDeps {
-	var hookEngine *hook.Engine
-	if m.services.Hook != nil {
-		hookEngine = m.services.Hook
-	}
 	return input.ApprovalFlowDeps{
 		Actions:            m,
 		Input:              &m.userInput,
-		HookEngine:         hookEngine,
+		HookEngine:         m.services.Hook,
 		Settings:           m.services.Setting.Snapshot(),
 		SessionPermissions: m.env.SessionPermissions,
 		SetOperationMode:   func(mode setting.OperationMode) { m.env.OperationMode = mode },

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -29,11 +29,9 @@ func (m *model) handleStreamCancel() tea.Cmd {
 	// any marker of its own, and the conv layer does not need to push
 	// state back into the agent.
 	m.services.Agent.InterruptTurn()
-	if m.services.Reminder != nil {
-		// EnqueueOnce so mashed Esc keys don't attach N identical
-		// <system-reminder> blocks to the next user message.
-		m.services.Reminder.EnqueueOnce(InterruptReminder)
-	}
+	// EnqueueOnce so mashed Esc keys don't attach N identical
+	// <system-reminder> blocks to the next user message.
+	m.services.Reminder.EnqueueOnce(InterruptReminder)
 	m.conv.Stream.Stop()
 	m.conv.ProgressHub.DrainPendingQuestions()
 	m.conv.Modal.Question.Hide()

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -10,13 +10,11 @@ import (
 )
 
 func (m *model) cycleOperationMode() {
-	allowBypass := m.services.Setting != nil && m.services.Setting.AllowBypass()
+	allowBypass := m.services.Setting.AllowBypass()
 	m.env.OperationMode = m.env.OperationMode.NextWithBypass(allowBypass)
 	m.env.ApplyModePermissions(m.env.CWD)
 
-	if m.services.Hook != nil {
-		m.services.Hook.SetPermissionMode(m.env.OperationModeName())
-	}
+	m.services.Hook.SetPermissionMode(m.env.OperationModeName())
 }
 
 func (m *model) updateMode(msg tea.Msg) (tea.Cmd, bool) {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -235,10 +235,8 @@ func (m model) renderModeStatus() string {
 		modelName += " (" + thinkingEffort + ")"
 		showThinking = false
 	}
-	if m.services.Hook != nil {
-		if status := m.services.Hook.CurrentStatusMessage(); status != "" {
-			modelName = status
-		}
+	if status := m.services.Hook.CurrentStatusMessage(); status != "" {
+		modelName = status
 	}
 	return conv.RenderModeStatus(conv.OperationModeParams{
 		Mode:             m.env.OperationMode,
@@ -306,9 +304,6 @@ func (m model) messageRenderParams() conv.RenderContext {
 }
 
 func (m model) agentColors() map[string]string {
-	if m.services.Subagent == nil {
-		return nil
-	}
 	return buildAgentColors(m.services.Subagent.ListConfigs())
 }
 


### PR DESCRIPTION
`newServices()` populates every `services.*` singleton non-nil and nothing ever sets them nil, so the ~40 `m.services.X` nil-guards across the app layer were dead defensive code — and inconsistent, since the same services were already accessed bare elsewhere.

Removes them (net −133 lines across 15 files): inline guards collapse to bare calls, outer pointer guards drop while legitimate inner result-nil checks (`Snapshot`/`System`/`Get`) stay, and the 4× `hookEngine` copy-dance and doubled nil-checks are simplified.

- Kept: the genuinely nilable `SelfLearn` bundle guards (`Reviewer`/`Cancel`/`Live`, plus the `Indicator` render/tick hot-path).
- Behavior-preserving (every dropped guard term was always-true/false); `go build ./...`, `go vet`, `gofmt -l`, and full `go test ./...` all clean.