### PR TITLE
refactor(llm): dispatch turn-cost via a provider registry, not an app switch

### DIFF
--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -16,9 +16,6 @@ import (
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
-	"github.com/genai-io/san/internal/llm/deepseek"
-	"github.com/genai-io/san/internal/llm/mimo"
-	"github.com/genai-io/san/internal/llm/minmax"
 	"github.com/genai-io/san/internal/log"
 )
 
@@ -48,37 +45,14 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 	m.env.TurnOutputTokens += resp.OutputTokens
 
 	if m.env.CurrentModel != nil {
-		switch m.env.CurrentModel.Provider {
-		case llm.MinMax:
-			cost, ok := minmax.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.InputTokens,
-				OutputTokens:             resp.OutputTokens,
-				CacheCreationInputTokens: resp.CacheCreationInputTokens,
-				CacheReadInputTokens:     resp.CacheReadInputTokens,
-			})
-			if ok {
-				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
-			}
-		case llm.DeepSeek:
-			cost, ok := deepseek.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.InputTokens,
-				OutputTokens:             resp.OutputTokens,
-				CacheCreationInputTokens: resp.CacheCreationInputTokens,
-				CacheReadInputTokens:     resp.CacheReadInputTokens,
-			})
-			if ok {
-				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
-			}
-		case llm.Mimo:
-			cost, ok := mimo.EstimateCost(m.env.CurrentModel.ModelID, llm.Usage{
-				InputTokens:              resp.InputTokens,
-				OutputTokens:             resp.OutputTokens,
-				CacheCreationInputTokens: resp.CacheCreationInputTokens,
-				CacheReadInputTokens:     resp.CacheReadInputTokens,
-			})
-			if ok {
-				m.env.ConversationCost = m.env.ConversationCost.Add(cost)
-			}
+		usage := llm.Usage{
+			InputTokens:              resp.InputTokens,
+			OutputTokens:             resp.OutputTokens,
+			CacheCreationInputTokens: resp.CacheCreationInputTokens,
+			CacheReadInputTokens:     resp.CacheReadInputTokens,
+		}
+		if cost, ok := llm.EstimateCost(m.env.CurrentModel.Provider, m.env.CurrentModel.ModelID, usage); ok {
+			m.env.ConversationCost = m.env.ConversationCost.Add(cost)
 		}
 	}
 }

--- a/internal/llm/cost.go
+++ b/internal/llm/cost.go
@@ -1,0 +1,39 @@
+package llm
+
+// CostEstimator computes the money cost of a single inference from its token
+// usage, returning (_, false) when the model's pricing is unknown. Each
+// provider package registers its own in init() via RegisterCostEstimator, so
+// callers price a turn through EstimateCost without importing provider
+// internals or switching on the provider name.
+type CostEstimator func(modelID string, usage Usage) (Money, bool)
+
+// RegisterCostEstimator registers a provider's cost estimator. Call once per
+// provider package, typically alongside Register() in init().
+func RegisterCostEstimator(provider Name, fn CostEstimator) {
+	globalRegistry.RegisterCostEstimator(provider, fn)
+}
+
+// RegisterCostEstimator registers a provider's cost estimator.
+func (r *Registry) RegisterCostEstimator(provider Name, fn CostEstimator) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.costEstimators[provider] = fn
+}
+
+// EstimateCost dispatches to the estimator registered for provider, or returns
+// (Money{}, false) when the provider has no registered pricing.
+func EstimateCost(provider Name, modelID string, usage Usage) (Money, bool) {
+	return globalRegistry.EstimateCost(provider, modelID, usage)
+}
+
+// EstimateCost dispatches to the estimator registered for provider, or returns
+// (Money{}, false) when the provider has no registered pricing.
+func (r *Registry) EstimateCost(provider Name, modelID string, usage Usage) (Money, bool) {
+	r.mu.RLock()
+	fn, ok := r.costEstimators[provider]
+	r.mu.RUnlock()
+	if !ok {
+		return Money{}, false
+	}
+	return fn(modelID, usage)
+}

