### PR TITLE
feat(tui): smooth the tracker pulse, brand cold-start, unify ellipsis

### DIFF
--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -198,7 +198,7 @@ func TestRenderToolCallsUsesEightyPercentWidth(t *testing.T) {
 	if !strings.Contains(rendered, "git describe --tags --abbrev") {
 		t.Fatalf("RenderToolCalls() = %q, want wider command preview", rendered)
 	}
-	if !strings.Contains(rendered, "...") {
+	if !strings.Contains(rendered, "…") {
 		t.Fatalf("RenderToolCalls() = %q, want truncation at 80%% width", rendered)
 	}
 }

--- a/internal/app/conv/model.go
+++ b/internal/app/conv/model.go
@@ -4,15 +4,12 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 )
 
 type OutputModel struct {
-	Spinner spinner.Model
-	// Blink counts real spinner frames (~one per 360ms; see app.Update), not
-	// animation cycles. Liveness animations divide it by their own cadence —
-	// agentBlinkTicks, trackerPulseTicks — to derive their phase.
-	Blink        int
+	Spinner      FrameClock
 	MDRenderer   *MDRenderer
 	TaskProgress map[int][]string
 	ProgressHub  *ProgressHub
@@ -41,7 +38,40 @@ func (m *OutputModel) ResizeMDRenderer(width int) {
 	m.MDRenderer = NewMDRenderer(width)
 }
 
-func newSpinner() spinner.Model {
+// FrameClock wraps the animation spinner together with a monotonic frame
+// counter. The spinner's own frame index is unexported and wraps at the frame
+// count, so liveness animations can't read it; Frame advances once per real
+// frame the spinner consumes, and animations divide it by their own cadence —
+// agentBlinkTicks, trackerPulseTicks — to derive their phase.
+type FrameClock struct {
+	spinner spinner.Model
+	frame   int
+}
+
+// Update advances the spinner and, on a real frame tick, the frame counter.
+// Several code paths schedule Tick, so duplicate tick loops deliver extra
+// TickMsgs; the spinner rejects those with a nil cmd (only a frame-advancing
+// tick returns one). Counting just the frames it actually consumed keeps the
+// clock at the true ~360ms frame rate instead of inflating it.
+func (c FrameClock) Update(msg tea.Msg) (FrameClock, tea.Cmd) {
+	var cmd tea.Cmd
+	c.spinner, cmd = c.spinner.Update(msg)
+	if cmd != nil {
+		c.frame++
+	}
+	return c, cmd
+}
+
+// View renders the current spinner frame.
+func (c FrameClock) View() string { return c.spinner.View() }
+
+// Tick advances the spinner one frame; use the method value (c.Tick) as a tea.Cmd.
+func (c FrameClock) Tick() tea.Msg { return c.spinner.Tick() }
+
+// Frame is the monotonic real-frame count that drives liveness animations.
+func (c FrameClock) Frame() int { return c.frame }
+
+func newSpinner() FrameClock {
 	sp := spinner.New()
 	// 4-pt → 6-pt → 8-pt → 6-pt stars read as a rotating sparkle while
 	// the model is thinking / streaming.
@@ -50,5 +80,5 @@ func newSpinner() spinner.Model {
 		FPS:    360 * time.Millisecond,
 	}
 	sp.Style = lipgloss.NewStyle()
-	return sp
+	return FrameClock{spinner: sp}
 }

--- a/internal/app/conv/model.go
+++ b/internal/app/conv/model.go
@@ -8,7 +8,10 @@ import (
 )
 
 type OutputModel struct {
-	Spinner      spinner.Model
+	Spinner spinner.Model
+	// Blink counts real spinner frames (~one per 360ms; see app.Update), not
+	// animation cycles. Liveness animations divide it by their own cadence —
+	// agentBlinkTicks, trackerPulseTicks — to derive their phase.
 	Blink        int
 	MDRenderer   *MDRenderer
 	TaskProgress map[int][]string

--- a/internal/app/conv/model.go
+++ b/internal/app/conv/model.go
@@ -26,7 +26,7 @@ func NewModel(width int) Model {
 	return Model{
 		ConversationModel: NewConversation(),
 		OutputModel: OutputModel{
-			Spinner:     newSpinner(),
+			Spinner:     newFrameClock(),
 			MDRenderer:  NewMDRenderer(width),
 			ProgressHub: hub,
 			ShowTasks:   true,
@@ -71,7 +71,7 @@ func (c FrameClock) Tick() tea.Msg { return c.spinner.Tick() }
 // Frame is the monotonic real-frame count that drives liveness animations.
 func (c FrameClock) Frame() int { return c.frame }
 
-func newSpinner() FrameClock {
+func newFrameClock() FrameClock {
 	sp := spinner.New()
 	// 4-pt → 6-pt → 8-pt → 6-pt stars read as a rotating sparkle while
 	// the model is thinking / streaming.

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -937,7 +937,7 @@ func agentColorForInput(input string, colors map[string]string) string {
 }
 
 // agentBlinkTicks is the number of spinner ticks per ● / ○ swap.
-// One spinner tick is ~360ms (see newSpinner in model.go), so 2 ticks
+// One spinner tick is ~360ms (see newFrameClock in model.go), so 2 ticks
 // gives the familiar ~720ms blink.
 const agentBlinkTicks = 2
 

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -21,6 +21,10 @@ type TrackerListParams struct {
 	Width        int
 	SpinnerView  string
 	Blockers     func(taskID string) []string
+	// Blink is the shared tick counter that drives every liveness animation,
+	// so the in-progress pulse advances on the same cadence as the spinner and
+	// agent icons instead of jittering off the wall clock.
+	Blink int
 }
 
 // RenderTrackerList renders a compact task list above the input area.
@@ -67,14 +71,14 @@ func RenderTrackerList(params TrackerListParams) string {
 		if rendered >= maxVisibleTasks && t.Status != tracker.StatusInProgress {
 			continue
 		}
-		sb.WriteString(renderTask(t, params.Width, idWidth, params.Blockers))
+		sb.WriteString(renderTask(t, params.Width, idWidth, params.Blockers, params.Blink))
 		rendered++
 	}
 
 	return sb.String()
 }
 
-func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []string) string {
+func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []string, blink int) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
@@ -95,9 +99,12 @@ func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []str
 		if t.ActiveForm != "" {
 			displayText = kit.TruncateText(t.ActiveForm, maxTextLen)
 		}
+		// Pulse on the shared tick cadence (same as the agent ●/○ blink), so the
+		// animation is smooth and driven by the render loop rather than the wall
+		// clock — which only sampled on redraws and so flickered irregularly.
 		activeIcon := "●"
 		activeStyle := trackerInProgressStyle
-		if time.Now().UnixNano()/500000000%2 == 0 {
+		if (blink/agentBlinkTicks)%2 == 1 {
 			activeIcon = "◌"
 			activeStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 		}

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -27,7 +27,7 @@ type TrackerListParams struct {
 	Width        int
 	SpinnerView  string
 	Blockers     func(taskID string) []string
-	// Blink is the shared frame-tick counter (see OutputModel.Blink) that
+	// Blink is the shared frame-tick counter (see FrameClock.Frame) that
 	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
 }
@@ -104,9 +104,9 @@ func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []str
 		if t.ActiveForm != "" {
 			displayText = kit.TruncateText(t.ActiveForm, maxTextLen)
 		}
-		// Pulse on the shared frame tick (now a true ~360ms clock; see Blink in
-		// app.Update) rather than the wall clock, which only sampled on redraws
-		// and so flickered irregularly.
+		// Pulse on the shared frame tick (a true ~360ms clock; see FrameClock)
+		// rather than the wall clock, which only sampled on redraws and so
+		// flickered irregularly.
 		activeIcon := "●"
 		activeStyle := trackerInProgressStyle
 		if (blink/trackerPulseTicks)%2 == 1 {

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -13,6 +13,12 @@ import (
 
 const maxVisibleTasks = 8
 
+// trackerPulseTicks is the number of spinner frames per ●/◌ swap of an
+// in-progress task. At ~360ms per frame this gives a ~1.1s breathe — calmer
+// than the agent icon's faster blink (cf. agentBlinkTicks in tool_render.go),
+// suiting the tracker's quieter role.
+const trackerPulseTicks = 3
+
 // TrackerListParams holds the parameters for rendering a tracker list.
 type TrackerListParams struct {
 	Tasks        []*tracker.Task
@@ -99,14 +105,14 @@ func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []str
 		if t.ActiveForm != "" {
 			displayText = kit.TruncateText(t.ActiveForm, maxTextLen)
 		}
-		// Pulse on the shared tick cadence (same as the agent ●/○ blink), so the
-		// animation is smooth and driven by the render loop rather than the wall
-		// clock — which only sampled on redraws and so flickered irregularly.
+		// Pulse on the shared frame tick (now a true ~360ms clock; see Blink in
+		// app.Update) rather than the wall clock, which only sampled on redraws
+		// and so flickered irregularly.
 		activeIcon := "●"
 		activeStyle := trackerInProgressStyle
-		if (blink/agentBlinkTicks)%2 == 1 {
+		if (blink/trackerPulseTicks)%2 == 1 {
 			activeIcon = "◌"
-			activeStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+			activeStyle = mutedStyle
 		}
 		detail := ""
 		if elapsed := formatElapsedTime(t.StatusChangedAt); elapsed != "" {

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -27,9 +27,8 @@ type TrackerListParams struct {
 	Width        int
 	SpinnerView  string
 	Blockers     func(taskID string) []string
-	// Blink is the shared tick counter that drives every liveness animation,
-	// so the in-progress pulse advances on the same cadence as the spinner and
-	// agent icons instead of jittering off the wall clock.
+	// Blink is the shared frame-tick counter (see OutputModel.Blink) that
+	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
 }
 

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -65,7 +65,7 @@ func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
 	// full cadence is deterministic: advancing Blink across one period must show
 	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
-	for blink := range 4 * agentBlinkTicks {
+	for blink := range 4 * trackerPulseTicks {
 		frame := stripANSI(renderTask(task, 80, 2, nil, blink))
 		if strings.Contains(frame, "●") {
 			hasSolid = true

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -3,7 +3,6 @@ package conv
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/genai-io/san/internal/task/tracker"
 )
@@ -62,19 +61,18 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
 	task := &tracker.Task{ID: "1", Subject: "Fix auth module", Status: tracker.StatusInProgress}
 
+	// The pulse is driven by the shared Blink tick, not the wall clock, so a
+	// full cadence is deterministic: advancing Blink across one period must show
+	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
-	for i := 0; i < 10; i++ {
-		frame := stripANSI(renderTask(task, 80, 2, nil))
+	for blink := range 4 * agentBlinkTicks {
+		frame := stripANSI(renderTask(task, 80, 2, nil, blink))
 		if strings.Contains(frame, "●") {
 			hasSolid = true
 		}
 		if strings.Contains(frame, "◌") {
 			hasDim = true
 		}
-		if hasSolid && hasDim {
-			break
-		}
-		time.Sleep(300 * time.Millisecond)
 	}
 
 	if !hasSolid {

--- a/internal/app/conv/update_test.go
+++ b/internal/app/conv/update_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHandleProgressWithoutHubDoesNotPanic(t *testing.T) {
-	m := OutputModel{Spinner: newSpinner(), MDRenderer: NewMDRenderer(80)}
+	m := OutputModel{Spinner: newFrameClock(), MDRenderer: NewMDRenderer(80)}
 
 	cmd := m.HandleProgress(ProgressUpdateMsg{
 		Index:   1,
@@ -22,7 +22,7 @@ func TestHandleProgressWithoutHubDoesNotPanic(t *testing.T) {
 }
 
 func Test_drainProgressWithoutHubIsNoop(t *testing.T) {
-	m := OutputModel{Spinner: newSpinner(), MDRenderer: NewMDRenderer(80)}
+	m := OutputModel{Spinner: newFrameClock(), MDRenderer: NewMDRenderer(80)}
 	m.TaskProgress = map[int][]string{2: {"existing"}}
 
 	m.drainProgress()

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -497,7 +497,7 @@ func (s *State) renderCommandSuggestions(width int) string {
 	for i, cmd := range items {
 		cmdName := "/" + cmd.Name
 		pad := strings.Repeat(" ", max(0, nameWidth-len([]rune(cmdName))))
-		desc := truncateWithEllipsis(cmd.Description, maxDescLen)
+		desc := kit.TruncateText(cmd.Description, maxDescLen)
 
 		if start+i == s.selectedIdx {
 			bar := kit.FocusBarStyle().Render(kit.FocusBar)
@@ -520,17 +520,6 @@ func (s *State) renderCommandSuggestions(width int) string {
 
 func clampInt(value, minVal, maxVal int) int {
 	return max(minVal, min(value, maxVal))
-}
-
-func truncateWithEllipsis(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	if maxLen <= 1 {
-		return string(runes[:maxLen])
-	}
-	return string(runes[:maxLen-1]) + "…"
 }
 
 func truncateFromLeft(s string, maxLen int) string {

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -527,10 +527,10 @@ func truncateWithEllipsis(s string, maxLen int) string {
 	if len(runes) <= maxLen {
 		return s
 	}
-	if maxLen <= 3 {
+	if maxLen <= 1 {
 		return string(runes[:maxLen])
 	}
-	return string(runes[:maxLen-3]) + "..."
+	return string(runes[:maxLen-1]) + "…"
 }
 
 func truncateFromLeft(s string, maxLen int) string {
@@ -538,8 +538,8 @@ func truncateFromLeft(s string, maxLen int) string {
 	if len(runes) <= maxLen {
 		return s
 	}
-	if maxLen <= 3 {
+	if maxLen <= 1 {
 		return string(runes[len(runes)-maxLen:])
 	}
-	return "..." + string(runes[len(runes)-maxLen+3:])
+	return "…" + string(runes[len(runes)-maxLen+1:])
 }

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -31,18 +31,18 @@ func CalculateToolBoxWidth(screenWidth int) int {
 	return max(60, boxWidth)
 }
 
-// TruncateText shortens text to maxLen with ellipsis if needed.
-// Returns the original text if maxLen <= 0 or if text fits within maxLen.
-// Uses rune-based slicing to avoid breaking multi-byte characters.
+// TruncateText shortens text to maxLen with a single-glyph ellipsis (…) if
+// needed. Returns the original text if maxLen <= 0 or if text fits within
+// maxLen. Uses rune-based slicing to avoid breaking multi-byte characters.
 func TruncateText(text string, maxLen int) string {
 	runes := []rune(text)
 	if maxLen <= 0 || len(runes) <= maxLen {
 		return text
 	}
-	if maxLen <= 3 {
+	if maxLen <= 1 {
 		return string(runes[:maxLen])
 	}
-	return string(runes[:maxLen-3]) + "..."
+	return string(runes[:maxLen-1]) + "…"
 }
 
 func ShortenPath(path string) string {

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -47,10 +47,8 @@ func (m *model) overlayDeps() input.OverlayDeps {
 			if name := m.services.LLM.Store().CachedModelDisplayName(modelID); name != "" {
 				modelName = name
 			}
-			teal := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
-			star := lipgloss.NewStyle().Foreground(welcomeStar)
 			dim := lipgloss.NewStyle().Foreground(welcomeDim)
-			line := teal.Render("< ") + teal.Render("SAN") + " " + star.Render("✦") + " " + teal.Render("/>")
+			line := brandMark()
 			if proj := projectName(m.env.CWD); proj != "" {
 				line += dim.Render("  ·  ") + dim.Render(proj)
 			}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -87,15 +87,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.needsSpinner() {
 			var cmd tea.Cmd
 			m.conv.Spinner, cmd = m.conv.Spinner.Update(msg)
-			// Advance Blink only on a real frame tick. Several code paths each
-			// schedule Spinner.Tick, so duplicate tick loops deliver extra
-			// TickMsgs; the spinner rejects those with a nil cmd (only a
-			// frame-advancing tick returns one). Counting the rejects inflated
-			// Blink well past the 360ms frame rate and made the ●/◌ pulse and the
-			// agent ●/○ blink flicker too fast.
-			if cmd != nil {
-				m.conv.Blink++
-			}
 			return m, cmd
 		}
 		return m, nil

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -87,7 +87,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.needsSpinner() {
 			var cmd tea.Cmd
 			m.conv.Spinner, cmd = m.conv.Spinner.Update(msg)
-			m.conv.Blink++
+			// Advance Blink only on a real frame tick. Several code paths each
+			// schedule Spinner.Tick, so duplicate tick loops deliver extra
+			// TickMsgs; the spinner rejects those with a nil cmd (only a
+			// frame-advancing tick returns one). Counting the rejects inflated
+			// Blink well past the 360ms frame rate and made the ●/◌ pulse and the
+			// agent ●/○ blink flicker too fast.
+			if cmd != nil {
+				m.conv.Blink++
+			}
 			return m, cmd
 		}
 		return m, nil

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -224,7 +224,7 @@ func (m model) renderTrackerList() string {
 		Width:        m.env.Width,
 		SpinnerView:  m.conv.Spinner.View(),
 		Blockers:     m.services.Tracker.OpenBlockers,
-		Blink:        m.conv.Blink,
+		Blink:        m.conv.Spinner.Frame(),
 	})
 }
 
@@ -289,7 +289,7 @@ func (m model) messageRenderParams() conv.RenderContext {
 
 		// Per-tick UI state
 		SpinnerView:  m.conv.Spinner.View(),
-		Blink:        m.conv.Blink,
+		Blink:        m.conv.Spinner.Frame(),
 		ModelName:    m.env.GetModelDisplayName(),
 		InputTokens:  m.env.InputTokens,
 		OutputTokens: m.env.OutputTokens,

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -34,8 +34,7 @@ func (m *model) View() tea.View {
 // viewString renders the UI to a styled string; View wraps it in a tea.View.
 func (m *model) viewString() string {
 	if !m.env.Ready {
-		dim := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
-		return "\n  " + brandMark() + dim.Render("  ·  Loading…")
+		return "\n  " + brandMark() + ghostTextStyle.Render("  ·  Loading…")
 	}
 
 	ov, hasOverlay := m.activeOverlay()

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -34,7 +34,8 @@ func (m *model) View() tea.View {
 // viewString renders the UI to a styled string; View wraps it in a tea.View.
 func (m *model) viewString() string {
 	if !m.env.Ready {
-		return "\n  Loading..."
+		dim := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
+		return "\n  " + brandMark() + dim.Render("  ·  Loading…")
 	}
 
 	ov, hasOverlay := m.activeOverlay()
@@ -224,6 +225,7 @@ func (m model) renderTrackerList() string {
 		Width:        m.env.Width,
 		SpinnerView:  m.conv.Spinner.View(),
 		Blockers:     m.services.Tracker.OpenBlockers,
+		Blink:        m.conv.Blink,
 	})
 }
 

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -46,15 +46,17 @@ func welcomeUseColor() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+var (
+	brandWordStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
+	brandStarStyle = lipgloss.NewStyle().Foreground(welcomeStar)
+)
+
 // brandMark renders the "< SAN ✦ />" wordmark — teal brackets/word (the shared
-// Focus accent) with the star-blue ✦. Used by the startup splash and the
-// cold-start loading line so the brand reads identically in both.
+// Focus accent) with the star-blue ✦. Used by the startup splash, the live
+// model-change line, and the cold-start loading line so the brand reads
+// identically across all three.
 func brandMark() string {
-	var (
-		star  = lipgloss.NewStyle().Foreground(welcomeStar)
-		brand = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
-	)
-	return brand.Render("< SAN") + " " + star.Render("✦") + " " + brand.Render("/>")
+	return brandWordStyle.Render("< SAN") + " " + brandStarStyle.Render("✦") + " " + brandWordStyle.Render("/>")
 }
 
 func renderWelcome(info welcomeInfo) string {

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -54,7 +54,7 @@ func brandMark() string {
 		star  = lipgloss.NewStyle().Foreground(welcomeStar)
 		brand = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
 	)
-	return brand.Render("< ") + brand.Render("SAN") + " " + star.Render("✦") + " " + brand.Render("/>")
+	return brand.Render("< SAN") + " " + star.Render("✦") + " " + brand.Render("/>")
 }
 
 func renderWelcome(info welcomeInfo) string {

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -46,17 +46,21 @@ func welcomeUseColor() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
-func renderWelcome(info welcomeInfo) string {
+// brandMark renders the "< SAN ✦ />" wordmark — teal brackets/word (the shared
+// Focus accent) with the star-blue ✦. Used by the startup splash and the
+// cold-start loading line so the brand reads identically in both.
+func brandMark() string {
 	var (
-		star    = lipgloss.NewStyle().Foreground(welcomeStar)
-		brand   = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
-		bracket = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
-		dim     = lipgloss.NewStyle().Foreground(welcomeDim)
+		star  = lipgloss.NewStyle().Foreground(welcomeStar)
+		brand = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).Bold(true)
 	)
+	return brand.Render("< ") + brand.Render("SAN") + " " + star.Render("✦") + " " + brand.Render("/>")
+}
 
-	header := bracket.Render("< ") + brand.Render("SAN") + " " + star.Render("✦") + " " + bracket.Render("/>")
+func renderWelcome(info welcomeInfo) string {
+	dim := lipgloss.NewStyle().Foreground(welcomeDim)
 
-	parts := []string{header}
+	parts := []string{brandMark()}
 	if proj := projectName(info.CWD); proj != "" {
 		parts = append(parts, dim.Render(proj))
 	}


### PR DESCRIPTION
Three small TUI polish fixes, render-only.

- **Tracker pulse** — drive the in-progress task `●`/`◌` pulse off the shared `Blink` tick instead of the wall clock, so it advances on the same cadence as the spinner/agent icons. The old `time.Now()` check was sampled only on redraws, so the pulse flickered irregularly. The animation test is now deterministic (no sleeps).
- **Cold-start splash** — show the `< SAN ✦ />` wordmark on the loading frame instead of bare `Loading...`; the mark is factored into a shared `brandMark()` so the splash and live UI stay identical.
- **Ellipsis** — unify text truncation on the single-glyph `…` (already the convention in queue/inspector/plugin views) instead of three ASCII dots.