### PR TITLE
docs: tidy non-package docs — categorize loose files, add category indexes

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -7,8 +7,8 @@ subagents.
 
 This page is the system-level overview. For per-package design see
 [`packages/`](packages/). For dependency rules and package-layer assignments
-see [`reference/dependency-rules.md`](reference/dependency-rules.md) and
-[`reference/package-map.md`](reference/package-map.md).
+see [`reference/dependency-rules.md`](../reference/dependency-rules.md) and
+[`reference/package-map.md`](../reference/package-map.md).
 
 ## Primitives
 
@@ -19,7 +19,7 @@ see [`reference/dependency-rules.md`](reference/dependency-rules.md) and
    `internal/tool` and gated by `internal/setting` permissions.
 3. **Extensions** — skill, plugin, MCP server, hook, slash command, subagent.
    Four extension primitives; *plugin* is one *source* among many — see
-   [`concepts/extension-model.md`](concepts/extension-model.md).
+   [`concepts/extension-model.md`](extension-model.md).
 4. **Sessions** — transcript persistence, resume, fork, projection
    (`internal/session`). Replayable in the inspector
    (`internal/inspector`).
@@ -62,12 +62,12 @@ events that mutate the TUI model.
 
 The detailed walkthrough (sub-model conventions, runtime adapters, cmd
 chains, directory structure of `internal/app/`) lives in
-[`packages/ui.md`](packages/1-app/app.md). For the step-by-step trace from a
+[`packages/ui.md`](../packages/1-app/app.md). For the step-by-step trace from a
 keystroke (or cron fire, or hub event) through the agent and back to
-the terminal, see [`concepts/data-flow.md`](concepts/data-flow.md).
+the terminal, see [`concepts/data-flow.md`](data-flow.md).
 For how rendered output is composed (View() layout, Markdown pipeline,
 tool blocks, scrollback vs repaint zone), see
-[`concepts/rendering.md`](concepts/rendering.md).
+[`concepts/rendering.md`](rendering.md).
 
 ## Layer Model
 
@@ -86,8 +86,8 @@ cmd  →  app  →  feature  →  core  →  infrastructure
 | `infrastructure` | `internal/{log,secret,filecache,markdown,image}` |
 
 Full membership list and allowed-edge rules live in
-[`reference/dependency-rules.md`](reference/dependency-rules.md) and
-[`reference/package-map.md`](reference/package-map.md). Both files are the
+[`reference/dependency-rules.md`](../reference/dependency-rules.md) and
+[`reference/package-map.md`](../reference/package-map.md). Both files are the
 source of truth — update them together when a package moves or a new package
 is added.
 
@@ -109,8 +109,8 @@ flow, or extension behavior, update the corresponding document in the same
 pull request.
 
 - Adding or moving a top-level package: update
-  [`reference/package-map.md`](reference/package-map.md) and
-  [`reference/dependency-rules.md`](reference/dependency-rules.md).
+  [`reference/package-map.md`](../reference/package-map.md) and
+  [`reference/dependency-rules.md`](../reference/dependency-rules.md).
 - Changing a package's public interface: update
   [`packages/<name>.md`](packages/) Contract section.
 - Adding a new cross-cutting concept: write a

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,16 @@
+# Concepts
+
+Cross-cutting explanations — how the system works across multiple packages.
+For per-package internals see [`../packages/index.md`](../packages/index.md);
+for task how-tos see [`../guides/index.md`](../guides/index.md).
+
+| Page | What it explains |
+|---|---|
+| [`architecture`](architecture.md) | System overview: the five layers, runtime model, core primitives. |
+| [`data-flow`](data-flow.md) | The full input → agent → render path. (中文: `data-flow.zh.md`) |
+| [`rendering`](rendering.md) | How model output becomes terminal frames. (中文: `rendering.zh.md`) |
+| [`extension-model`](extension-model.md) | Skills, plugins, MCP, hooks, commands, subagents — how San is extended. |
+| [`harness-channels`](harness-channels.md) | Out-of-band channels (system-reminders, etc.) the harness uses. |
+| [`permission-model`](permission-model.md) | How tool-call permissions are decided and gated. |
+| [`compaction`](compaction.md) | Automatic and manual conversation compaction. |
+| [`persona`](persona.md) | Switchable system prompt + skills + config bundles. |

