### PR TITLE
docs: drop legacy "Feature N:" prefixes from doc titles

### DIFF
--- a/docs/guides/explore-mode.md
+++ b/docs/guides/explore-mode.md
@@ -1,4 +1,4 @@
-# Feature 22: Explore Mode
+# Explore Mode
 
 ## Overview
 
@@ -36,7 +36,7 @@ This feature exists to document the contract that was previously split across th
 
 ## Relationship To Other Features
 
-- [Feature 10](./agents.md) defines the generic agent system and custom agent format.
+- [Writing a Subagent](writing-a-subagent.md) covers the generic agent system and custom agent format.
 - `explore` is the investigative permission boundary used by subagents.
 
 ## Automated Tests

--- a/docs/reference/cli-startup.md
+++ b/docs/reference/cli-startup.md
@@ -1,4 +1,4 @@
-# Feature 1: CLI Entry & Startup Modes
+# CLI Entry & Startup Modes
 
 ## Overview
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,4 +1,4 @@
-# Feature 20: Configuration System
+# Configuration System
 
 ## Overview
 

--- a/docs/reference/cost-tracking.md
+++ b/docs/reference/cost-tracking.md
@@ -1,4 +1,4 @@
-# Feature 18: Cost / Token Tracking
+# Cost / Token Tracking
 
 ## Overview
 

--- a/docs/reference/loop.md
+++ b/docs/reference/loop.md
@@ -1,4 +1,4 @@
-# Feature 21: Loop Scheduling Command
+# Loop Scheduling Command
 
 ## Overview
 

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -1,4 +1,4 @@
-# Feature 4: Slash Commands (21 Commands)
+# Slash Commands
 
 ## Overview
 
@@ -34,7 +34,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 - Selector commands (`/model`, `/skills`, `/search`, etc.) open a scrollable picker overlay.
 - `/clear` immediately resets the visible conversation.
 - `/think` cycles through levels and updates the status bar indicator.
-- `/loop` has a dedicated feature document: see [Feature 21](./loop.md).
+- `/loop` has a dedicated reference page: see [Loop Scheduling Command](./loop.md).
 
 ## Automated Tests
 


### PR DESCRIPTION
Six pages carried inconsistent `Feature N:` heading prefixes (`Feature 1: CLI Entry…`, `Feature 4: Slash Commands`, `Feature 18/20/21/22…`) — leftover internal numbering that matches nothing readers see. Strips them to clean titles and updates the two body cross-refs (`[Feature 21](loop.md)`, `[Feature 10](agents.md)`) to real page names.

Bonus: the `Feature 10` ref pointed at a non-existent `./agents.md` — it now links to `writing-a-subagent.md`, **fixing the last broken link in docs/** (link check is now fully green).

8 line changes across 6 files; titles only, no content moves.