### PR TITLE
docs(cmd): fix `agent run` example to a real built-in agent type

### DIFF
--- a/cmd/san/agent.go
+++ b/cmd/san/agent.go
@@ -29,7 +29,7 @@ var agentRunCmd = &cobra.Command{
 	Long: `Run an agent in headless mode without TUI.
 
 Example:
-  san agent run --type Explore --prompt "find main.go"`,
+  san agent run --type general-purpose --prompt "find main.go"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return app.RunAgent(agentRunOpts)
 	},


### PR DESCRIPTION
The `san agent run` help text used `--type Explore`, which is not a built-in agent type — copy-pasting the example fails with `unknown agent type: Explore`. Switch it to `general-purpose`, one of the registered built-ins.

Follow-up to #210.