### PR TITLE
refactor(app): unify plugin-backed reload behind one source of truth

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -101,6 +101,51 @@ func initExtensions(cwd string) {
 	}
 }
 
+// discoverPlugins scans the working directory for plugins. Run on a cwd change
+// so the new project's plugins (and their command / agent / MCP / hook
+// contributions) replace the previous project's before reloadProjectServices
+// rebuilds the project's feature services.
+func discoverPlugins(cwd string) {
+	if err := plugin.Initialize(context.Background(), plugin.Options{CWD: cwd}); err != nil {
+		log.Logger().Warn("Failed to initialize plugin", zap.Error(err))
+	}
+}
+
+// reloadProjectServices rebuilds the feature singletons that depend on the
+// current project — its config dirs plus the active plugins' contributions —
+// and re-points the services struct at the fresh instances. Both halves live
+// here so the Initialize set and the Default()-regrab set cannot drift. The
+// six: settings, skills, commands, subagents, MCP servers, personas. Plugins
+// themselves are not rebuilt here — discoverPlugins does that on a cwd change,
+// and a plugin load (--plugin-dir or /plugin install) has already done it.
+func (m *model) reloadProjectServices(cwd string) {
+	setting.Initialize(setting.Options{CWD: cwd})
+	m.services.Setting = setting.Default()
+
+	skill.Initialize(skill.Options{CWD: cwd})
+	m.services.Skill = skill.Default()
+
+	command.Initialize(command.Options{
+		CWD:                cwd,
+		DynamicProviders:   []func() []command.Info{skillCommandInfos},
+		PluginCommandPaths: pluginCommandPaths,
+	})
+	m.services.Command = command.Default()
+
+	if err := subagent.Initialize(subagent.Options{CWD: cwd, PluginAgentPaths: pluginAgentPaths}); err != nil {
+		log.Logger().Warn("Failed to initialize subagent", zap.Error(err))
+	}
+	m.services.Subagent = subagent.Default()
+
+	if err := mcp.Initialize(mcp.Options{CWD: cwd, PluginServers: pluginMCPServers}); err != nil {
+		log.Logger().Warn("Failed to initialize mcp", zap.Error(err))
+	}
+	m.services.MCP = mcp.DefaultRegistry()
+
+	persona.Initialize(cwd)
+	m.services.Persona = persona.Default()
+}
+
 func pluginCommandPaths() []command.PluginCommandPath {
 	pPaths := plugin.GetPluginCommandPaths()
 	paths := make([]command.PluginCommandPath, len(pPaths))

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -206,7 +206,7 @@ func UpdatePlugin(deps OverlayDeps, state *PluginSelector, msg tea.Msg) (tea.Cmd
 	case PluginUninstallMsg:
 		uninstalled := state.HandleUninstall(msg.PluginName)
 		if uninstalled {
-			_ = deps.ReloadPluginState()
+			_ = deps.ReloadAfterPluginChange()
 		}
 		return nil, true
 
@@ -216,7 +216,7 @@ func UpdatePlugin(deps OverlayDeps, state *PluginSelector, msg tea.Msg) (tea.Cmd
 	case PluginInstallResultMsg:
 		state.HandleInstallResult(msg)
 		if msg.Success {
-			_ = deps.ReloadPluginState()
+			_ = deps.ReloadAfterPluginChange()
 		}
 		return nil, true
 

--- a/internal/app/input/runtime.go
+++ b/internal/app/input/runtime.go
@@ -22,7 +22,7 @@ type OverlayDeps struct {
 	ClearCachedInstructions func()
 	RefreshMemoryContext    func(cwd, reason string)
 	FireFileChanged         func(path, tool string)
-	ReloadPluginState       func() error
+	ReloadAfterPluginChange func() error
 	LoadSession             func(string) error
 	SetActivePersona        func(name string) error
 	OpenPersona             func(name string) tea.Cmd

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -72,7 +72,7 @@ type SlashCommandEnv struct {
 	SubmitToAgent           func(content string, images []core.Image) tea.Cmd
 	HandleSkillInvocation   func() tea.Cmd
 	StartExternalEditor     func(path string) tea.Cmd
-	ReloadPluginBackedState func() error
+	ReloadAfterPluginChange func() error
 	PersistSession          func() error
 	InitTaskStorage         func()
 	ReconfigureAgentTool    func()
@@ -415,7 +415,7 @@ func (c *SlashCommandController) handleReloadPluginsCommand(ctx context.Context,
 		return "", nil, fmt.Errorf("failed to reload plugin registry: %w", err)
 	}
 	_ = c.env.Plugin.LoadClaudePlugins(ctx)
-	if err := c.env.ReloadPluginBackedState(); err != nil {
+	if err := c.env.ReloadAfterPluginChange(); err != nil {
 		return "", nil, err
 	}
 	return "Reloaded plugins and refreshed plugin-backed skills, agents, MCP servers, and hooks.", nil, nil

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -1,5 +1,5 @@
 // Model lifecycle: construction (newModel/newBaseModel), startup-time
-// option application (--continue / --resume / --plugin-dir), plugin-backed
+// option application (--continue / --resume / --plugin-dir), plugin-change
 // state reload, memory-context priming, task lifecycle wiring, and
 // SessionEnd shutdown.
 package app
@@ -12,14 +12,9 @@ import (
 	"github.com/genai-io/san/internal/app/hub"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/trigger"
-	"github.com/genai-io/san/internal/command"
 	"github.com/genai-io/san/internal/hook"
-	"github.com/genai-io/san/internal/mcp"
-	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/setting"
-	"github.com/genai-io/san/internal/skill"
-	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/task/tracker"
 )
@@ -78,7 +73,7 @@ func (m *model) applyRunOptions(opts setting.RunOptions) error {
 		if err := m.services.Plugin.LoadFromPath(ctx, opts.PluginDir); err != nil {
 			return fmt.Errorf("failed to load plugins from %s: %w", opts.PluginDir, err)
 		}
-		if err := m.ReloadPluginBackedState(); err != nil {
+		if err := m.ReloadAfterPluginChange(); err != nil {
 			return err
 		}
 	}
@@ -111,19 +106,15 @@ func (m *model) applyRunOptions(opts setting.RunOptions) error {
 	return nil
 }
 
-func (m *model) ReloadPluginBackedState() error {
-	skill.Initialize(skill.Options{CWD: m.env.CWD})
-	command.Initialize(command.Options{
-		CWD:                m.env.CWD,
-		DynamicProviders:   []func() []command.Info{skillCommandInfos},
-		PluginCommandPaths: pluginCommandPaths,
-	})
-	subagent.Initialize(subagent.Options{CWD: m.env.CWD, PluginAgentPaths: pluginAgentPaths})
-	mcp.Initialize(mcp.Options{CWD: m.env.CWD, PluginServers: pluginMCPServers})
-	setting.Initialize(setting.Options{CWD: m.env.CWD})
-	persona.Initialize(m.env.CWD)
-
-	m.services.refreshAfterReload()
+// ReloadAfterPluginChange rebuilds the state that plugins contribute to after
+// the active plugin set changes — a --plugin-dir load at startup, or a /plugin
+// install / uninstall mid-session. It reloads the project's feature services,
+// re-merges plugin hooks, and re-wires the agent tool, persona, and reminders
+// so the running session reflects the new set.
+func (m *model) ReloadAfterPluginChange() error {
+	// Plugins were just loaded by the caller; rebuild the project's feature
+	// services (not the plugins themselves) and re-point at them.
+	m.reloadProjectServices(m.env.CWD)
 
 	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -67,7 +67,7 @@ func (m *model) overlayDeps() input.OverlayDeps {
 		ClearCachedInstructions: m.env.ClearCachedInstructions,
 		RefreshMemoryContext:    m.refreshMemoryContext,
 		FireFileChanged:         m.fireFileChanged,
-		ReloadPluginState:       m.ReloadPluginBackedState,
+		ReloadAfterPluginChange: m.ReloadAfterPluginChange,
 		LoadSession:             m.loadSessionByID,
 		SetActivePersona:        m.setActivePersona,
 		OpenPersona:             m.openPersona,

--- a/internal/app/model_workspace.go
+++ b/internal/app/model_workspace.go
@@ -9,7 +9,6 @@ import (
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/persona"
 	"github.com/genai-io/san/internal/plugin"
-	"github.com/genai-io/san/internal/setting"
 )
 
 func (m *model) changeCwd(newCwd string) {
@@ -36,9 +35,10 @@ func (m *model) fireFileChanged(filePath, source string) {
 }
 
 func (m *model) ReloadProjectContext(cwd string) {
-	initExtensions(cwd)
-	setting.Initialize(setting.Options{CWD: cwd})
-	m.services.refreshAfterReload()
+	// cwd changed: discover the new project's plugins, then rebuild the project
+	// feature services that depend on them and re-point at them.
+	discoverPlugins(cwd)
+	m.reloadProjectServices(cwd)
 	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -98,16 +98,3 @@ func newServices() services {
 		SelfLearn: SelfLearnServices{Indicator: NewSelfLearnIndicator()},
 	}
 }
-
-// refreshAfterReload re-snapshots the 5 services whose singletons are replaced
-// by Initialize() calls in ReloadPluginBackedState. The remaining services
-// (LLM, Hook, Session, Tool, Task, Tracker, Cron, Plugin)
-// are stable — their singletons are created once at startup and never replaced.
-func (s *services) refreshAfterReload() {
-	s.Setting = setting.Default()
-	s.Skill = skill.Default()
-	s.Command = command.Default()
-	s.Subagent = subagent.Default()
-	s.MCP = mcp.DefaultRegistry()
-	s.Persona = persona.Default()
-}

--- a/internal/app/update_command.go
+++ b/internal/app/update_command.go
@@ -43,7 +43,7 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 		SubmitToAgent:           m.SubmitToAgent,
 		HandleSkillInvocation:   m.HandleSkillInvocation,
 		StartExternalEditor:     m.StartExternalEditor,
-		ReloadPluginBackedState: m.ReloadPluginBackedState,
+		ReloadAfterPluginChange: m.ReloadAfterPluginChange,
 		PersistSession:          m.PersistSession,
 		InitTaskStorage:         m.InitTaskStorage,
 		ReconfigureAgentTool:    m.ReconfigureAgentTool,

--- a/internal/selflearn/skill.go
+++ b/internal/selflearn/skill.go
@@ -118,7 +118,7 @@ func (i SkillInfo) Editable() bool { return i.Origin == agentOrigin }
 //
 // Why the disk scan instead of consulting skill.Registry: the registry is
 // initialized once at startup and only refreshed on
-// ReloadPluginBackedState. The L1 reviewer mutates ~/.san/skills and
+// ReloadAfterPluginChange. The L1 reviewer mutates ~/.san/skills and
 // ./.san/skills mid-session via skill_manage; a registry-backed Inventory
 // would not see skills the reviewer just created in earlier passes, which
 // would cause it to re-create duplicates. Reading the on-disk state


### PR DESCRIPTION
Two parallel lists declared the plugin-backed feature set and were hand-kept in sync — `ReloadPluginBackedState` re-`Initialize()`d 6 feature singletons, `refreshAfterReload` re-grabbed the same 6 via `Default()`. They'd already drifted (the comment said "**5** services"; the code did **6**).

**Single source of truth:** one `reloadProjectServices(cwd)` co-locates each feature's `Initialize()` + `Default()`-regrab, so the two sets can't diverge. Plugin re-discovery (cwd-change only) is a separate, explicit `discoverPlugins(cwd)` — call sites read for themselves, no boolean flag. `refreshAfterReload` is deleted.

**Naming (per review):**
- helper → `reloadProjectServices` (was the opaque `reinitPluginBackedServices`).
- `discoverPlugins` (not `rediscoverPlugins` — `discover` is scan-neutral).
- the reload entry point `ReloadPluginBackedState` fires on `--plugin-dir` **and** `/plugin install|uninstall`, so it's renamed to the trigger-accurate `ReloadAfterPluginChange`; its two inconsistent `input`-package callback fields (`ReloadPluginState` / `ReloadPluginBackedState`) are unified to match. Added a doc comment.

Behavior-preserving (init-order change is harmless — only command/subagent/mcp depend on plugins being initialized first, preserved). One intentional improvement: the reload path now logs subagent/mcp init failures (previously silent), matching `initExtensions`. `go build ./...`, `go vet`, `gofmt -l`, full `go test ./...` all clean.