### PR TITLE
refactor(app): unify provider resolution, move headless agent into app

### DIFF
--- a/cmd/san/agent.go
+++ b/cmd/san/agent.go
@@ -1,32 +1,18 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/spf13/cobra"
 
-	"github.com/genai-io/san/internal/llm"
-	"github.com/genai-io/san/internal/setting"
-	"github.com/genai-io/san/internal/subagent"
-	"github.com/genai-io/san/internal/tool"
+	"github.com/genai-io/san/internal/app"
 )
 
-var agentRunOpts struct {
-	agentType string
-	prompt    string
-	model     string
-	maxSteps  int
-}
+var agentRunOpts app.AgentRunOptions
 
 func init() {
-	agentRunCmd.Flags().StringVar(&agentRunOpts.agentType, "type", "", "Agent type to run")
-	agentRunCmd.Flags().StringVar(&agentRunOpts.prompt, "prompt", "", "Task prompt")
-	agentRunCmd.Flags().StringVar(&agentRunOpts.model, "model", "", "Model override")
-	agentRunCmd.Flags().IntVar(&agentRunOpts.maxSteps, "max-steps", 100, "Maximum LLM inference steps")
+	agentRunCmd.Flags().StringVar(&agentRunOpts.Type, "type", "", "Agent type to run")
+	agentRunCmd.Flags().StringVar(&agentRunOpts.Prompt, "prompt", "", "Task prompt")
+	agentRunCmd.Flags().StringVar(&agentRunOpts.Model, "model", "", "Model override")
+	agentRunCmd.Flags().IntVar(&agentRunOpts.MaxSteps, "max-steps", 100, "Maximum LLM inference steps")
 
 	agentCmd.AddCommand(agentRunCmd)
 	rootCmd.AddCommand(agentCmd)
@@ -45,98 +31,6 @@ var agentRunCmd = &cobra.Command{
 Example:
   san agent run --type Explore --prompt "find main.go"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if agentRunOpts.agentType == "" {
-			return fmt.Errorf("--type is required")
-		}
-		if agentRunOpts.prompt == "" {
-			return fmt.Errorf("--prompt is required")
-		}
-		return runHeadlessAgent()
+		return app.RunAgent(agentRunOpts)
 	},
-}
-
-// runHeadlessAgent executes an agent in headless mode (no TUI).
-func runHeadlessAgent() error {
-	cwd, _ := os.Getwd()
-
-	// Set up signal handling for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		fmt.Println("\nShutting down agent...")
-		cancel()
-	}()
-
-	// Initialize provider
-	store, _ := llm.NewStore()
-	if store == nil {
-		return fmt.Errorf("no provider store available")
-	}
-
-	currentModel := store.GetCurrentModel()
-	var llmProvider llm.Provider
-
-	if currentModel != nil {
-		p, err := llm.GetProvider(ctx, currentModel.Provider, currentModel.AuthMethod)
-		if err != nil {
-			return fmt.Errorf("failed to connect provider: %w", err)
-		}
-		llmProvider = p
-	}
-	if llmProvider == nil {
-		return fmt.Errorf("no provider available")
-	}
-
-	modelID := ""
-	if currentModel != nil {
-		modelID = currentModel.ModelID
-	}
-	if agentRunOpts.model != "" {
-		modelID = agentRunOpts.model
-	}
-
-	// Initialize agent registry — loads built-ins and any user/project AGENT.md.
-	if err := subagent.Initialize(subagent.Options{CWD: cwd}); err != nil {
-		return fmt.Errorf("failed to initialize agent registry: %w", err)
-	}
-	if _, ok := subagent.Default().Get(agentRunOpts.agentType); !ok {
-		return fmt.Errorf("unknown agent type: %s", agentRunOpts.agentType)
-	}
-
-	// Run through the full subagent pipeline so headless invocations get the
-	// same permission gate (deny_tools / bypass-immune / allow_tools / mode)
-	// as TUI-spawned subagents.
-	executor := subagent.NewExecutor(llmProvider, cwd, modelID, nil)
-	executor.SetContext(setting.IsGitRepo(cwd))
-
-	fmt.Printf("Agent: %s\n", agentRunOpts.agentType)
-	fmt.Printf("Prompt: %s\n", agentRunOpts.prompt)
-	fmt.Println("---")
-
-	req := tool.AgentExecRequest{
-		Agent:    agentRunOpts.agentType,
-		Prompt:   agentRunOpts.prompt,
-		Model:    agentRunOpts.model,
-		MaxSteps: agentRunOpts.maxSteps,
-		OnProgress: func(msg string) {
-			fmt.Fprintln(os.Stderr, "·", msg)
-		},
-	}
-	result, err := executor.Run(ctx, req)
-	if err != nil {
-		return fmt.Errorf("agent failed: %w", err)
-	}
-
-	if result.Content != "" {
-		fmt.Println(result.Content)
-	}
-
-	fmt.Printf("\n---\nDone: %d steps, %d tool uses (success=%t)\n", result.StepCount, result.ToolUses, result.Success)
-	if result.Error != "" {
-		fmt.Printf("Error: %s\n", result.Error)
-	}
-	return nil
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -139,36 +139,9 @@ func formatAsyncHookContinuationContext(result hook.AsyncHookResult, reason stri
 func runPrint(userMessage string) error {
 	ctx := context.Background()
 
-	store, err := llm.NewStore()
+	llmProvider, modelID, err := resolveProvider(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to load store: %w", err)
-	}
-
-	var llmProvider llm.Provider
-	var modelID string
-
-	current := store.GetCurrentModel()
-	if current != nil {
-		p, err := llm.GetProvider(ctx, current.Provider, current.AuthMethod)
-		if err != nil {
-			return fmt.Errorf("provider %s (%s) not available: %w. Run 'san' and use /model to connect",
-				current.Provider, current.AuthMethod, err)
-		}
-		llmProvider = p
-		modelID = current.ModelID
-	} else {
-		for providerName, conn := range store.GetConnections() {
-			p, err := llm.GetProvider(ctx, llm.Name(providerName), conn.AuthMethod)
-			if err == nil {
-				llmProvider = p
-				modelID = setting.DefaultModel(providerName, string(conn.AuthMethod))
-				break
-			}
-		}
-	}
-
-	if llmProvider == nil {
-		return fmt.Errorf("no provider connected. Run 'san' and use /model to connect")
+		return err
 	}
 
 	completionOpts := llm.CompletionOptions{
@@ -192,6 +165,27 @@ func runPrint(userMessage string) error {
 	}
 
 	return nil
+}
+
+// resolveProvider connects to the best available provider for a one-shot,
+// non-interactive run (print mode, headless agent) and returns it with a
+// concrete model id. It shares llm.ResolveProvider's resolution order with the
+// interactive startup path; when resolution falls back to a connection without
+// a saved current model, it fills that provider's default model id.
+func resolveProvider(ctx context.Context) (llm.Provider, string, error) {
+	store, err := llm.NewStore()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load store: %w", err)
+	}
+	resolved, ok := llm.ResolveProvider(ctx, store)
+	if !ok {
+		return nil, "", fmt.Errorf("no provider connected. Run 'san' and use /model to connect")
+	}
+	modelID := resolved.ModelID
+	if modelID == "" {
+		modelID = setting.DefaultModel(resolved.Provider.Name(), string(resolved.AuthMethod))
+	}
+	return resolved.Provider, modelID, nil
 }
 
 // validatePersona ensures the named persona exists on disk, early in startup,

--- a/internal/app/run_agent.go
+++ b/internal/app/run_agent.go
@@ -1,0 +1,97 @@
+// Headless agent entry point: san agent run. Runs a single subagent without the
+// TUI, sharing provider resolution (resolveProvider) with print mode and the
+// full subagent pipeline (permission gating, mode) with TUI-spawned agents.
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/genai-io/san/internal/setting"
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/tool"
+)
+
+// AgentRunOptions configures a one-shot headless agent run.
+type AgentRunOptions struct {
+	Type     string // agent type to run (required)
+	Prompt   string // task prompt (required)
+	Model    string // model override; empty uses the connected provider's model
+	MaxSteps int    // maximum LLM inference steps
+}
+
+// RunAgent executes a single agent in headless mode (no TUI).
+func RunAgent(opts AgentRunOptions) error {
+	if opts.Type == "" {
+		return fmt.Errorf("--type is required")
+	}
+	if opts.Prompt == "" {
+		return fmt.Errorf("--prompt is required")
+	}
+
+	// Graceful shutdown: SIGINT/SIGTERM cancels the run's context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		fmt.Println("\nShutting down agent...")
+		cancel()
+	}()
+
+	provider, modelID, err := resolveProvider(ctx)
+	if err != nil {
+		return err
+	}
+	if opts.Model != "" {
+		modelID = opts.Model
+	}
+
+	cwd, _ := os.Getwd()
+
+	// Initialize agent registry — loads built-ins and any user/project AGENT.md.
+	if err := subagent.Initialize(subagent.Options{CWD: cwd}); err != nil {
+		return fmt.Errorf("failed to initialize agent registry: %w", err)
+	}
+	if _, ok := subagent.Default().Get(opts.Type); !ok {
+		return fmt.Errorf("unknown agent type: %s", opts.Type)
+	}
+
+	// Run through the full subagent pipeline so headless invocations get the
+	// same permission gate (deny_tools / bypass-immune / allow_tools / mode)
+	// as TUI-spawned subagents.
+	executor := subagent.NewExecutor(provider, cwd, modelID, nil)
+	executor.SetContext(setting.IsGitRepo(cwd))
+
+	fmt.Printf("Agent: %s\n", opts.Type)
+	fmt.Printf("Prompt: %s\n", opts.Prompt)
+	fmt.Println("---")
+
+	req := tool.AgentExecRequest{
+		Agent:    opts.Type,
+		Prompt:   opts.Prompt,
+		Model:    opts.Model,
+		MaxSteps: opts.MaxSteps,
+		OnProgress: func(msg string) {
+			fmt.Fprintln(os.Stderr, "·", msg)
+		},
+	}
+	result, err := executor.Run(ctx, req)
+	if err != nil {
+		return fmt.Errorf("agent failed: %w", err)
+	}
+
+	if result.Content != "" {
+		fmt.Println(result.Content)
+	}
+
+	fmt.Printf("\n---\nDone: %d steps, %d tool uses (success=%t)\n", result.StepCount, result.ToolUses, result.Success)
+	if result.Error != "" {
+		fmt.Printf("Error: %s\n", result.Error)
+	}
+	return nil
+}

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -36,24 +36,43 @@ func Initialize(opts Options) {
 	defaultConn.mu.Lock()
 	defaultConn.store = store
 	defaultConn.currentModel = store.GetCurrentModel()
-	cm := defaultConn.currentModel
 	defaultConn.mu.Unlock()
 
-	ctx := context.Background()
+	if resolved, ok := ResolveProvider(context.Background(), store); ok {
+		defaultConn.SetProvider(resolved.Provider)
+	}
+}
 
