### PR TITLE
fix(skill): source plugin skills from the enabled-plugin registry

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -86,7 +86,7 @@ func initExtensions(cwd string) {
 	if err := plugin.Initialize(context.Background(), plugin.Options{CWD: cwd}); err != nil {
 		log.Logger().Warn("Failed to initialize plugin", zap.Error(err))
 	}
-	skill.Initialize(skill.Options{CWD: cwd})
+	skill.Initialize(skill.Options{CWD: cwd, PluginSkillPaths: pluginSkillPaths})
 	persona.Initialize(cwd)
 	command.Initialize(command.Options{
 		CWD:                cwd,
@@ -122,7 +122,7 @@ func (m *model) reloadProjectServices(cwd string) {
 	setting.Initialize(setting.Options{CWD: cwd})
 	m.services.Setting = setting.Default()
 
-	skill.Initialize(skill.Options{CWD: cwd})
+	skill.Initialize(skill.Options{CWD: cwd, PluginSkillPaths: pluginSkillPaths})
 	m.services.Skill = skill.Default()
 
 	command.Initialize(command.Options{
@@ -166,6 +166,19 @@ func pluginAgentPaths() []subagent.PluginAgentPath {
 		paths[i] = subagent.PluginAgentPath{
 			Path:      p.Path,
 			Namespace: p.Namespace,
+		}
+	}
+	return paths
+}
+
+func pluginSkillPaths() []skill.PluginSkillPath {
+	pPaths := plugin.GetPluginSkillPaths()
+	paths := make([]skill.PluginSkillPath, len(pPaths))
+	for i, p := range pPaths {
+		paths[i] = skill.PluginSkillPath{
+			Path:      p.Path,
+			Namespace: p.Namespace,
+			IsProject: p.Scope == plugin.ScopeProject || p.Scope == plugin.ScopeLocal,
 		}
 	}
 	return paths

--- a/internal/skill/loader.go
+++ b/internal/skill/loader.go
@@ -1,7 +1,6 @@
 package skill
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,22 +11,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// installedPluginsData represents the installed_plugins.json structure.
-type installedPluginsData struct {
-	Version int                        `json:"version"`
-	Plugins map[string][]pluginInstall `json:"plugins"`
-}
-
-// pluginInstall represents a single plugin installation.
-type pluginInstall struct {
-	Scope       string `json:"scope"`       // "user" or "project"
-	InstallPath string `json:"installPath"` // Full path to plugin
-	Version     string `json:"version"`
-}
-
 // Loader handles loading skills from multiple directories.
 type loader struct {
 	cwd string // Current working directory for project-level skills
+	// pluginSkillPaths, when set, supplies the skill directories contributed
+	// by enabled plugins (injected by the app from the plugin registry). nil
+	// in contexts that don't load plugin skills (e.g. persona, tests).
+	pluginSkillPaths func() []PluginSkillPath
 }
 
 // searchPath represents a skill search location with optional namespace.
@@ -45,9 +35,14 @@ func newLoader(cwd string) *loader {
 }
 
 // getSearchPaths returns skill directories in priority order (lowest to highest).
-// Note: .claude/plugins/ loading is removed - plugins are handled by the plugin system.
+// Plugin skills are injected by the app from the plugin registry (only enabled
+// plugins), keeping discovery consistent with commands and subagents instead of
+// re-parsing installed_plugins.json here.
 func (l *loader) getSearchPaths() []searchPath {
 	homeDir, _ := os.UserHomeDir()
+
+	userPlugins, projectPlugins := l.pluginPaths()
+
 	var paths []searchPath
 
 	// 1. ~/.claude/skills/ (Claude user compat - lowest priority)
@@ -56,11 +51,8 @@ func (l *loader) getSearchPaths() []searchPath {
 		scope: ScopeClaudeUser,
 	})
 
-	// 2. User plugins from ~/.san/plugins/installed_plugins.json
-	paths = append(paths, l.getPluginPaths(
-		filepath.Join(confdir.Dir(homeDir), "plugins"),
-		ScopeUserPlugin,
-	)...)
+	// 2. User-scope plugin skills
+	paths = append(paths, userPlugins...)
 
 	// 3. ~/.san/skills/ (User level)
 	paths = append(paths, searchPath{
@@ -74,11 +66,8 @@ func (l *loader) getSearchPaths() []searchPath {
 		scope: ScopeClaudeProject,
 	})
 
-	// 5. Project plugins from .san/plugins/installed_plugins.json
-	paths = append(paths, l.getPluginPaths(
-		filepath.Join(confdir.Dir(l.cwd), "plugins"),
-		ScopeProjectPlugin,
-	)...)
+	// 5. Project-scope plugin skills
+	paths = append(paths, projectPlugins...)
 
 	// 6. .san/skills/ (Project level - highest priority)
 	paths = append(paths, searchPath{
@@ -89,50 +78,21 @@ func (l *loader) getSearchPaths() []searchPath {
 	return paths
 }
 
-// getPluginPaths discovers plugin skill directories from installed_plugins.json.
-// Plugin skills inherit namespace from their plugin name (before @).
-func (l *loader) getPluginPaths(pluginsDir string, scope SkillScope) []searchPath {
-	var paths []searchPath
-
-	// Read installed_plugins.json
-	configPath := filepath.Join(pluginsDir, "installed_plugins.json")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return paths // File doesn't exist
+// pluginPaths splits the injected plugin skill directories into user- and
+// project-scope buckets. Each directory contains a SKILL.md and inherits the
+// plugin name as its default namespace. Returns nil/nil when no callback is set.
+func (l *loader) pluginPaths() (user, project []searchPath) {
+	if l.pluginSkillPaths == nil {
+		return nil, nil
 	}
-
-	var config installedPluginsData
-	if err := json.Unmarshal(data, &config); err != nil {
-		return paths // Invalid JSON
-	}
-
-	// Process each installed plugin
-	for pluginKey, installs := range config.Plugins {
-		if len(installs) == 0 {
-			continue
-		}
-
-		// Use the first (most recent) installation
-		install := installs[0]
-
-		// Extract plugin name from key (format: "plugin-name@marketplace")
-		pluginName := pluginKey
-		if idx := strings.Index(pluginKey, "@"); idx > 0 {
-			pluginName = pluginKey[:idx]
-		}
-
-		// Check if skills directory exists in the install path
-		skillsDir := filepath.Join(install.InstallPath, "skills")
-		if _, err := os.Stat(skillsDir); err == nil {
-			paths = append(paths, searchPath{
-				path:      skillsDir,
-				scope:     scope,
-				namespace: pluginName, // Plugin name becomes default namespace
-			})
+	for _, p := range l.pluginSkillPaths() {
+		if p.IsProject {
+			project = append(project, searchPath{path: p.Path, scope: ScopeProjectPlugin, namespace: p.Namespace})
+		} else {
+			user = append(user, searchPath{path: p.Path, scope: ScopeUserPlugin, namespace: p.Namespace})
 		}
 	}
-
-	return paths
+	return user, project
 }
 
 // loadAll loads all skills from all directories.

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -9,9 +9,17 @@
 // hold *Registry as an opaque handle and call its methods.
 package skill
 
+// PluginSkillPath describes a skill directory provided by a plugin.
+type PluginSkillPath struct {
+	Path      string
+	Namespace string
+	IsProject bool // true for project-scope, false for user-scope
+}
+
 // Options holds all dependencies for initialization.
 type Options struct {
-	CWD string
+	CWD              string
+	PluginSkillPaths func() []PluginSkillPath // injected plugin callback
 }
 
 // Initialize loads skills from all sources, applies persisted states,
@@ -19,6 +27,7 @@ type Options struct {
 func Initialize(opts Options) {
 	cwd := opts.CWD
 	loader := newLoader(cwd)
+	loader.pluginSkillPaths = opts.PluginSkillPaths
 
 	skills, _ := loader.loadAll()
 	userStore, _ := NewUserStore()

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,7 +1,6 @@
 package skill
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -284,17 +283,13 @@ func containsHelper(s, substr string) bool {
 }
 
 func TestLoadPluginSkills(t *testing.T) {
-	// Create temporary directories for plugin skills
 	tmpDir := t.TempDir()
 
-	// Create a plugin cache directory with skills
-	pluginCacheDir := filepath.Join(tmpDir, ".san", "plugins", "cache", "test-marketplace", "git", "1.0.0")
-	skillDir := filepath.Join(pluginCacheDir, "skills", "commit")
+	// A plugin contributes one skill directory containing a SKILL.md.
+	skillDir := filepath.Join(tmpDir, "git-plugin", "skills", "commit")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	skillPath := filepath.Join(skillDir, "SKILL.md")
 	skillContent := `---
 name: commit
 description: Create git commits
@@ -303,37 +298,17 @@ argument-hint: "[message]"
 
 Git commit instructions.
 `
-	if err := os.WriteFile(skillPath, []byte(skillContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create installed_plugins.json
-	pluginsDir := filepath.Join(tmpDir, ".san", "plugins")
-	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	installedPlugins := installedPluginsData{
-		Version: 2,
-		Plugins: map[string][]pluginInstall{
-			"git@test-marketplace": {
-				{
-					Scope:       "user",
-					InstallPath: pluginCacheDir,
-					Version:     "1.0.0",
-				},
-			},
-		},
-	}
-
-	configData, _ := json.MarshalIndent(installedPlugins, "", "  ")
-	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), configData, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create loader with the temp directory as project root
+	// The app injects enabled-plugin skill directories; here a project-scope
+	// plugin named "git" contributes the commit skill.
 	loader := &loader{
 		cwd: tmpDir,
+		pluginSkillPaths: func() []PluginSkillPath {
+			return []PluginSkillPath{{Path: skillDir, Namespace: "git", IsProject: true}}
+		},
 	}
 
 	skills, err := loader.loadAll()
@@ -362,17 +337,12 @@ Git commit instructions.
 }
 
 func TestPluginSkillExplicitNamespaceOverride(t *testing.T) {
-	// Create temporary directories for plugin skills
 	tmpDir := t.TempDir()
 
-	// Create a plugin cache directory with skills
-	pluginCacheDir := filepath.Join(tmpDir, ".san", "plugins", "cache", "test-marketplace", "my-plugin", "1.0.0")
-	skillDir := filepath.Join(pluginCacheDir, "skills", "review")
+	skillDir := filepath.Join(tmpDir, "my-plugin", "skills", "review")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	skillPath := filepath.Join(skillDir, "SKILL.md")
 	skillContent := `---
 name: review
 namespace: code
@@ -381,37 +351,17 @@ description: Code review skill
 
 Review instructions.
 `
-	if err := os.WriteFile(skillPath, []byte(skillContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create installed_plugins.json
-	pluginsDir := filepath.Join(tmpDir, ".san", "plugins")
-	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	installedPlugins := installedPluginsData{
-		Version: 2,
-		Plugins: map[string][]pluginInstall{
-			"my-plugin@test-marketplace": {
-				{
-					Scope:       "user",
-					InstallPath: pluginCacheDir,
-					Version:     "1.0.0",
-				},
-			},
-		},
-	}
-
-	configData, _ := json.MarshalIndent(installedPlugins, "", "  ")
-	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), configData, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create loader with the temp directory as project root
+	// Plugin "my-plugin" contributes the skill, but the skill's frontmatter
+	// declares an explicit namespace "code" that must win.
 	loader := &loader{
 		cwd: tmpDir,
+		pluginSkillPaths: func() []PluginSkillPath {
+			return []PluginSkillPath{{Path: skillDir, Namespace: "my-plugin", IsProject: true}}
+		},
 	}
 
 	skills, err := loader.loadAll()


### PR DESCRIPTION
`skill` discovered plugin skills by re-parsing `installed_plugins.json` itself — a 4th copy of that parser — and never consulted enabled/disabled state. So a **disabled plugin's skills kept loading**, while its commands, subagents, MCP servers, and hooks correctly disappeared.

Now `skill` sources plugin skill directories from `plugin.GetPluginSkillPaths()` via an injected `Options.PluginSkillPaths` callback — the same pattern `command` and `subagent` already use. Only enabled plugins contribute, and the duplicate `installed_plugins.json` parser (with its private `installedPluginsData`/`pluginInstall` structs) is deleted.

- Fixes disabled-plugin skills still loading.
- Removes the 4th copy of `installed_plugins.json` parsing; makes skill symmetric with command/subagent.
- Net −68 lines. Plugin-skill tests rewritten to inject paths (namespace inheritance, explicit-override, and scope coverage preserved).