--- a/docs/design/decisions/0001-layered-package-architecture.md
+++ b/docs/design/decisions/0001-layered-package-architecture.md
@@ -115,7 +115,7 @@ Full road map in `notes/tech-debt.md`.
 
 ## References
 
-- [`docs/architecture.md`](../../architecture.md) — the new
+- [`docs/architecture.md`](../../concepts/architecture.md) — the new
   system-level overview.
 - [`docs/packages/TEMPLATE.md`](../../packages/TEMPLATE.md) — the
   binding template for new package pages.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -104,6 +104,6 @@ full schema.
 - [Writing a skill](writing-a-skill.md) — your first user extension.
 - [Writing a subagent](writing-a-subagent.md) — define a parallel agent.
 - [Writing a plugin](writing-a-plugin.md) — bundle skills + agents + commands.
-- [`docs/architecture.md`](../architecture.md) — how the system is built.
+- [`docs/architecture.md`](../concepts/architecture.md) — how the system is built.
 - [`reference/slash-commands.md`](../reference/slash-commands.md) —
   every `/command`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,14 @@
+# Guides
+
+Task-oriented how-tos. For conceptual background see
+[`../concepts/index.md`](../concepts/index.md); to look up a fact see
+[`../reference/index.md`](../reference/index.md).
+
+| Guide | Task |
+|---|---|
+| [`getting-started`](getting-started.md) | Install, build, and run San for the first time. |
+| [`inspector`](inspector.md) | Replay session transcripts with `san inspector`. |
+| [`explore-mode`](explore-mode.md) | Use the read-only Explore subagent for fan-out search. |
+| [`writing-a-skill`](writing-a-skill.md) | Author a Skill. |
+| [`writing-a-subagent`](writing-a-subagent.md) | Author a custom subagent. |
+| [`writing-a-plugin`](writing-a-plugin.md) | Bundle skills / agents / hooks / commands into a plugin. |

--- a/docs/guides/inspector.md
+++ b/docs/guides/inspector.md
@@ -148,7 +148,7 @@ directly for scripting:
 
 ## See Also
 
-- [Package design doc](packages/2-feature/inspector.md) — internals and contracts
-- [Session transcripts](packages/2-feature/session.md) — the JSONL format on disk
-- [Compaction](concepts/compaction.md) — how context window compaction
+- [Package design doc](../packages/2-feature/inspector.md) — internals and contracts
+- [Session transcripts](../packages/2-feature/session.md) — the JSONL format on disk
+- [Compaction](../concepts/compaction.md) — how context window compaction
   interacts with transcript replay

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,24 +8,23 @@ explanations here.
 
 - `../README.md` — product overview, installation, usage.
 - `../AGENTS.md` — short agent and contributor navigation guide.
-- `architecture.md` — system-level overview and primitives.
-- `packages/index.md` — per-package design pages.
-- `concepts/index.md` — cross-cutting concept pages.
-- `operations/development.md` — local development workflow.
+- `concepts/architecture.md` — system-level overview and primitives.
+- `packages/index.md` — per-package design pages (grouped by layer).
+- `concepts/index.md` · `guides/index.md` · `reference/index.md` ·
+  `operations/index.md` — each category's own index.
 
 ## By Reader Goal
 
-### Understand the system
-
-- `architecture.md` — primitives, runtime model, layer model.
-- `packages/` — one page per Go package; each has a Contract section with
-  the package's public Go interface.
-- `concepts/` — cross-cutting concepts that span multiple packages
-  (data flow, rendering, extension model, harness channels,
-  permission model).
+- `concepts/architecture.md` — primitives, runtime model, layer model.
+- `concepts/index.md` — cross-cutting concepts that span multiple packages
+  (data flow, rendering, extension model, harness channels, permission
+  model).
+- `packages/index.md` — one page per Go package, grouped by layer; each has
+  a Contract section with the package's public Go interface.
 
 ### Look up a fact
 
+- `reference/index.md` — full reference index. Common lookups:
 - `reference/slash-commands.md` — all slash commands.
 - `reference/configuration.md` — config files and field reference.
 - `reference/dependency-rules.md` — layer / import rules.
