### PR TITLE
refactor: disambiguate the Task/Tracker naming tangle

### DIFF
--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -168,7 +168,7 @@ routeKeypress → handleTextareaShortcut
    SubmitToAgent
         ├─ provider connected?    yes
         ├─ ensureAgentSession()    starts agent goroutine if needed
-        ├─ sendToAgent ───────────► agent.Task inbox channel
+        ├─ sendToAgent ───────────► agent.Session inbox channel
         │                           (a Go channel; non-blocking push)
         │
         └─ returns ContinueOutbox cmd  (see Path D)

--- a/docs/concepts/data-flow.zh.md
+++ b/docs/concepts/data-flow.zh.md
@@ -160,7 +160,7 @@ routeKeypress → handleTextareaShortcut
    SubmitToAgent
         ├─ provider 连上了吗？     是
         ├─ ensureAgentSession()    必要时启动 agent goroutine
-        ├─ sendToAgent ───────────► agent.Task 的 inbox channel
+        ├─ sendToAgent ───────────► agent.Session 的 inbox channel
         │                           （Go channel，非阻塞推入）
         │
         └─ 返回 ContinueOutbox cmd  （见 Path D）

--- a/docs/packages/2-feature/task.md
+++ b/docs/packages/2-feature/task.md
@@ -77,6 +77,6 @@ internal/task/hooks_test.go          — lifecycle hook emission.
 
 ## See Also
 
-- Code: `internal/task/`, `internal/task/tracker/`
+- Code: `internal/task/`, `internal/todo/`
 - Spawning surface: [`packages/tool.md`](tool.md) (Bash/Agent tools), [`packages/subagent.md`](subagent.md)
 - Layer: `feature`

--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -40,7 +40,7 @@ Agent, persistence, and orchestration:
 | `internal/session` | `feature` | Session metadata, transcript persistence, resume, projection, message conversion. |
 | `internal/session/transcript` | `feature` | Transcript records, filesystem store, projection, renderable views. |
 | `internal/task` | `feature` | Background task management, bash and agent task execution, output storage. |
-| `internal/task/tracker` | `feature` | Task tracker state and background tracker service. |
+| `internal/todo` | `feature` | Agent to-do list state and background tracker service (lifted from `task/tracker`). |
 | `internal/subagent` | `feature` | Subagent registry, loading, matching, execution, storage, progress tools. |
 | `internal/cron` | `feature` | Cron definitions, storage, service, loop. |
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,34 +1,34 @@
-// Package agent owns the foreground agent session lifecycle. *Task
+// Package agent owns the foreground agent session lifecycle. *Session
 // is the concrete handle; the package exposes it directly.
 package agent
 
 // Options holds dependencies for initialization.
 type Options struct{}
 
-// Initialize installs a fresh *Task as the package-level default.
+// Initialize installs a fresh *Session as the package-level default.
 func Initialize(opts Options) {
-	defaultTask = &Task{}
+	defaultSession = &Session{}
 }
 