-	if cm != nil {
+// ResolvedProvider is a connected provider plus the identity used to reach it.
+// ModelID carries the saved current model when one is set, and is empty when
+// resolution fell back to a connection without a saved model — in that case the
+// caller picks a model (see setting.DefaultModel).
+type ResolvedProvider struct {
+	Provider   Provider
+	ModelID    string
+	AuthMethod AuthMethod
+}
+
+// ResolveProvider connects to the best available provider recorded in the
+// store: the saved current model's provider first, then any other connected
+// provider. It reports ok=false when no provider can be connected. This is the
+// single resolution order shared by Initialize (interactive startup) and the
+// one-shot print / headless entry points, so they can never drift apart.
+func ResolveProvider(ctx context.Context, store *Store) (ResolvedProvider, bool) {
+	if store == nil {
+		return ResolvedProvider{}, false
+	}
+	if cm := store.GetCurrentModel(); cm != nil {
 		if p, err := GetProvider(ctx, cm.Provider, cm.AuthMethod); err == nil {
-			defaultConn.SetProvider(p)
-			return
+			return ResolvedProvider{Provider: p, ModelID: cm.ModelID, AuthMethod: cm.AuthMethod}, true
 		}
 	}
-
 	for providerName, conn := range store.GetConnections() {
 		if p, err := GetProvider(ctx, Name(providerName), conn.AuthMethod); err == nil {
-			defaultConn.SetProvider(p)
-			return
+			return ResolvedProvider{Provider: p, AuthMethod: conn.AuthMethod}, true
 		}
 	}
+	return ResolvedProvider{}, false
 }
 
 // Default returns the package-level *Conn.


### PR DESCRIPTION
Provider resolution from the store (current model first, then fall back to any connected provider) was implemented three times — `llm.Initialize`, `app.runPrint`, and cmd's `runHeadlessAgent` — and had drifted: the headless agent lacked the connection fallback, so `san agent run` failed when no current model was saved even with a provider connected.

- Add `llm.ResolveProvider` as the single resolution order; `Initialize` now uses it.
- `runPrint` and the headless runner share an `app.resolveProvider` helper.
- Move `runHeadlessAgent` into `internal/app` as `app.RunAgent`; `cmd/san/agent.go` is now flag parsing + delegation, no longer reaching into `llm`/`setting`/`subagent`/`tool`.

Note: print mode now falls back to another connected provider when the current model's provider fails to connect (matching the interactive path), instead of erroring out.