@@ -36,16 +35,10 @@ explanations here.
   `reference/cli-startup.md`, `reference/loop.md`,
   `reference/file-naming.md`, `reference/minmax-provider.md`.
 
-### Do something
-
-- `guides/explore-mode.md` — using the explore subagent.
-- `inspector.md` — session transcript viewer (`san inspector`).
-- `operations/development.md` — build / test / lint / format.
-- `operations/testing.md` — test strategy and local commands.
-- `operations/release.md` — release process.
-- `operations/troubleshooting.md` — common development issues.
-- `operations/benchmark.md` — reproduce the benchmark numbers.
-- `operations/footprint.md` — why the single small binary is so portable.
+- `guides/index.md` — task how-tos: getting started, the inspector, explore
+  mode, and writing skills / subagents / plugins.
+- `operations/index.md` — build, test, release, troubleshoot, benchmark, and
+  the small-footprint rationale.
 
 ### Know why a decision was made
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,12 @@
+# Operations
+
+Building, testing, releasing, and operating San.
+
+| Page | Topic |
+|---|---|
+| [`development`](development.md) | Local dev workflow: build / test / lint / format. |
+| [`testing`](testing.md) | Test strategy and local commands. |
+| [`release`](release.md) | Release process. |
+| [`troubleshooting`](troubleshooting.md) | Common development issues. |
+| [`benchmark`](benchmark.md) | Reproduce the performance benchmark numbers. |
+| [`footprint`](footprint.md) | Why the single binary stays small and portable. |

--- a/docs/packages/2-feature/inspector.md
+++ b/docs/packages/2-feature/inspector.md
@@ -79,6 +79,6 @@ internal/inspector/server_test.go    — HTTP routes, SSE dedup across
 ## See Also
 
 - Code: `internal/inspector/`, `internal/inspector/ui/`
-- User guide: [`docs/inspector.md`](../../inspector.md)
+- User guide: [`docs/inspector.md`](../../guides/inspector.md)
 - Source data: [`packages/session.md`](session.md) (`session/transcript`)
 - Layer: `feature`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,19 @@
+# Reference
+
+Look up a specific fact. For explanations see
+[`../concepts/index.md`](../concepts/index.md); for how-tos see
+[`../guides/index.md`](../guides/index.md).
+
+| Page | Looks up |
+|---|---|
+| [`slash-commands`](slash-commands.md) | Every slash command. |
+| [`configuration`](configuration.md) | Config files and every settings field. |
+| [`cli-startup`](cli-startup.md) | CLI entry flags and startup modes. |
+| [`dependency-rules`](dependency-rules.md) | Layer / import rules (enforced by `layercheck`). |
+| [`package-map`](package-map.md) | Package-to-layer assignment. |
+| [`token-limits`](token-limits.md) | Per-model token limits. |
+| [`cost-tracking`](cost-tracking.md) | How turn cost / tokens are tracked. |
+| [`loop`](loop.md) | The `/loop` scheduling command. |
+| [`file-naming`](file-naming.md) | Repo file-naming rules. |
+| [`claude-permission-compat`](claude-permission-compat.md) | Claude-Code-compatible permission rule syntax. |
+| [`minmax-provider`](minmax-provider.md) | MiniMax provider integration design. |


### PR DESCRIPTION
Follow-up to the package-docs reorg (#204): tidy the **rest** of `docs/`.

The docs were organized "by reader goal" in `index.md`, but the folder reality lagged — `architecture.md` and `inspector.md` sat loose at `docs/` root, and only `design/` and `packages/` had an `index.md` (the homepage even linked a non-existent `concepts/index.md`).

- **No loose root files:** `architecture.md` → `concepts/` (system explanation), `inspector.md` → `guides/` (tool how-to). `docs/` root is now just `index.md` + category folders.
- **Every category self-describing:** added `index.md` to `concepts/`, `guides/`, `operations/`, `reference/` (mirroring `packages/` and `design/`).
- Rewrote affected links and refreshed the homepage to point at the new paths + per-category indexes. Every relative `.md` link verified to resolve (the one pre-existing broken link, `guides/explore-mode.md → ./agents.md`, is untouched).

Left alone (separate scope): the inconsistent `Feature N:` H1 prefixes on some reference/guide pages.