--- a/internal/llm/cost_test.go
+++ b/internal/llm/cost_test.go
@@ -1,0 +1,29 @@
+package llm
+
+import "testing"
+
+func TestEstimateCostDispatchesToRegisteredProvider(t *testing.T) {
+	const fake Name = "test-cost-provider"
+	want := Money{Amount: 1.5, Currency: CurrencyUSD}
+	RegisterCostEstimator(fake, func(modelID string, usage Usage) (Money, bool) {
+		if modelID != "m1" {
+			t.Fatalf("modelID = %q, want m1", modelID)
+		}
+		if usage.InputTokens != 10 {
+			t.Fatalf("usage.InputTokens = %d, want 10", usage.InputTokens)
+		}
+		return want, true
+	})
+
+	got, ok := EstimateCost(fake, "m1", Usage{InputTokens: 10})
+	if !ok || got != want {
+		t.Fatalf("EstimateCost = (%+v, %v), want (%+v, true)", got, ok, want)
+	}
+}
+
+func TestEstimateCostUnknownProviderReturnsFalse(t *testing.T) {
+	cost, ok := EstimateCost("totally-unregistered-provider", "m", Usage{})
+	if ok || !cost.IsZero() {
+		t.Fatalf("EstimateCost(unknown) = (%+v, %v), want (zero, false)", cost, ok)
+	}
+}

--- a/internal/llm/deepseek/apikey.go
+++ b/internal/llm/deepseek/apikey.go
@@ -37,4 +37,5 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 func init() {
 	llm.RegisterProviderDisplay(llm.DeepSeek, llm.ProviderDisplay{Name: "DeepSeek", Order: 40})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
+	llm.RegisterCostEstimator(llm.DeepSeek, EstimateCost)
 }

--- a/internal/llm/mimo/apikey.go
+++ b/internal/llm/mimo/apikey.go
@@ -37,4 +37,5 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 func init() {
 	llm.RegisterProviderDisplay(llm.Mimo, llm.ProviderDisplay{Name: "Xiaomi MiMo", Order: 110})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
+	llm.RegisterCostEstimator(llm.Mimo, EstimateCost)
 }

--- a/internal/llm/minmax/apikey.go
+++ b/internal/llm/minmax/apikey.go
@@ -44,4 +44,5 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 func init() {
 	llm.RegisterProviderDisplay(llm.MinMax, llm.ProviderDisplay{Name: "MiniMax", Order: 60})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
+	llm.RegisterCostEstimator(llm.MinMax, EstimateCost)
 }

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -20,12 +20,14 @@ type Registry struct {
 	mu              sync.RWMutex
 	entries         map[string]registryEntry // key: "provider:authMethod"
 	providerDisplay map[Name]ProviderDisplay // provider-level UI presentation
+	costEstimators  map[Name]CostEstimator   // per-provider turn-cost pricing
 }
 
 // globalRegistry is the default registry instance
 var globalRegistry = &Registry{
 	entries:         make(map[string]registryEntry),
 	providerDisplay: make(map[Name]ProviderDisplay),
+	costEstimators:  make(map[Name]CostEstimator),
 }
 
 // Register registers a provider with its metadata and factory


### PR DESCRIPTION
`OnTokenUsage` hard-coded a 3-way switch (MinMax/DeepSeek/Mimo) that rebuilt an identical `llm.Usage` and called each provider package's `EstimateCost` — the only place the app layer reached into provider internals (`internal/llm/minmax`, `deepseek`, `mimo`).

Adds a `CostEstimator` registry to the `llm` package; each provider registers its `EstimateCost` in its existing `init()` alongside `Register()`. The app now prices a turn through `llm.EstimateCost(provider, modelID, usage)` — no provider-internal imports, no per-provider branching. Adding pricing for a new provider becomes a one-line registration in that provider's package instead of a new `case` in the app layer.

Behavior-preserving: only MinMax/DeepSeek/Mimo register (matching the prior switch); unpriced providers return `(_, false)` as before. Adds unit tests for dispatch + the unknown-provider path. `go build ./...`, `go vet`, `gofmt -l`, and full `go test ./...` all clean.