-// Default returns the package-level *Task.
-func Default() *Task {
-	return defaultTask
+// Default returns the package-level *Session.
+func Default() *Session {
+	return defaultSession
 }
 
-// SetDefaultTask replaces the package-level *Task. Intended for
-// tests. A nil argument restores a fresh empty *Task.
-func SetDefaultTask(s *Task) {
+// SetDefaultSession replaces the package-level *Session. Intended for
+// tests. A nil argument restores a fresh empty *Session.
+func SetDefaultSession(s *Session) {
 	if s == nil {
-		defaultTask = &Task{}
+		defaultSession = &Session{}
 		return
 	}
-	defaultTask = s
+	defaultSession = s
 }
 
-// ResetDefaultTask restores a fresh empty *Task. Intended for
+// ResetDefaultSession restores a fresh empty *Session. Intended for
 // tests.
-func ResetDefaultTask() {
-	defaultTask = &Task{}
+func ResetDefaultSession() {
+	defaultSession = &Session{}
 }
 
-var defaultTask = &Task{}
+var defaultSession = &Session{}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -9,7 +9,7 @@ import (
 	"github.com/genai-io/san/internal/core"
 )
 
-type Task struct {
+type Session struct {
 	mu                 sync.RWMutex
 	agent              core.Agent
 	permBridge         *PermissionBridge
@@ -18,7 +18,7 @@ type Task struct {
 	pluginRoot         string // see SetPluginRoot
 }
 
-func (s *Task) Start(params BuildParams, messages []core.Message) error {
+func (s *Session) Start(params BuildParams, messages []core.Message) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -44,13 +44,13 @@ func (s *Task) Start(params BuildParams, messages []core.Message) error {
 	return nil
 }
 
-func (s *Task) Stop() {
+func (s *Session) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stopLocked()
 }
 
-func (s *Task) stopLocked() {
+func (s *Session) stopLocked() {
 	if s.agent == nil {
 		return
 	}
@@ -68,13 +68,13 @@ func (s *Task) stopLocked() {
 	s.pluginRoot = ""
 }
 
-func (s *Task) Active() bool {
+func (s *Session) Active() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.agent != nil
 }
 
-func (s *Task) Send(content string, images []core.Image) {
+func (s *Session) Send(content string, images []core.Image) {
 	s.mu.RLock()
 	ag := s.agent
 	s.mu.RUnlock()
@@ -90,7 +90,7 @@ func (s *Task) Send(content string, images []core.Image) {
 // and a compaction boundary and emits CompactEvent. Returns false when there is
 // no active agent to compact. Safe because the agent applies it at a phase
 // boundary on its own goroutine.
-func (s *Task) Compact(summary string) bool {
+func (s *Session) Compact(summary string) bool {
 	s.mu.RLock()
 	ag := s.agent
 	s.mu.RUnlock()
@@ -120,7 +120,7 @@ const interruptDrainTimeout = 250 * time.Millisecond
 // fresh one). The clear runs AFTER the agent quiesces so an in-flight
 // PermissionFunc can't repopulate pendingPermRequest via PollPermBridge
 // → SetPendingPermission between the clear and the cancel.
-func (s *Task) InterruptTurn() {
+func (s *Session) InterruptTurn() {
 	s.mu.RLock()
 	ag := s.agent
 	s.mu.RUnlock()
@@ -139,7 +139,7 @@ func (s *Task) InterruptTurn() {
 	s.mu.Unlock()
 }
 
-func (s *Task) Outbox() <-chan core.Event {
+func (s *Session) Outbox() <-chan core.Event {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {
@@ -148,25 +148,25 @@ func (s *Task) Outbox() <-chan core.Event {
 	return s.agent.Outbox()
 }
 
-func (s *Task) PermissionBridge() *PermissionBridge {
+func (s *Session) PermissionBridge() *PermissionBridge {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.permBridge
 }
 
-func (s *Task) PendingPermission() *PermBridgeRequest {
+func (s *Session) PendingPermission() *PermBridgeRequest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.pendingPermRequest
 }
 
-func (s *Task) SetPendingPermission(req *PermBridgeRequest) {
+func (s *Session) SetPendingPermission(req *PermBridgeRequest) {
 	s.mu.Lock()
 	s.pendingPermRequest = req
 	s.mu.Unlock()
 }
 
-func (s *Task) System() core.System {
+func (s *Session) System() core.System {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.agent == nil {
@@ -179,7 +179,7 @@ func (s *Task) System() core.System {
 // flow calls this when the user invokes a /plugin-skill so subprocesses
 // spawned during the turn see PLUGIN_ROOT pointing at that plugin.
 // Pass "" to clear (typically done at turn end).
-func (s *Task) SetPluginRoot(path string) {
+func (s *Session) SetPluginRoot(path string) {
 	s.mu.Lock()
 	s.pluginRoot = path
 	s.mu.Unlock()
@@ -187,7 +187,7 @@ func (s *Task) SetPluginRoot(path string) {
 
 // PluginRoot returns the plugin scope for the current turn, or "" if
 // no plugin scope is active.
-func (s *Task) PluginRoot() string {
+func (s *Session) PluginRoot() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.pluginRoot

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -1,4 +1,4 @@
-// Agent session lifecycle: building params, delegating to *agent.Task,
+// Agent session lifecycle: building params, delegating to *agent.Session,
 // and wrapping channels in tea.Cmds for the TUI.
 package app
 

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -8,7 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/genai-io/san/internal/app/kit"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 const maxVisibleTasks = 8
@@ -21,7 +21,7 @@ const trackerPulseTicks = 3
 
 // TrackerListParams holds the parameters for rendering a tracker list.
 type TrackerListParams struct {
-	Tasks        []*tracker.Task
+	Tasks        []*todo.Task
 	AllDone      bool
 	StreamActive bool
 	Width        int
@@ -58,11 +58,11 @@ func RenderTrackerList(params TrackerListParams) string {
 
 	idWidth := taskIDWidth(params.Tasks)
 
-	sorted := make([]*tracker.Task, 0, len(params.Tasks))
-	var active []*tracker.Task
-	var rest []*tracker.Task
+	sorted := make([]*todo.Task, 0, len(params.Tasks))
+	var active []*todo.Task
+	var rest []*todo.Task
 	for _, t := range params.Tasks {
-		if t.Status == tracker.StatusInProgress {
+		if t.Status == todo.StatusInProgress {
 			active = append(active, t)
 		} else {
 			rest = append(rest, t)
@@ -73,7 +73,7 @@ func RenderTrackerList(params TrackerListParams) string {
 
 	rendered := 0
 	for _, t := range sorted {
-		if rendered >= maxVisibleTasks && t.Status != tracker.StatusInProgress {
+		if rendered >= maxVisibleTasks && t.Status != todo.StatusInProgress {
 			continue
 		}
 		sb.WriteString(renderTask(t, params.Width, idWidth, params.Blockers, params.Blink))
@@ -83,7 +83,7 @@ func RenderTrackerList(params TrackerListParams) string {
 	return sb.String()
 }
 
-func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []string, blink int) string {
+func renderTask(t *todo.Task, width, idWidth int, blockers func(string) []string, blink int) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
@@ -92,14 +92,14 @@ func renderTask(t *tracker.Task, width, idWidth int, blockers func(string) []str
 	statusDetail := kit.MapString(t.Metadata, "background_status_detail")
 
 	switch t.Status {
-	case tracker.StatusCompleted:
+	case todo.StatusCompleted:
 		if statusDetail == "failed" || statusDetail == "killed" {
 			failedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
 			return renderTaskLine(indent, failedStyle.Render("!"), idTag, subject, mutedStyle.Render("["+statusDetail+"]"))
 		}
 		return renderTaskLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
 
-	case tracker.StatusInProgress:
+	case todo.StatusInProgress:
 		displayText := subject
 		if t.ActiveForm != "" {
 			displayText = kit.TruncateText(t.ActiveForm, maxTextLen)
@@ -150,16 +150,16 @@ type taskStatusCounts struct {
 	failed int
 }
 
-func countTaskStatuses(tasks []*tracker.Task) taskStatusCounts {
+func countTaskStatuses(tasks []*todo.Task) taskStatusCounts {
 	var counts taskStatusCounts
 	for _, t := range tasks {
 		statusDetail := kit.MapString(t.Metadata, "background_status_detail")
 		switch {
-		case t.Status == tracker.StatusCompleted && (statusDetail == "failed" || statusDetail == "killed"):
+		case t.Status == todo.StatusCompleted && (statusDetail == "failed" || statusDetail == "killed"):
 			counts.failed++
-		case t.Status == tracker.StatusCompleted:
+		case t.Status == todo.StatusCompleted:
 			counts.done++
-		case t.Status == tracker.StatusInProgress:
+		case t.Status == todo.StatusInProgress:
 			counts.active++
 		default:
 			counts.todo++
@@ -168,7 +168,7 @@ func countTaskStatuses(tasks []*tracker.Task) taskStatusCounts {
 	return counts
 }
 
-func taskIDWidth(tasks []*tracker.Task) int {
+func taskIDWidth(tasks []*todo.Task) int {
 	width := 2
 	for _, t := range tasks {
 		if n := len("#" + t.ID); n > width {

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -4,38 +4,38 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
-	tracker.Initialize(tracker.Options{})
-	t.Cleanup(func() { tracker.Default().Reset() })
+	todo.Initialize(todo.Options{})
+	t.Cleanup(func() { todo.Default().Reset() })
 
-	inProgress := tracker.Default().Create("Fix auth module", "", "", map[string]any{
+	inProgress := todo.Default().Create("Fix auth module", "", "", map[string]any{
 		"background_task_id":       "bg-1",
 		"background_status_detail": "running",
 	})
-	_ = tracker.Default().Update(inProgress.ID, tracker.WithStatus(tracker.StatusInProgress))
+	_ = todo.Default().Update(inProgress.ID, todo.WithStatus(todo.StatusInProgress))
 
-	failed := tracker.Default().Create("Fix payment module", "", "", map[string]any{
+	failed := todo.Default().Create("Fix payment module", "", "", map[string]any{
 		"background_task_id":       "bg-2",
 		"background_status_detail": "failed",
 	})
-	_ = tracker.Default().Update(failed.ID, tracker.WithStatus(tracker.StatusCompleted))
+	_ = todo.Default().Update(failed.ID, todo.WithStatus(todo.StatusCompleted))
 
-	completed := tracker.Default().Create("Ship feature", "", "", nil)
-	_ = tracker.Default().Update(completed.ID, tracker.WithStatus(tracker.StatusCompleted))
+	completed := todo.Default().Create("Ship feature", "", "", nil)
+	_ = todo.Default().Update(completed.ID, todo.WithStatus(todo.StatusCompleted))
 
-	pending := tracker.Default().Create("Write tests", "", "", nil)
-	_ = tracker.Default().Update(pending.ID, tracker.WithStatus(tracker.StatusPending))
+	pending := todo.Default().Create("Write tests", "", "", nil)
+	_ = todo.Default().Update(pending.ID, todo.WithStatus(todo.StatusPending))
 
 	view := RenderTrackerList(TrackerListParams{
-		Tasks:        tracker.Default().List(),
+		Tasks:        todo.Default().List(),
 		AllDone:      false,
 		StreamActive: true,
 		Width:        120,
 		SpinnerView:  "•",
-		Blockers:     tracker.Default().OpenBlockers,
+		Blockers:     todo.Default().OpenBlockers,
 	})
 	plain := stripANSI(view)
 
@@ -59,7 +59,7 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 }
 
 func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
-	task := &tracker.Task{ID: "1", Subject: "Fix auth module", Status: tracker.StatusInProgress}
+	task := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
 
 	// The pulse is driven by the shared Blink tick, not the wall clock, so a
 	// full cadence is deterministic: advancing Blink across one period must show

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -25,7 +25,7 @@ import (
 	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/fs"
 	_ "github.com/genai-io/san/internal/tool/registry"
@@ -47,7 +47,7 @@ func initInfrastructure() error {
 	tool.Initialize(tool.Options{})
 	agent.Initialize(agent.Options{})
 	task.Initialize(task.Options{})
-	tracker.Initialize(tracker.Options{})
+	todo.Initialize(todo.Options{})
 	cron.Initialize(cron.Options{
 		StoragePath: filepath.Join(confdir.Dir(appCwd), "scheduled_tasks.json"),
 	})

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -23,7 +23,7 @@ import (
 	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/skill"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -54,7 +54,7 @@ type SlashCommandEnv struct {
 	Skill   *skill.Registry
 	Plugin  *plugin.Registry
 	MCP     *mcp.Registry
-	Tracker tracker.Service
+	Tracker todo.Service
 	Cron    *cron.Scheduler
 	ToolSvc *tool.Registry
 	Command *command.Registry

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -16,7 +16,7 @@ import (
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/task"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func newModel(opts setting.RunOptions) (*model, error) {
@@ -190,7 +190,7 @@ func (m *model) wireTaskLifecycle(hookEngine hook.Handler) {
 		},
 		onCompleted: func(info task.TaskInfo) {
 			fireHook(hook.TaskCompleted, info)
-			tracker.CompleteWorker(trackerSvc, info)
+			todo.CompleteWorker(trackerSvc, info)
 
 			subject := hub.TaskSubject(info)
 			msg, ok := hub.TaskMessage(info, subject)

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
@@ -102,7 +102,7 @@ func TestOnAgentMessageIsNoOpForUserEcho(t *testing.T) {
 	m := &model{
 		userInput: input.Model{Queue: input.NewQueue()},
 		conv:      conv.NewModel(80),
-		services:  services{Tracker: tracker.NewStore()},
+		services:  services{Tracker: todo.NewStore()},
 	}
 
 	_ = m.OnAgentMessage(core.UserMessage("anything", nil))

--- a/internal/app/model_tool_effects.go
+++ b/internal/app/model_tool_effects.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -58,7 +58,7 @@ func (m *model) trackAgentLaunch(toolName string, resp map[string]any) {
 	if !ok {
 		return
 	}
-	launch := tracker.BackgroundTaskLaunch{
+	launch := todo.BackgroundTaskLaunch{
 		TaskID:      kit.MapString(bg, "taskId"),
 		AgentName:   kit.MapString(bg, "agentName"),
 		AgentType:   kit.MapString(bg, "agentType"),
@@ -67,7 +67,7 @@ func (m *model) trackAgentLaunch(toolName string, resp map[string]any) {
 	if launch.TaskID == "" {
 		return
 	}
-	tracker.TrackWorker(m.services.Tracker, launch)
+	todo.TrackWorker(m.services.Tracker, launch)
 }
 
 func (m *model) persistOverflow(result *core.ToolResult) {

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -35,7 +35,7 @@ type services struct {
 	Skill    *skill.Registry
 	Subagent *subagent.Registry
 	Command  *command.Registry
-	Task     *task.Tracker
+	Task     *task.Manager
 	Tracker  tracker.Service
 	Cron     *cron.Scheduler
 	MCP      *mcp.Registry

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -40,7 +40,7 @@ type services struct {
 	Cron     *cron.Scheduler
 	MCP      *mcp.Registry
 	Plugin   *plugin.Registry
-	Agent    *agent.Task
+	Agent    *agent.Session
 	Persona  *persona.Registry
 	Reminder *reminder.Service
 

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -19,7 +19,7 @@ import (
 	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -36,7 +36,7 @@ type services struct {
 	Subagent *subagent.Registry
 	Command  *command.Registry
 	Task     *task.Manager
-	Tracker  tracker.Service
+	Tracker  todo.Service
 	Cron     *cron.Scheduler
 	MCP      *mcp.Registry
 	Plugin   *plugin.Registry
@@ -88,7 +88,7 @@ func newServices() services {
 		Subagent:  subagent.Default(),
 		Command:   command.Default(),
 		Task:      task.Default(),
-		Tracker:   tracker.Default(),
+		Tracker:   todo.Default(),
 		Cron:      cron.Default(),
 		MCP:       mcp.DefaultRegistry(),
 		Plugin:    plugin.Default(),

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -12,7 +12,7 @@ import (
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/subagent"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 var ghostTextStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
@@ -322,7 +322,7 @@ func buildAgentColors(configs []*subagent.AgentConfig) map[string]string {
 	return colors
 }
 
-func buildTaskOwnerMap(tasks []*tracker.Task) map[string]string {
+func buildTaskOwnerMap(tasks []*todo.Task) map[string]string {
 	if len(tasks) == 0 {
 		return nil
 	}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/genai-io/san/internal/confdir"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/session/transcript"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 type Store struct {
@@ -32,7 +32,7 @@ type Store struct {
 type Snapshot struct {
 	Metadata SessionMetadata
 	Entries  []Entry
-	Tasks    []tracker.Task
+	Tasks    []todo.Task
 
 	// OmitMessageWrites skips the per-entry AppendMessage loop in Save. Used
 	// by the main TUI path where the agent's Recorder already persists every

--- a/internal/session/transcript/projector.go
+++ b/internal/session/transcript/projector.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func Project(records []Record) (*Transcript, error) {
@@ -145,7 +145,7 @@ func applyStatePatch(state *State, patch *StateRecord) error {
 			}
 			state.Mode = v
 		case PatchPathTasks:
-			var tasks []tracker.Task
+			var tasks []todo.Task
 			if err := json.Unmarshal(op.Value, &tasks); err != nil {
 				return fmt.Errorf("patch %s: %w", op.Path, err)
 			}

--- a/internal/session/transcript/projector_test.go
+++ b/internal/session/transcript/projector_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func TestProjectStartAndAppendMessages(t *testing.T) {
@@ -65,10 +65,10 @@ func TestProjectStatePatchLastWins(t *testing.T) {
 
 func TestProjectTasksAndWorktreePatches(t *testing.T) {
 	taskTime := time.Date(2026, 4, 6, 14, 10, 0, 0, time.UTC)
-	task := tracker.Task{
+	task := todo.Task{
 		ID:              "1",
 		Subject:         "Refactor",
-		Status:          tracker.StatusInProgress,
+		Status:          todo.StatusInProgress,
 		CreatedAt:       taskTime,
 		UpdatedAt:       taskTime,
 		StatusChangedAt: taskTime,
@@ -76,7 +76,7 @@ func TestProjectTasksAndWorktreePatches(t *testing.T) {
 	wt := &WorktreeState{OriginalCwd: "/repo", WorktreePath: "/repo/.wt/1", WorktreeName: "fix-1"}
 	transcript, err := Project([]Record{
 		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
-		{SessionID: "tx-1", Time: time.Now(), Type: SessionStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]tracker.Task{task}), PatchWorktree(wt)}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]todo.Task{task}), PatchWorktree(wt)}}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)

--- a/internal/session/transcript/store.go
+++ b/internal/session/transcript/store.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/log"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 type StartCommand struct {
@@ -115,7 +115,7 @@ func PatchTitle(title string) PatchOp       { return mustPatch(PatchPathTitle, t
 func PatchLastPrompt(prompt string) PatchOp { return mustPatch(PatchPathLastPrompt, prompt) }
 func PatchTag(tag string) PatchOp           { return mustPatch(PatchPathTag, tag) }
 func PatchMode(mode string) PatchOp         { return mustPatch(PatchPathMode, mode) }
-func PatchTasks(tasks []tracker.Task) PatchOp {
+func PatchTasks(tasks []todo.Task) PatchOp {
 	return mustPatch(PatchPathTasks, tasks)
 }
 func PatchWorktree(worktree *WorktreeState) PatchOp { return mustPatch(PatchPathWorktree, worktree) }

--- a/internal/session/transcript/store_test.go
+++ b/internal/session/transcript/store_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 	taskTime := time.Date(2026, 4, 6, 13, 0, 0, 0, time.UTC)
-	task := tracker.Task{
+	task := todo.Task{
 		ID:              "1",
 		Subject:         "Refactor",
-		Status:          tracker.StatusInProgress,
+		Status:          todo.StatusInProgress,
 		CreatedAt:       taskTime,
 		UpdatedAt:       taskTime,
 		StatusChangedAt: taskTime,
@@ -36,8 +36,8 @@ func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 		}
 	}
 
-	taskPatch := PatchTasks([]tracker.Task{task})
-	var decodedTasks []tracker.Task
+	taskPatch := PatchTasks([]todo.Task{task})
+	var decodedTasks []todo.Task
 	if err := json.Unmarshal(taskPatch.Value, &decodedTasks); err != nil {
 		t.Fatalf("Unmarshal(task patch): %v", err)
 	}

--- a/internal/session/transcript/types_test.go
+++ b/internal/session/transcript/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 func TestTranscriptTypesCarryProjectedState(t *testing.T) {
@@ -95,12 +95,12 @@ func TestMetadataAndTaskViewHelpers(t *testing.T) {
 	}
 
 	taskTime := now.Add(2 * time.Minute)
-	tasks := []tracker.Task{{
+	tasks := []todo.Task{{
 		ID:              "1",
 		Subject:         "Refactor",
 		Description:     "Move projection helpers",
 		ActiveForm:      "Refactoring",
-		Status:          tracker.StatusInProgress,
+		Status:          todo.StatusInProgress,
 		Owner:           "main",
 		Blocks:          []string{"2"},
 		BlockedBy:       []string{"3"},

--- a/internal/session/transcript/view.go
+++ b/internal/session/transcript/view.go
@@ -3,7 +3,7 @@ package transcript
 import (
 	"time"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
 type MetadataView struct {
@@ -53,10 +53,10 @@ func MetadataFromListItem(item ListItem, cwd string) MetadataView {
 	}
 }
 
-func TrackerTasksFromView(tasks []TrackerTaskView) []tracker.Task {
-	out := make([]tracker.Task, 0, len(tasks))
+func TrackerTasksFromView(tasks []TrackerTaskView) []todo.Task {
+	out := make([]todo.Task, 0, len(tasks))
 	for _, task := range tasks {
-		out = append(out, tracker.Task{
+		out = append(out, todo.Task{
 			ID:              task.ID,
 			Subject:         task.Subject,
 			Description:     task.Description,
@@ -73,7 +73,7 @@ func TrackerTasksFromView(tasks []TrackerTaskView) []tracker.Task {
 	return out
 }
 
-func TrackerTaskViewsFromTasks(tasks []tracker.Task) []TrackerTaskView {
+func TrackerTaskViewsFromTasks(tasks []todo.Task) []TrackerTaskView {
 	out := make([]TrackerTaskView, 0, len(tasks))
 	for _, task := range tasks {
 		out = append(out, TrackerTaskView{

--- a/internal/subagent/executor_prompt.go
+++ b/internal/subagent/executor_prompt.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/genai-io/san/internal/core/system"
 	"github.com/genai-io/san/internal/skill"
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -112,7 +112,7 @@ func formatTaskToolProgress(toolName string, params map[string]any) string {
 			return ""
 		}
 		subject := ""
-		if t, ok := tracker.Default().Get(taskID); ok {
+		if t, ok := todo.Default().Get(taskID); ok {
 			subject = t.Subject
 		}
 		if subject != "" {

--- a/internal/task/hooks_test.go
+++ b/internal/task/hooks_test.go
@@ -24,7 +24,7 @@ func TestTaskLifecycleHandler(t *testing.T) {
 	SetLifecycleHandler(observer)
 	defer SetLifecycleHandler(nil)
 
-	mgr := NewTracker()
+	mgr := NewManager()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -10,21 +10,21 @@ import (
 	"time"
 )
 
-// Tracker tracks background bash and subagent tasks.
-type Tracker struct {
+// Manager tracks background bash and subagent tasks.
+type Manager struct {
 	mu    sync.RWMutex
 	tasks map[string]BackgroundTask
 }
 
-// NewTracker creates a new *Tracker.
-func NewTracker() *Tracker {
-	return &Tracker{
+// NewManager creates a new *Manager.
+func NewManager() *Manager {
+	return &Manager{
 		tasks: make(map[string]BackgroundTask),
 	}
 }
 
 // CreateBashTask creates and registers a new bash task
-func (m *Tracker) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
+func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -38,7 +38,7 @@ func (m *Tracker) CreateBashTask(cmd *exec.Cmd, command, description string, ctx
 }
 
 // RegisterTask registers an existing task (used for agent tasks)
-func (m *Tracker) RegisterTask(task BackgroundTask) {
+func (m *Manager) RegisterTask(task BackgroundTask) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.tasks[task.GetID()] = task
@@ -55,7 +55,7 @@ func generateID() string {
 }
 
 // Get retrieves a task by ID
-func (m *Tracker) Get(id string) (BackgroundTask, bool) {
+func (m *Manager) Get(id string) (BackgroundTask, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	task, ok := m.tasks[id]
@@ -63,7 +63,7 @@ func (m *Tracker) Get(id string) (BackgroundTask, bool) {
 }
 
 // getBashTask retrieves a bash task by ID (for backward compatibility)
-func (m *Tracker) getBashTask(id string) (*BashTask, bool) {
+func (m *Manager) getBashTask(id string) (*BashTask, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	task, ok := m.tasks[id]
@@ -75,7 +75,7 @@ func (m *Tracker) getBashTask(id string) (*BashTask, bool) {
 }
 
 // List returns all tasks
-func (m *Tracker) List() []BackgroundTask {
+func (m *Manager) List() []BackgroundTask {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -87,7 +87,7 @@ func (m *Tracker) List() []BackgroundTask {
 }
 
 // ListRunning returns all running tasks
-func (m *Tracker) ListRunning() []BackgroundTask {
+func (m *Manager) ListRunning() []BackgroundTask {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -101,7 +101,7 @@ func (m *Tracker) ListRunning() []BackgroundTask {
 }
 
 // Kill terminates a task by ID
-func (m *Tracker) Kill(id string) error {
+func (m *Manager) Kill(id string) error {
 	m.mu.RLock()
 	task, ok := m.tasks[id]
 	m.mu.RUnlock()
@@ -141,14 +141,14 @@ func (m *Tracker) Kill(id string) error {
 }
 
 // Remove removes a completed task from the manager
-func (m *Tracker) Remove(id string) {
+func (m *Manager) Remove(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.tasks, id)
 }
 
 // cleanup removes all completed tasks older than maxAge
-func (m *Tracker) cleanup(maxAge time.Duration) {
+func (m *Manager) cleanup(maxAge time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestManager_CreateAndGet(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -32,7 +32,7 @@ func TestManager_CreateAndGet(t *testing.T) {
 }
 
 func TestManager_GetNotFound(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	_, ok := m.Get("nonexistent")
 	if ok {
@@ -41,7 +41,7 @@ func TestManager_GetNotFound(t *testing.T) {
 }
 
 func TestManager_List(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -60,7 +60,7 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_ListRunning(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -84,7 +84,7 @@ func TestManager_ListRunning(t *testing.T) {
 }
 
 func TestManager_Remove(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -104,7 +104,7 @@ func TestManager_Remove(t *testing.T) {
 }
 
 func TestManager_Cleanup(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -131,7 +131,7 @@ func TestManager_Cleanup(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRecent(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -152,7 +152,7 @@ func TestManager_CleanupKeepsRecent(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRunning(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -172,7 +172,7 @@ func TestManager_CleanupKeepsRunning(t *testing.T) {
 }
 
 func TestManager_GenerateUniqueIDs(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -192,7 +192,7 @@ func TestManager_GenerateUniqueIDs(t *testing.T) {
 }
 
 func TestManager_RegisterTask(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -214,7 +214,7 @@ func TestManager_RegisterTask(t *testing.T) {
 }
 
 func TestManager_GetBashTask(t *testing.T) {
-	m := NewTracker()
+	m := NewManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/task/service.go
+++ b/internal/task/service.go
@@ -1,6 +1,6 @@
 // Package task tracks background bash and subagent tasks for the TUI's
 // task panel and the agent's TaskOutput / TaskList tools. Exposes
-// *Tracker directly.
+// *Manager directly.
 package task
 
 // Options holds all dependencies for initialization.
@@ -8,39 +8,39 @@ type Options struct {
 	OutputDir string
 }
 
-// Initialize creates the package-level *Tracker and configures it.
+// Initialize creates the package-level *Manager and configures it.
 func Initialize(opts Options) {
-	m := NewTracker()
+	m := NewManager()
 	if opts.OutputDir != "" {
 		m.SetOutputDir(opts.OutputDir)
 	}
-	defaultTracker = m
+	defaultManager = m
 }
 
-// Default returns the package-level *Tracker.
-func Default() *Tracker {
-	return defaultTracker
+// Default returns the package-level *Manager.
+func Default() *Manager {
+	return defaultManager
 }
 
-// SetDefaultTracker replaces the package-level *Tracker. Intended for
-// tests. A nil argument restores a fresh empty *Tracker.
-func SetDefaultTracker(m *Tracker) {
+// SetDefaultTracker replaces the package-level *Manager. Intended for
+// tests. A nil argument restores a fresh empty *Manager.
+func SetDefaultTracker(m *Manager) {
 	if m == nil {
-		defaultTracker = NewTracker()
+		defaultManager = NewManager()
 		return
 	}
-	defaultTracker = m
+	defaultManager = m
 }
 
-// ResetDefaultTracker restores a fresh empty *Tracker. Intended for
+// ResetDefaultTracker restores a fresh empty *Manager. Intended for
 // tests.
 func ResetDefaultTracker() {
-	defaultTracker = NewTracker()
+	defaultManager = NewManager()
 }
 
-var defaultTracker = NewTracker()
+var defaultManager = NewManager()
 
-// SetOutputDir on *Tracker delegates to the package-level setOutputDir.
-func (m *Tracker) SetOutputDir(dir string) error {
+// SetOutputDir on *Manager delegates to the package-level setOutputDir.
+func (m *Manager) SetOutputDir(dir string) error {
 	return setOutputDir(dir)
 }

--- a/internal/todo/background.go
+++ b/internal/todo/background.go
@@ -1,4 +1,4 @@
-package tracker
+package todo
 
 import (
 	"strings"

--- a/internal/todo/background_test.go
+++ b/internal/todo/background_test.go
@@ -1,4 +1,4 @@
-package tracker
+package todo
 
 import (
 	"testing"

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1,4 +1,4 @@
-package tracker
+package todo
 
 import "sync"
 

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -1,4 +1,4 @@
-package tracker
+package todo
 
 import (
 	"encoding/json"

--- a/internal/tool/tasktools/tracker_tools_test.go
+++ b/internal/tool/tasktools/tracker_tools_test.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 )
 
-func useTestTrackerStore(t *testing.T) *tracker.Store {
+func useTestTrackerStore(t *testing.T) *todo.Store {
 	t.Helper()
-	store := tracker.NewStore()
+	store := todo.NewStore()
 	if err := store.SetStorageDir(t.TempDir()); err != nil {
 		t.Fatalf("SetStorageDir(): %v", err)
 	}
-	tracker.SetDefault(store)
-	t.Cleanup(func() { tracker.SetDefault(store) })
+	todo.SetDefault(store)
+	t.Cleanup(func() { todo.SetDefault(store) })
 	return store
 }
 
@@ -24,7 +24,7 @@ func TestTrackerGetTool_ShowsOwnerAndOpenBlockers(t *testing.T) {
 
 	blocker := store.Create("Blocker", "finish first", "blocking", nil)
 	blocked := store.Create("Blocked", "waits on blocker", "waiting", nil)
-	if err := store.Update(blocked.ID, tracker.WithOwner("Explore"), tracker.WithAddBlockedBy([]string{blocker.ID})); err != nil {
+	if err := store.Update(blocked.ID, todo.WithOwner("Explore"), todo.WithAddBlockedBy([]string{blocker.ID})); err != nil {
 		t.Fatalf("Update(blocked): %v", err)
 	}
 
@@ -51,7 +51,7 @@ func TestTrackerUpdateTool_ParsesJSONBlockedByAndPersistsFields(t *testing.T) {
 
 	result := (&TrackerUpdateTool{}).Execute(context.Background(), map[string]any{
 		"taskId":       task.ID,
-		"status":       tracker.StatusInProgress,
+		"status":       todo.StatusInProgress,
 		"owner":        "Plan",
 		"description":  "write more tests",
 		"addBlockedBy": `["` + blocker.ID + `"]`,
@@ -60,7 +60,7 @@ func TestTrackerUpdateTool_ParsesJSONBlockedByAndPersistsFields(t *testing.T) {
 	if !result.Success {
 		t.Fatalf("expected success, got error: %s", result.Error)
 	}
-	if result.Metadata.Subtitle != "#"+task.ID+" "+tracker.StatusInProgress {
+	if result.Metadata.Subtitle != "#"+task.ID+" "+todo.StatusInProgress {
 		t.Fatalf("unexpected subtitle %q", result.Metadata.Subtitle)
 	}
 
@@ -68,8 +68,8 @@ func TestTrackerUpdateTool_ParsesJSONBlockedByAndPersistsFields(t *testing.T) {
 	if !ok {
 		t.Fatal("expected updated task to exist")
 	}
-	if updated.Status != tracker.StatusInProgress {
-		t.Fatalf("status = %q, want %q", updated.Status, tracker.StatusInProgress)
+	if updated.Status != todo.StatusInProgress {
+		t.Fatalf("status = %q, want %q", updated.Status, todo.StatusInProgress)
 	}
 	if updated.Owner != "Plan" {
 		t.Fatalf("owner = %q, want %q", updated.Owner, "Plan")

--- a/internal/tool/tasktools/trackercreate.go
+++ b/internal/tool/tasktools/trackercreate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
@@ -30,11 +30,11 @@ func (t *TrackerCreateTool) Execute(ctx context.Context, params map[string]any, 
 	activeForm := tool.GetString(params, "activeForm")
 	metadata, _ := params["metadata"].(map[string]any)
 
-	task := tracker.Default().Create(subject, description, activeForm, metadata)
+	task := todo.Default().Create(subject, description, activeForm, metadata)
 
 	// Set dependencies if provided
 	if ids := parseStringSlice(params["addBlockedBy"]); len(ids) > 0 {
-		tracker.Default().Update(task.ID, tracker.WithAddBlockedBy(ids))
+		todo.Default().Update(task.ID, todo.WithAddBlockedBy(ids))
 	}
 
 	return toolresult.ToolResult{

--- a/internal/tool/tasktools/trackerget.go
+++ b/internal/tool/tasktools/trackerget.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
@@ -24,13 +24,13 @@ func (t *TrackerGetTool) Execute(ctx context.Context, params map[string]any, cwd
 	}
 
 	// Reload from disk to pick up changes from other processes
-	tracker.Default().ReloadFromDisk()
+	todo.Default().ReloadFromDisk()
 
-	task, ok := tracker.Default().Get(taskID)
+	task, ok := todo.Default().Get(taskID)
 	if !ok {
 		// Fallback: background agent tasks use hex IDs from the task manager,
 		// stored as "background_task_id" metadata in tracker entries.
-		task = tracker.Default().FindByMetadata("background_task_id", taskID)
+		task = todo.Default().FindByMetadata("background_task_id", taskID)
 		if task == nil {
 			return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("task %s not found", taskID))
 		}
@@ -51,7 +51,7 @@ func (t *TrackerGetTool) Execute(ctx context.Context, params map[string]any, cwd
 	if len(task.Blocks) > 0 {
 		fmt.Fprintf(&sb, "Blocks: %s\n", strings.Join(task.Blocks, ", "))
 	}
-	if openBlockers := tracker.Default().OpenBlockers(task.ID); len(openBlockers) > 0 {
+	if openBlockers := todo.Default().OpenBlockers(task.ID); len(openBlockers) > 0 {
 		fmt.Fprintf(&sb, "Blocked by (open): %s\n", strings.Join(openBlockers, ", "))
 	}
 

--- a/internal/tool/tasktools/trackerlist.go
+++ b/internal/tool/tasktools/trackerlist.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
@@ -19,9 +19,9 @@ func (t *TrackerListTool) Icon() string        { return "📋" }
 
 func (t *TrackerListTool) Execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
 	// Reload from disk to pick up changes from other processes
-	tracker.Default().ReloadFromDisk()
+	todo.Default().ReloadFromDisk()
 
-	tasks := tracker.Default().List()
+	tasks := todo.Default().List()
 
 	if len(tasks) == 0 {
 		return toolresult.ToolResult{
@@ -41,7 +41,7 @@ func (t *TrackerListTool) Execute(ctx context.Context, params map[string]any, cw
 	var sb strings.Builder
 	completed := 0
 	for _, task := range tasks {
-		if task.Status == tracker.StatusCompleted {
+		if task.Status == todo.StatusCompleted {
 			completed++
 		}
 		line := fmt.Sprintf("#%s [%s]", task.ID, task.Status)
@@ -65,14 +65,14 @@ func (t *TrackerListTool) Execute(ctx context.Context, params map[string]any, cw
 }
 
 // TaskIcon returns the status icon for a task.
-func TaskIcon(task *tracker.Task) string {
+func TaskIcon(task *todo.Task) string {
 	switch task.Status {
-	case tracker.StatusCompleted:
+	case todo.StatusCompleted:
 		return "✓"
-	case tracker.StatusInProgress:
+	case todo.StatusInProgress:
 		return "⠋"
 	default:
-		if tracker.Default().IsBlocked(task.ID) {
+		if todo.Default().IsBlocked(task.ID) {
 			return "▸"
 		}
 		return "☐"

--- a/internal/tool/tasktools/trackerupdate.go
+++ b/internal/tool/tasktools/trackerupdate.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/genai-io/san/internal/task/tracker"
+	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
@@ -24,8 +24,8 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 	}
 
 	// Handle deletion separately
-	if status := tool.GetString(params, "status"); status == tracker.StatusDeleted {
-		if err := tracker.Default().Delete(taskID); err != nil {
+	if status := tool.GetString(params, "status"); status == todo.StatusDeleted {
+		if err := todo.Default().Delete(taskID); err != nil {
 			return toolresult.NewErrorResult(t.Name(), err.Error())
 		}
 		return toolresult.ToolResult{
@@ -48,7 +48,7 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 		return toolresult.NewErrorResult(t.Name(), "no updates specified")
 	}
 
-	if err := tracker.Default().Update(taskID, opts...); err != nil {
+	if err := todo.Default().Update(taskID, opts...); err != nil {
 		return toolresult.NewErrorResult(t.Name(), err.Error())
 	}
 
@@ -69,14 +69,14 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 }
 
 // buildUpdateOptions extracts update options from params, returns options, status change, and error
-func buildUpdateOptions(params map[string]any) ([]tracker.UpdateOption, string, error) {
-	var opts []tracker.UpdateOption
+func buildUpdateOptions(params map[string]any) ([]todo.UpdateOption, string, error) {
+	var opts []todo.UpdateOption
 	var statusChange string
 
 	if status := tool.GetString(params, "status"); status != "" {
 		switch status {
-		case tracker.StatusPending, tracker.StatusInProgress, tracker.StatusCompleted:
-			opts = append(opts, tracker.WithStatus(status))
+		case todo.StatusPending, todo.StatusInProgress, todo.StatusCompleted:
+			opts = append(opts, todo.WithStatus(status))
 			statusChange = status
 		default:
 			return nil, "", fmt.Errorf("invalid status: %s (must be pending, in_progress, completed, or deleted)", status)
@@ -84,25 +84,25 @@ func buildUpdateOptions(params map[string]any) ([]tracker.UpdateOption, string, 
 	}
 
 	if subject := tool.GetString(params, "subject"); subject != "" {
-		opts = append(opts, tracker.WithSubject(subject))
+		opts = append(opts, todo.WithSubject(subject))
 	}
 	if description := tool.GetString(params, "description"); description != "" {
-		opts = append(opts, tracker.WithDescription(description))
+		opts = append(opts, todo.WithDescription(description))
 	}
 	if activeForm := tool.GetString(params, "activeForm"); activeForm != "" {
-		opts = append(opts, tracker.WithActiveForm(activeForm))
+		opts = append(opts, todo.WithActiveForm(activeForm))
 	}
 	if owner := tool.GetString(params, "owner"); owner != "" {
-		opts = append(opts, tracker.WithOwner(owner))
+		opts = append(opts, todo.WithOwner(owner))
 	}
 	if metadata, ok := params["metadata"].(map[string]any); ok {
-		opts = append(opts, tracker.WithMetadata(metadata))
+		opts = append(opts, todo.WithMetadata(metadata))
 	}
 	if ids := parseStringSlice(params["addBlocks"]); len(ids) > 0 {
-		opts = append(opts, tracker.WithAddBlocks(ids))
+		opts = append(opts, todo.WithAddBlocks(ids))
 	}
 	if ids := parseStringSlice(params["addBlockedBy"]); len(ids) > 0 {
-		opts = append(opts, tracker.WithAddBlockedBy(ids))
+		opts = append(opts, todo.WithAddBlockedBy(ids))
 	}
 
 	return opts, statusChange, nil

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -21,15 +21,15 @@ This file tracks structural follow-ups that are not tied to a single feature.
   ~~`tool` (6 methods)~~ — `*tool.Registry` direct.
   ~~`cron` (10 methods)~~ — `*cron.Scheduler` direct (renamed from
   `*Store`; methods schedule, persistence is a detail).
-  ~~`task` (8 methods)~~ — `*task.Tracker` direct (renamed from
-  `*Manager`; tracks background bash/subagent tasks).
+  ~~`task` (8 methods)~~ — `*task.Manager` direct (tracks background
+  bash/subagent tasks).
   ~~`command` (7 methods)~~ — `*command.Registry` direct.
   ~~`llm` (8 methods)~~ — `*llm.Conn` direct (active provider/model/Store
   handle + `*Client` factory). Originally `*ClientFactory` wrapping a
   separate `*Setup`; the two mirror types were merged into one `Conn`
   (single mutex, unexported fields) — no wrapper remains.
-  ~~`agent` (11 methods)~~ — `*agent.Task` direct (foreground agent
-  task lifecycle).
+  ~~`agent` (11 methods)~~ — `*agent.Session` direct (foreground agent
+  session lifecycle).
   ~~`setting` (14 methods)~~ — `*setting.Settings` direct (live,
   mutex-protected handle over `*setting.Data`; also the permission
   decision gate).

--- a/tests/integration/session/session_test.go
+++ b/tests/integration/session/session_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	session "github.com/genai-io/san/internal/session"
-	taskTracker "github.com/genai-io/san/internal/task/tracker"
+	taskTracker "github.com/genai-io/san/internal/todo"
 )
 
 // newTestStore creates a Store using a temp directory instead of ~/.san/projects/.

--- a/tools/layercheck/main.go
+++ b/tools/layercheck/main.go
@@ -55,6 +55,7 @@ var layerOf = map[string]string{
 	"internal/skill":     "feature",
 	"internal/subagent":  "feature",
 	"internal/task":      "feature",
+	"internal/todo":      "feature",
 	"internal/tool":      "feature",
 	"internal/worktree":  "feature",
 


### PR DESCRIPTION
Three adjacent feature packages each had a type called `Task`/`Tracker` for unrelated concepts, so a call site couldn't tell which was meant. This renames them apart — pure renames/move, no behavior change.

- `agent.Task` → `agent.Session` — the foreground agent session handle (lives in `session.go`).
- `task.Tracker` → `task.Manager` — the registry of background bash/agent executions (restores the name a prior commit had moved away from).
- `internal/task/tracker` → `internal/todo` — the LLM's to-do list (`tracker.Task` → `todo.Task`). It modeled an unrelated concept yet sat as a subpackage of `task` and imported its parent; lifting it to a sibling package removes that inversion.

Updates all import paths/consumers, the layercheck map, and the package map. Filenames keeping the "tracker" word (e.g. `tracker_view.go`, `tasktools/tracker*.go`) are left as-is — they name the user-facing to-do *tracker* feature, which is still a valid concept.