### PR TITLE
feat(tui): real-time context-usage status bar

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -37,6 +37,7 @@ type OperationModeParams struct {
 	ModelName        string
 	StatusMessage    string
 	ConversationCost llm.Money
+	Compressions     int // NEW — session compact count, drives the badge
 	Width            int
 	ThinkingEffort   string
 	ShowThinking     bool
@@ -63,7 +64,13 @@ func RenderModeStatus(params OperationModeParams) string {
 
 	left := strings.Join(leftParts, "  ")
 
-	right := renderModelWithTokens(params.ModelName, params.StatusMessage, params.InputTokens, params.InputLimit, params.ConversationCost)
+	right := renderModelWithTokens(
+		params.ModelName, params.StatusMessage,
+		params.InputTokens, params.InputLimit,
+		params.ConversationCost,
+		params.Compressions,
+		params.Width,
+	)
 	if right == "" || params.Width <= 0 {
 		return left
 	}
@@ -72,41 +79,82 @@ func RenderModeStatus(params OperationModeParams) string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
-// renderModelWithTokens renders the model name with token usage on the right side.
-func renderModelWithTokens(modelName, statusMessage string, inputTokens, inputLimit int, conversationCost llm.Money) string {
+// renderModelWithTokens composes the right-side cluster of the status
+// bar: model name, context label, bar, optional compressions badge,
+// optional cost. The actual rendering lives in status_bar.go; this
+// function preserves the existing call shape from RenderModeStatus.
+func renderModelWithTokens(
+	modelName, statusMessage string,
+	inputTokens, inputLimit int,
+	conversationCost llm.Money,
+	compressions int,
+	width int,
+) string {
 	if modelName == "" {
 		return ""
 	}
 	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	sep := muted.Render(" · ")
 
-	parts := []string{muted.Render(modelName)}
-	if statusMessage != "" {
-		parts = append(parts, muted.Render(statusMessage))
-	}
-
-	if inputTokens > 0 && inputLimit > 0 {
-		pct := float64(inputTokens) / float64(inputLimit) * 100
-		ctxSegment := fmt.Sprintf("%s/%s (%.0f%%)", kit.FormatTokenCount(inputTokens), kit.FormatTokenCount(inputLimit), pct)
-		if hint := compactStatusHint(pct); hint != "" {
-			ctxSegment += " · " + hint
+	// Always render the label + bar — RenderContext{Label,Bar} emit a
+	// dim placeholder ("ctx X/--" / "[----------] --") when the limit
+	// is unknown, so the gap stays visible instead of silently hiding.
+	labelText := RenderContextLabel(inputTokens, inputLimit)
+	barText := RenderContextBar(inputTokens, inputLimit)
+	if inputLimit > 0 {
+		if hint := compactStatusHint(float64(inputTokens) / float64(inputLimit) * 100); hint != "" {
+			barText += sep + muted.Render(hint)
 		}
-		// Tint the context budget as it nears auto-compact so it's glanceable;
-		// below the threshold it stays muted like the rest of the line.
-		ctxStyle := muted
-		switch {
-		case pct >= autoCompactThreshold:
-			ctxStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
-		case pct >= 85:
-			ctxStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
-		}
-		parts = append(parts, ctxStyle.Render(ctxSegment))
 	}
-
+	badgeText := RenderCompressionsBadge(compressions)
+	costText := ""
 	if !conversationCost.IsZero() {
-		parts = append(parts, muted.Render(kit.FormatMoney(conversationCost)))
+		costText = muted.Render(kit.FormatMoney(conversationCost))
 	}
 
+	segments := []statusSegment{
+		{render: func() string { return muted.Render(modelName) }, width: lipgloss.Width(modelName), priority: 1},
+	}
+	if statusMessage != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return muted.Render(statusMessage) },
+			width:    lipgloss.Width(statusMessage),
+			priority: 2,
+		})
+	}
+	if labelText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return labelText },
+			width:    lipgloss.Width(labelText),
+			priority: 3,
+		})
+		segments = append(segments, statusSegment{
+			render:   func() string { return barText },
+			width:    lipgloss.Width(barText),
+			priority: 4,
+		})
+	}
+	if badgeText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return badgeText },
+			width:    lipgloss.Width(badgeText),
+			priority: 5,
+		})
+	}
+	if costText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return costText },
+			width:    lipgloss.Width(costText),
+			priority: 6,
+		})
+	}
+
+	// AllocateStatusSegments joins survivors with segmentSep (a sentinel);
+	// split on it and rejoin with the visual separator to match the
+	// existing aesthetic. The sentinel guarantees segments containing the
+	// visual separator substring stay intact.
+	allocated := AllocateStatusSegments(segments, width)
+	parts := strings.Split(allocated, segmentSep)
 	return strings.Join(parts, sep)
 }
 
@@ -128,10 +176,10 @@ func RenderTurnUsageSummary(inputTokens, outputTokens, width int) string {
 
 func compactStatusHint(percent float64) string {
 	switch {
-	case percent >= autoCompactThreshold:
+	case percent >= pctCritical:
 		return "auto-compact"
-	case percent >= 85:
-		return fmt.Sprintf("compact at %d%%", autoCompactThreshold)
+	case percent > pctWarn:
+		return fmt.Sprintf("compact at %d%%", int(pctCritical))
 	default:
 		return ""
 	}

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -91,50 +91,93 @@ func Test_extractToolArgsPreservesFullCommand(t *testing.T) {
 
 func TestRenderModeStatusShowsTokenUsageWithModel(t *testing.T) {
 	rendered := RenderModeStatus(OperationModeParams{
-		ModelName:        "gpt-test",
-		InputTokens:      1234,
-		OutputTokens:     56,
-		InputLimit:       10000,
-		ConversationCost: llm.Money{Amount: 0.1234, Currency: llm.CurrencyCNY},
-		Width:            100,
+		ModelName:        "claude-sonnet-4-6",
+		InputTokens:      142000,
+		InputLimit:       200000,
+		ConversationCost: llm.Money{Amount: 0.04, Currency: llm.CurrencyUSD},
+		Width:            120,
 	})
-
-	for _, want := range []string{"gpt-test", "1.2k/10.0k (12%)", "¥0.123"} {
-		if !strings.Contains(rendered, want) {
-			t.Fatalf("RenderModeStatus() = %q, want %q", rendered, want)
-		}
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "claude-sonnet-4-6") {
+		t.Fatalf("RenderModeStatus() = %q, want model name", visible)
 	}
-	for _, unwanted := range []string{"↑1.2k", "↓56"} {
-		if strings.Contains(rendered, unwanted) {
-			t.Fatalf("RenderModeStatus() = %q, should not contain per-turn usage %q", rendered, unwanted)
-		}
+	if !strings.Contains(visible, "[") || !strings.Contains(visible, "] 71%") {
+		t.Fatalf("RenderModeStatus() = %q, want bar with percent", visible)
 	}
-	if !strings.Contains(rendered, " · ") {
-		t.Fatalf("RenderModeStatus() = %q, want segmented display", rendered)
+	// Cost segment must still render.
+	if !strings.Contains(visible, "$0.04") {
+		t.Fatalf("RenderModeStatus() = %q, want cost segment", visible)
+	}
+	// Old per-call percent format must NOT appear anymore.
+	if strings.Contains(visible, "(71%)") {
+		t.Fatalf("RenderModeStatus() = %q, should not contain old (NN%%) format", visible)
 	}
 }
 
 func TestRenderModeStatusKeepsContextDisplayOnRightOnly(t *testing.T) {
 	rendered := RenderModeStatus(OperationModeParams{
-		ModelName:      "kimi-k2.6",
-		InputTokens:    301800,
-		InputLimit:     262100,
-		ThinkingEffort: "think+",
-		ShowThinking:   true,
-		Width:          120,
+		ModelName:   "claude-sonnet-4-6",
+		InputTokens: 190000,
+		InputLimit:  200000,
+		Width:       120,
 	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "claude-sonnet-4-6") {
+		t.Fatalf("want model name in %q", visible)
+	}
+	// Bar should appear exactly once: fail if EITHER count is wrong.
+	if strings.Count(visible, "] ") != 1 || strings.Count(visible, "%") != 1 {
+		t.Fatalf("want unified context display (single bar + percent) in %q", visible)
+	}
+	if !strings.Contains(visible, "compact at") && !strings.Contains(visible, "auto-compact") {
+		t.Fatalf("want auto-compact hint in %q", visible)
+	}
+}
 
-	if !strings.Contains(rendered, "kimi-k2.6") {
-		t.Fatalf("RenderModeStatus() = %q, want model name", rendered)
+func TestRenderModeStatusShowsCompressionsBadgeWhenNonZero(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:    "claude-sonnet-4-6",
+		InputTokens:  1000,
+		InputLimit:   200000,
+		Compressions: 3,
+		Width:        120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "🗜️ 3") {
+		t.Fatalf("want '🗜️ 3' badge in %q", visible)
 	}
-	if !strings.Contains(rendered, "301.8k/262.1k (115%)") {
-		t.Fatalf("RenderModeStatus() = %q, want unified context display on the right", rendered)
+}
+
+func TestRenderModeStatusHidesBadgeWhenZero(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:    "claude-sonnet-4-6",
+		InputTokens:  1000,
+		InputLimit:   200000,
+		Compressions: 0,
+		Width:        120,
+	})
+	visible := stripANSI(rendered)
+	if strings.Contains(visible, "🗜️") {
+		t.Fatalf("badge should be hidden when zero; got %q", visible)
 	}
-	if !strings.Contains(rendered, "auto-compact") {
-		t.Fatalf("RenderModeStatus() = %q, want auto-compact hint", rendered)
+}
+
+func TestRenderModeStatusShowsPlaceholderWhenLimitUnknown(t *testing.T) {
+	// When InputLimit == 0 (limit unknown), the bar must still render with
+	// a placeholder so the gap stays visible and actionable, instead of
+	// silently hiding the entire context segment.
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:   "some-model",
+		InputTokens: 5000,
+		InputLimit:  0,
+		Width:       120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "[----------]") {
+		t.Errorf("want placeholder bar [----------] when limit unknown; got %q", visible)
 	}
-	if strings.Count(rendered, "115%") != 1 {
-		t.Fatalf("RenderModeStatus() = %q, should only show context percentage once", rendered)
+	if !strings.Contains(visible, "--") {
+		t.Errorf("want '--' percent label when limit unknown; got %q", visible)
 	}
 }
 

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -1,0 +1,209 @@
+// Package conv: status-bar components — context bar, color tiers,
+// compressions badge, and the responsive segment allocator. Pure
+// functions over primitives; the orchestrator (RenderModeStatus) wires
+// them to env state.
+package conv
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/genai-io/san/internal/app/kit"
+)
+
+// Threshold percentages for the 4 PRD §7.2 color tiers.
+const (
+	pctGood     = 50.0
+	pctWarn     = 80.0
+	pctCritical = 95.0
+
+	// contextBarWidth is the cell count for the visual bar (PRD §7.1).
+	contextBarWidth = 10
+)
+
+// contextTier classifies a context-window fill percentage into one of
+// the 4 PRD §7.2 tiers. Off-by-one preserved: 80 itself falls into warn,
+// only strictly-greater-than-80 is bad. ≥95 is critical.
+type contextTier int
+
+const (
+	tierNone     contextTier = iota // pct unknown — denominator missing
+	tierGood                        // [0, 50]    healthy
+	tierWarn                        // (50, 80]   watch
+	tierBad                         // (80, 95)   pressure
+	tierCritical                    // [95, 100+] imminent compression
+)
+
+// classifyContextTier maps a percentage to its tier. Defensive for
+// out-of-range inputs: pct < 0 returns tierGood, pct > 100 returns
+// tierCritical. Renderers should still clamp for clean display.
+func classifyContextTier(pct float64) contextTier {
+	switch {
+	case pct <= pctGood: // pct ≤ 50
+		return tierGood
+	case pct <= pctWarn: // 50 < pct ≤ 80
+		return tierWarn
+	case pct < pctCritical: // 80 < pct < 95
+		return tierBad
+	default: // pct ≥ 95
+		return tierCritical
+	}
+}
+
+// style resolves a tier to a lipgloss style composed from existing
+// theme tokens (per project decision: no new theme infrastructure).
+func (t contextTier) style() lipgloss.Style {
+	switch t {
+	case tierGood:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
+	case tierWarn:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+	case tierBad:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+	case tierCritical:
+		// Critical = Error + Bold. Distinct from "bad" without adding a
+		// new theme token.
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error).Bold(true)
+	default: // tierNone
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	}
+}
+
+// RenderContextBar renders the 10-cell bar with a percentage label:
+//
+//	"[██████░░░░] 71%"   normal case
+//	"[----------] --"    when limit is 0 (unknown)
+//
+// The percentage is rounded to an integer at this layer (PRD §4.2); the
+// engine itself never rounds. `used` is clamped to [0, limit] before
+// computing pct so callers cannot accidentally render negatives or >100%.
+func RenderContextBar(used, limit int) string {
+	if limit <= 0 {
+		dim := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+		return dim.Render("[" + strings.Repeat("-", contextBarWidth) + "] --")
+	}
+	if used < 0 {
+		used = 0
+	}
+	pct := float64(used) / float64(limit) * 100
+	if pct > 100 {
+		pct = 100
+	}
+	filled := int((pct/100)*float64(contextBarWidth) + 0.5) // round to nearest cell
+	if filled > contextBarWidth {
+		filled = contextBarWidth
+	}
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", contextBarWidth-filled)
+	style := classifyContextTier(pct).style()
+	return style.Render(fmt.Sprintf("[%s] %d%%", bar, int(pct+0.5)))
+}
+
+// RenderContextLabel renders the "ctx X/Y" segment using compact
+// humanized numbers (PRD §7.4). Limit renders as "--" when unknown.
+func RenderContextLabel(used, limit int) string {
+	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	if limit <= 0 {
+		return muted.Render(fmt.Sprintf("ctx %s/--", kit.FormatTokenCount(used)))
+	}
+	return muted.Render(fmt.Sprintf("ctx %s/%s", kit.FormatTokenCount(used), kit.FormatTokenCount(limit)))
+}
+
+// compressionBadgeStyle escalates color with count (PRD §7.5):
+//
+//	<5     muted
+//	5–9    warn
+//	≥10    error
+func compressionBadgeStyle(n int) lipgloss.Style {
+	switch {
+	case n >= 10:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+	case n >= 5:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+	default:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	}
+}
+
+// RenderCompressionsBadge returns the "🗜️ N" badge or "" when n ≤ 0.
+// Color escalates per compressionBadgeStyle.
+func RenderCompressionsBadge(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return compressionBadgeStyle(n).Render(fmt.Sprintf("🗜️ %d", n))
+}
+
+// segmentSep is the internal join separator. Uses the ASCII Unit
+// Separator (\x1f) so it can never collide with rendered segment text
+// (lipgloss emits ANSI escapes with \x1b; user strings don't contain
+// control characters). Callers split on it to swap in their own visual
+// separator.
+const segmentSep = "\x1f"
+
+// statusSegment is a unit the allocator can keep or drop atomically.
+// Lower priority drops first when width is constrained (PRD §8.3).
+type statusSegment struct {
+	render   func() string // lazy — only invoked if the segment survives
+	width    int           // precomputed visible width (excluding separators)
+	priority int           // 1 = highest (drops last); larger = drops first
+}
+
+// AllocateStatusSegments walks segments in priority order, keeping each
+// segment that fits in the remaining budget plus its leading separator.
+// Segments are never truncated mid-render. Returns survivors joined with
+// segmentSep, in the original caller-supplied order. Callers split on
+// segmentSep to rejoin with their preferred visual separator.
+func AllocateStatusSegments(segments []statusSegment, availableWidth int) string {
+	if availableWidth <= 0 || len(segments) == 0 {
+		return ""
+	}
+	// Sort by priority ascending (1 first). Stable so equal-priority
+	// segments keep their original order.
+	order := make([]int, len(segments))
+	for i := range order {
+		order[i] = i
+	}
+	// Insertion sort — n is tiny (≤6 segments in practice).
+	for i := 1; i < len(order); i++ {
+		j := i
+		for j > 0 && segments[order[j-1]].priority > segments[order[j]].priority {
+			order[j-1], order[j] = order[j], order[j-1]
+			j--
+		}
+	}
+
+	type kept struct {
+		idx    int
+		render string
+	}
+	var survivors []kept
+	budget := availableWidth
+	for _, idx := range order {
+		s := segments[idx]
+		need := s.width
+		if len(survivors) > 0 {
+			need += len(segmentSep)
+		}
+		if need > budget {
+			continue
+		}
+		survivors = append(survivors, kept{idx: idx, render: s.render()})
+		budget -= need
+	}
+
+	// Re-emit in the original (caller-supplied) order so the layout reads
+	// naturally regardless of priority.
+	byIdx := make(map[int]int, len(survivors))
+	for i, k := range survivors {
+		byIdx[k.idx] = i
+	}
+	out := make([]string, 0, len(survivors))
+	for origIdx := range segments {
+		if i, ok := byIdx[origIdx]; ok {
+			out = append(out, survivors[i].render)
+		}
+	}
+	return strings.Join(out, segmentSep)
+}

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -1,0 +1,190 @@
+package conv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyContextTier_Boundaries(t *testing.T) {
+	cases := []struct {
+		pct  float64
+		want contextTier
+	}{
+		{0, tierGood},     // empty context
+		{49, tierGood},    // just under warn
+		{50, tierGood},    // PRD §7.2: 50 stays good
+		{50.01, tierWarn}, // just past good
+		{51, tierWarn},
+		{79, tierWarn},
+		{80, tierWarn}, // PRD §7.2 off-by-one: 80 stays warn
+		{81, tierBad},  // only >80 is bad
+		{94, tierBad},
+		{94.99, tierBad},
+		{95, tierCritical}, // PRD §7.2: ≥95 is critical
+		{100, tierCritical},
+		{120, tierCritical}, // clamp handled upstream; classifier still critical
+	}
+	for _, c := range cases {
+		got := classifyContextTier(c.pct)
+		if got != c.want {
+			t.Errorf("classifyContextTier(%.2f) = %v, want %v", c.pct, got, c.want)
+		}
+	}
+}
+
+func TestRenderContextBar_FillLevels(t *testing.T) {
+	cases := []struct {
+		name     string
+		used     int
+		limit    int
+		wantFill int // expected number of '█' characters
+		wantPct  string
+	}{
+		{"empty", 0, 200000, 0, "0%"},
+		{"half", 100000, 200000, 5, "50%"},
+		{"near-full", 190000, 200000, 10, "95%"}, // 95% rounds to 10 cells (9.5 → 10)
+		{"full", 200000, 200000, 10, "100%"},
+		{"oversend-clamped", 240000, 200000, 10, "100%"}, // pct > 100 clamped
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderContextBar(c.used, c.limit)
+			if strings.Count(got, "█") != c.wantFill {
+				t.Errorf("fill cells = %d, want %d (rendered: %q)", strings.Count(got, "█"), c.wantFill, got)
+			}
+			if !strings.Contains(got, c.wantPct) {
+				t.Errorf("pct label %q missing from %q", c.wantPct, got)
+			}
+		})
+	}
+}
+
+func TestRenderContextBar_NoLimit(t *testing.T) {
+	got := RenderContextBar(100, 0)
+	if !strings.Contains(got, "--") {
+		t.Errorf("missing '--' label for unknown limit; got %q", got)
+	}
+	// No fill cells when denominator is unknown.
+	if strings.Contains(got, "█") {
+		t.Errorf("should not render fill cells for unknown limit; got %q", got)
+	}
+}
+
+func TestRenderContextBar_NoNegativePercent(t *testing.T) {
+	// Defensive: callers should pass non-negative, but the renderer
+	// must never emit a negative percentage.
+	got := RenderContextBar(-1, 200000)
+	if strings.Contains(got, "-") {
+		t.Errorf("negative percent rendered: %q", got)
+	}
+}
+
+func TestRenderContextLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		used  int
+		limit int
+		want  string
+	}{
+		{"compact", 142_000, 200_000, "ctx 142.0k/200.0k"},
+		{"millions", 1_500_000, 2_000_000, "ctx 1.5M/2.0M"},
+		{"unknown-limit", 5000, 0, "ctx 5.0k/--"}, // used shown, limit unknown
+		{"zero-used", 0, 200_000, "ctx 0/200.0k"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderContextLabel(c.used, c.limit)
+			visible := stripANSI(got)
+			if visible != c.want {
+				t.Errorf("RenderContextLabel(%d, %d) visible = %q, want %q (raw: %q)", c.used, c.limit, visible, c.want, got)
+			}
+		})
+	}
+}
+func TestRenderCompressionsBadge(t *testing.T) {
+	cases := []struct {
+		name    string
+		n       int
+		visible string // empty means badge should not render
+	}{
+		{"zero-hidden", 0, ""},
+		{"one", 1, "🗜️ 1"},
+		{"four-dim", 4, "🗜️ 4"},
+		{"five-warn", 5, "🗜️ 5"},
+		{"nine-warn", 9, "🗜️ 9"},
+		{"ten-error", 10, "🗜️ 10"},
+		{"twenty-error", 20, "🗜️ 20"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderCompressionsBadge(c.n)
+			visible := stripANSI(got)
+			if c.visible == "" {
+				if got != "" {
+					t.Errorf("RenderCompressionsBadge(%d) = %q, want empty", c.n, got)
+				}
+				return
+			}
+			if visible != c.visible {
+				t.Errorf("RenderCompressionsBadge(%d) visible = %q, want %q", c.n, visible, c.visible)
+			}
+		})
+	}
+}
+
+func TestAllocateStatusSegments_DropsInPriorityOrder(t *testing.T) {
+	// Priorities: 1=highest (drops last), 4=lowest (drops first).
+	segments := []statusSegment{
+		{render: func() string { return "[bar] 71%" }, width: 11, priority: 1},
+		{render: func() string { return "ctx 142K/200K" }, width: 14, priority: 2},
+		{render: func() string { return "🗜️ 2" }, width: 5, priority: 3},
+		{render: func() string { return "$0.04" }, width: 5, priority: 4},
+	}
+
+	// Wide: everything fits with separators.
+	got := AllocateStatusSegments(segments, 100)
+	for _, s := range segments {
+		if !strings.Contains(got, stripANSI(s.render())) {
+			t.Errorf("wide: segment %q dropped from %q", stripANSI(s.render()), got)
+		}
+	}
+
+	// Narrow (~30 cols): lowest-priority segments drop first.
+	got = AllocateStatusSegments(segments, 30)
+	if !strings.Contains(got, "[bar] 71%") {
+		t.Errorf("priority-1 segment should survive at width 30; got %q", got)
+	}
+	if strings.Contains(got, "$0.04") {
+		t.Errorf("priority-4 (cost) should drop first at width 30; got %q", got)
+	}
+}
+
+func TestAllocateStatusSegments_NeverTruncatesMidSegment(t *testing.T) {
+	segments := []statusSegment{
+		{render: func() string { return "exactly12ch" }, width: 11, priority: 1},
+	}
+	// Just enough room.
+	got := AllocateStatusSegments(segments, 11)
+	if !strings.Contains(got, "exactly12ch") {
+		t.Errorf("segment should fit at width=its own width; got %q", got)
+	}
+	// One col too narrow.
+	got = AllocateStatusSegments(segments, 10)
+	if strings.Contains(got, "exactly12") {
+		t.Errorf("segment must drop, not truncate, when it doesn't fit; got %q", got)
+	}
+}
+
+func TestAllocateStatusSegments_PreservesSegmentContainingSpaces(t *testing.T) {
+	// Regression: the internal separator is a sentinel (\x1f) that
+	// cannot appear in rendered text, so segments containing arbitrary
+	// substrings (including spaces) survive intact.
+	segments := []statusSegment{
+		{render: func() string { return "ab  cd" }, width: 6, priority: 1},
+		{render: func() string { return "ef" }, width: 2, priority: 2},
+	}
+	got := AllocateStatusSegments(segments, 100)
+	if !strings.Contains(got, "ab  cd") || !strings.Contains(got, "ef") {
+		t.Errorf("segments with inner spaces corrupted: %q", got)
+	}
+}

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -39,6 +39,10 @@ type env struct {
 	turnUsageActive  bool
 	ConversationCost llm.Money
 	ThinkingEffort   string
+	// Compressions counts auto + manual compacts this session. Survives
+	// ResetContextDisplay (called per-compact); zeroed only by ResetTokens
+	// (called on /reset, /new).
+	Compressions int
 
 	// ── Permission (mutable — changes per mode cycle) ───────────
 	OperationMode      setting.OperationMode
@@ -240,4 +244,5 @@ func (m *env) ResetTokens() {
 	m.TurnInputTokens = 0
 	m.TurnOutputTokens = 0
 	m.turnUsageActive = false
+	m.Compressions = 0
 }

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -1,0 +1,32 @@
+package app
+
+import "testing"
+
+func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
+	e := &env{Compressions: 3, InputTokens: 100, OutputTokens: 50}
+	e.ResetContextDisplay()
+	if e.Compressions != 3 {
+		t.Errorf("Compressions = %d, want 3 (must survive ResetContextDisplay)", e.Compressions)
+	}
+	if e.InputTokens != 0 || e.OutputTokens != 0 {
+		t.Errorf("InputTokens=%d OutputTokens=%d, want 0/0", e.InputTokens, e.OutputTokens)
+	}
+}
+
+func TestResetTokens_ZeroesCompressions(t *testing.T) {
+	e := &env{Compressions: 5, TurnInputTokens: 80, TurnOutputTokens: 40}
+	e.ResetTokens()
+	if e.Compressions != 0 {
+		t.Errorf("Compressions = %d, want 0 after ResetTokens", e.Compressions)
+	}
+	if e.TurnInputTokens != 0 || e.TurnOutputTokens != 0 {
+		t.Errorf("turn tokens not zeroed: %d/%d", e.TurnInputTokens, e.TurnOutputTokens)
+	}
+}
+
+func TestCompressions_StartsAtZero(t *testing.T) {
+	e := &env{}
+	if e.Compressions != 0 {
+		t.Errorf("Compressions = %d, want 0 at session start", e.Compressions)
+	}
+}

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -41,6 +41,7 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 
 	m.conv.Clear()
 	m.env.ResetContextDisplay()
+	m.env.Compressions++
 	token := m.userInput.Provider.SetStatusMessage("compacted")
 	// The summary is injected as a user message — the model reads it (Content),
 	// and it persists + seeds resume — but the UI renders it as a single system

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -247,6 +247,7 @@ func (m model) renderModeStatus() string {
 		ModelName:        modelName,
 		StatusMessage:    m.userInput.Provider.StatusMessage,
 		ConversationCost: m.env.ConversationCost,
+		Compressions:     m.env.Compressions,
 		Width:            m.env.Width,
 		ThinkingEffort:   thinkingEffort,
 		ShowThinking:     showThinking,

--- a/internal/llm/CATALOGS.md
+++ b/internal/llm/CATALOGS.md
@@ -1,0 +1,90 @@
+# Provider Catalog Patterns
+
+Each LLM provider lives in `internal/llm/<provider>/` and resolves model
+metadata (display names, token limits) through one of three patterns.
+Pick the one that matches what the provider's API gives you.
+
+## Pattern A — Flat static catalog
+
+**Use when:** the provider has few, stable models and no per-model pricing.
+
+```go
+// catalog.go
+var catalog = []llm.ModelInfo{
+    {ID: "model-id", Name: "Model", DisplayName: "Model",
+     InputTokenLimit: 200000, OutputTokenLimit: 8192},
+}
+
+func StaticModels() []llm.ModelInfo { ... }
+func CatalogModel(modelID string) (llm.ModelInfo, bool) { ... }
+```
+
+`ListModels` returns `StaticModels()` directly — no API call.
+
+**Users:** sensenova
+
+## Pattern B — Catalog with pricing
+
+**Use when:** the provider charges per-token and you track cost.
+
+```go
+type modelCatalogEntry struct {
+    info    llm.ModelInfo
+    pricing pricing
+}
+
+var catalog = []modelCatalogEntry{ ... }
+
+func StaticModels() []llm.ModelInfo { ... }
+func CatalogModel(modelID string) (llm.ModelInfo, bool) { ... }
+func EstimateCost(modelID string, usage llm.Usage) (llm.Money, bool) { ... }
+```
+
+`ListModels` returns `StaticModels()` or merges with an API fetch.
+
+**Users:** deepseek, mimo, minmax, ollama
+
+## Pattern C — API-discovered + static fallback functions
+
+**Use when:** the provider has a working `/v1/models` endpoint that lists
+model IDs but doesn't include token limits.
+
+```go
+// catalog.go — limit lookup functions, NOT a model list
+func staticInputLimit(modelID string) int { ... }   // pattern-match on ID
+func staticOutputLimit(modelID string) int { ... }
+```
+
+`ListModels` calls the API for the model list, then applies the static
+functions to fill in limits the API didn't provide.
+
+**Users:** bigmodel, moonshot, volcengine, openai
+
+## Pattern D — Prefix-matching catalog (variant of A)
+
+**Use when:** one logical model has many versioned IDs
+(e.g. `claude-opus-4-5-20251101`, `claude-opus-4-5-latest`).
+
+```go
+type catalogEntry struct {
+    match            func(string) bool   // prefix matcher
+    info             llm.ModelInfo
+    supportsThinking bool
+}
+```
+
+**Users:** anthropic
+
+## Which to pick for a new provider
+
+1. Does the provider have a `/v1/models` endpoint? → Pattern C
+2. Do you need per-model pricing? → Pattern B
+3. Are there many versioned aliases for the same model? → Pattern D
+4. Otherwise → Pattern A
+
+## Guardrail
+
+`internal/llm/catalog_check_test.go` verifies that every model in a
+static catalog has `InputTokenLimit > 0`. A zero limit means the
+context-usage status bar can't render. If a model's limit is genuinely
+unknown, don't add it to a static catalog — resolve it dynamically.

--- a/internal/llm/anthropic/catalog.go
+++ b/internal/llm/anthropic/catalog.go
@@ -24,61 +24,61 @@ type catalogEntry struct {
 var anthropicCatalog = []catalogEntry{
 	{
 		match:            matchAnyPrefix("claude-opus-4-7"),
-		info:             newModelInfo("claude-opus-4-7", "Claude Opus 4.7", "Claude Opus 4.7 (Most Capable)", 200000),
+		info:             newModelInfo("claude-opus-4-7", "Claude Opus 4.7", "Claude Opus 4.7 (Most Capable)", 200000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4-6[1m]"),
-		info:             newModelInfo("claude-opus-4-6[1m]", "Claude Opus 4.6 (1M)", "Claude Opus 4.6 (1M Context)", 1000000),
+		info:             newModelInfo("claude-opus-4-6[1m]", "Claude Opus 4.6 (1M)", "Claude Opus 4.6 (1M Context)", 1000000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4-6"),
-		info:             newModelInfo("claude-opus-4-6", "Claude Opus 4.6", "Claude Opus 4.6", 200000),
+		info:             newModelInfo("claude-opus-4-6", "Claude Opus 4.6", "Claude Opus 4.6", 200000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4-5"),
-		info:             newModelInfo("claude-opus-4-5-20251101", "Claude Opus 4.5", "Claude Opus 4.5", 200000),
+		info:             newModelInfo("claude-opus-4-5-20251101", "Claude Opus 4.5", "Claude Opus 4.5", 200000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4-1"),
-		info:             newModelInfo("claude-opus-4-1-20250805", "Claude Opus 4.1", "Claude Opus 4.1", 200000),
+		info:             newModelInfo("claude-opus-4-1-20250805", "Claude Opus 4.1", "Claude Opus 4.1", 200000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-opus-4"),
-		info:             newModelInfo("claude-opus-4-20250514", "Claude Opus 4", "Claude Opus 4", 200000),
+		info:             newModelInfo("claude-opus-4-20250514", "Claude Opus 4", "Claude Opus 4", 200000, 32000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-sonnet-4-6"),
-		info:             newModelInfo("claude-sonnet-4-6", "Claude Sonnet 4.6", "Claude Sonnet 4.6", 200000),
+		info:             newModelInfo("claude-sonnet-4-6", "Claude Sonnet 4.6", "Claude Sonnet 4.6", 200000, 64000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-sonnet-4-5"),
-		info:             newModelInfo("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "Claude Sonnet 4.5", 200000),
+		info:             newModelInfo("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "Claude Sonnet 4.5", 200000, 64000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-sonnet-4"),
-		info:             newModelInfo("claude-sonnet-4-20250514", "Claude Sonnet 4", "Claude Sonnet 4", 200000),
+		info:             newModelInfo("claude-sonnet-4-20250514", "Claude Sonnet 4", "Claude Sonnet 4", 200000, 64000),
 		supportsThinking: true,
 	},
 	{
 		match:            matchAnyPrefix("claude-3-7-sonnet"),
-		info:             newModelInfo("claude-3-7-sonnet-20250219", "Claude Sonnet 3.7", "Claude Sonnet 3.7", 200000),
+		info:             newModelInfo("claude-3-7-sonnet-20250219", "Claude Sonnet 3.7", "Claude Sonnet 3.7", 200000, 8192),
 		supportsThinking: true,
 	},
 	{
 		match: matchAnyPrefix("claude-haiku-4-5"),
-		info:  newModelInfo("claude-haiku-4-5-20251001", "Claude Haiku 4.5", "Claude Haiku 4.5 (Fast)", 200000),
+		info:  newModelInfo("claude-haiku-4-5-20251001", "Claude Haiku 4.5", "Claude Haiku 4.5 (Fast)", 200000, 16384),
 	},
 	{
 		match: matchAnyPrefix("claude-3-5-haiku"),
-		info:  newModelInfo("claude-3-5-haiku-20241022", "Claude Haiku 3.5", "Claude Haiku 3.5", 200000),
+		info:  newModelInfo("claude-3-5-haiku-20241022", "Claude Haiku 3.5", "Claude Haiku 3.5", 200000, 8192),
 	},
 }
 
@@ -134,12 +134,13 @@ func StaticModels() []llm.ModelInfo {
 	return models
 }
 
-func newModelInfo(id, name, displayName string, inputLimit int) llm.ModelInfo {
+func newModelInfo(id, name, displayName string, inputLimit, outputLimit int) llm.ModelInfo {
 	return llm.ModelInfo{
-		ID:              id,
-		Name:            name,
-		DisplayName:     displayName,
-		InputTokenLimit: inputLimit,
+		ID:               id,
+		Name:             name,
+		DisplayName:      displayName,
+		InputTokenLimit:  inputLimit,
+		OutputTokenLimit: outputLimit,
 	}
 }
 

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -252,8 +252,12 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 			case "message_delta":
 				msgDelta := event.AsMessageDelta()
 				state.Response.StopReason = string(msgDelta.Delta.StopReason)
-				state.UpdateUsage(0, int(msgDelta.Usage.OutputTokens))
-				state.UpdateCacheUsage(0, int(msgDelta.Usage.CacheReadInputTokens))
+				// Anthropic populates only OutputTokens here; some Anthropic-compatible
+				// providers (e.g. SenseNova) emit InputTokens in message_delta rather
+				// than message_start. UpdateUsage is a no-op when the value is 0, so
+				// passing both is safe for either shape.
+				state.UpdateUsage(int(msgDelta.Usage.InputTokens), int(msgDelta.Usage.OutputTokens))
+				state.UpdateCacheUsage(int(msgDelta.Usage.CacheCreationInputTokens), int(msgDelta.Usage.CacheReadInputTokens))
 
 			case "message_start":
 				msgStart := event.AsMessageStart()

--- a/internal/llm/bigmodel/catalog.go
+++ b/internal/llm/bigmodel/catalog.go
@@ -1,0 +1,17 @@
+package bigmodel
+
+import "strings"
+
+// staticInputLimit returns the known context window for a GLM model ID.
+// Used as a fallback when BigModel's /v1/models endpoint omits
+// context_length (which it does in practice — the endpoint follows the
+// bare OpenAI shape with only id/object/owned_by).
+//
+//	GLM-5.2:             1M tokens
+//	GLM-5.1 and earlier: 256K tokens
+func staticInputLimit(modelID string) int {
+	if strings.HasPrefix(modelID, "glm-5.2") {
+		return 1_000_000
+	}
+	return 256_000
+}

--- a/internal/llm/bigmodel/client.go
+++ b/internal/llm/bigmodel/client.go
@@ -117,6 +117,9 @@ func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 				info.InputTokenLimit = extra.ContextLength
 			}
 		}
+		if info.InputTokenLimit == 0 {
+			info.InputTokenLimit = staticInputLimit(id)
+		}
 		models = append(models, info)
 	}
 

--- a/internal/llm/bigmodel/client_test.go
+++ b/internal/llm/bigmodel/client_test.go
@@ -204,6 +204,55 @@ func TestBigModelListModelsReturnsAPIResults(t *testing.T) {
 	}
 }
 
+func TestBigModelListModelsFallsBackToStaticLimit(t *testing.T) {
+	// Real BigModel API omits context_length — verify the static fallback
+	// kicks in so the status bar can render.
+	transport := &modelsTransport{
+		body: `{
+			"object": "list",
+			"data": [
+				{"id": "glm-4.7", "object": "model"},
+				{"id": "glm-5.2", "object": "model"}
+			]
+		}`,
+	}
+	c := newTestClient(transport)
+
+	models, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	byID := map[string]int{}
+	for _, m := range models {
+		byID[m.ID] = m.InputTokenLimit
+	}
+	if byID["glm-4.7"] != 256_000 {
+		t.Errorf("glm-4.7 limit = %d, want 256000 (static fallback)", byID["glm-4.7"])
+	}
+	if byID["glm-5.2"] != 1_000_000 {
+		t.Errorf("glm-5.2 limit = %d, want 1000000 (static fallback)", byID["glm-5.2"])
+	}
+}
+
+func TestStaticInputLimit(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"glm-5.2", 1_000_000},
+		{"glm-5.2-flash", 1_000_000},
+		{"glm-5.1", 256_000},
+		{"glm-4.7", 256_000},
+		{"glm-4-long", 256_000},
+		{"glm-4.7-flash", 256_000},
+	}
+	for _, c := range cases {
+		if got := staticInputLimit(c.model); got != c.want {
+			t.Errorf("staticInputLimit(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}
+
 func TestBigModelListModelsReturnsErrorOnAPIFailure(t *testing.T) {
 	c := newTestClient(&modelsErrorTransport{})
 

--- a/internal/llm/catalog_check_test.go
+++ b/internal/llm/catalog_check_test.go
@@ -1,0 +1,48 @@
+package llm_test
+
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/anthropic"
+	"github.com/genai-io/san/internal/llm/deepseek"
+	"github.com/genai-io/san/internal/llm/mimo"
+	"github.com/genai-io/san/internal/llm/minmax"
+	"github.com/genai-io/san/internal/llm/ollama"
+	"github.com/genai-io/san/internal/llm/sensenova"
+)
+
+// TestStaticCatalogsHaveInputLimits is a guardrail: every model that a
+// provider ships in its static catalog MUST declare an InputTokenLimit.
+// A zero limit means the context-usage status bar can't render and
+// auto-compact can't fire — both fail silently.
+//
+// When adding a new model to any catalog, set its InputTokenLimit.
+// If the limit is genuinely unknown, omit the model from the static
+// catalog and resolve it dynamically (API fetch or /tokenlimit).
+func TestStaticCatalogsHaveInputLimits(t *testing.T) {
+	providers := []struct {
+		name   string
+		models []llm.ModelInfo
+	}{
+		{"anthropic", anthropic.StaticModels()},
+		{"deepseek", deepseek.StaticModels()},
+		{"mimo", mimo.StaticModels()},
+		{"minmax", minmax.StaticModels()},
+		{"ollama", ollama.StaticModels()},
+		{"sensenova", sensenova.StaticModels()},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			if len(p.models) == 0 {
+				t.Fatalf("%s: StaticModels() returned empty", p.name)
+			}
+			for _, m := range p.models {
+				if m.InputTokenLimit == 0 {
+					t.Errorf("%s: model %q has InputTokenLimit=0; set the context window or remove from catalog", p.name, m.ID)
+				}
+			}
+		})
+	}
+}

--- a/internal/llm/moonshot/catalog.go
+++ b/internal/llm/moonshot/catalog.go
@@ -1,0 +1,40 @@
+package moonshot
+
+import "strings"
+
+// staticInputLimit returns the known context window for Kimi/Moonshot
+// model IDs. Moonshot's /v1/models endpoint doesn't include context_length,
+// so we parse it from the model ID suffix (8k/32k/128k) or default by
+// model family.
+func staticInputLimit(modelID string) int {
+	m := strings.ToLower(modelID)
+	switch {
+	case strings.Contains(m, "128k"):
+		return 131_072
+	case strings.Contains(m, "32k"):
+		return 32_768
+	case strings.Contains(m, "8k"):
+		return 8_192
+	case strings.Contains(m, "k2"):
+		return 262_144
+	}
+	return 0
+}
+
+// staticOutputLimit returns the known max output tokens for Kimi/Moonshot
+// model IDs. Used as a fallback when the API doesn't include
+// max_output_tokens in the model metadata.
+func staticOutputLimit(modelID string) int {
+	m := strings.ToLower(modelID)
+	switch {
+	case strings.Contains(m, "k2"):
+		return 8_192
+	case strings.Contains(m, "128k"):
+		return 8_192
+	case strings.Contains(m, "32k"):
+		return 8_192
+	case strings.Contains(m, "8k"):
+		return 3_000
+	}
+	return 0
+}

--- a/internal/llm/moonshot/catalog_test.go
+++ b/internal/llm/moonshot/catalog_test.go
@@ -1,0 +1,38 @@
+package moonshot
+
+import "testing"
+
+func TestStaticInputLimit(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"moonshot-v1-8k", 8_192},
+		{"moonshot-v1-32k", 32_768},
+		{"moonshot-v1-128k", 131_072},
+		{"kimi-k2-0905-preview", 262_144},
+		{"unknown-model", 0},
+	}
+	for _, c := range cases {
+		if got := staticInputLimit(c.model); got != c.want {
+			t.Errorf("staticInputLimit(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}
+
+func TestStaticOutputLimit(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"moonshot-v1-8k", 3_000},
+		{"moonshot-v1-128k", 8_192},
+		{"kimi-k2-0905-preview", 8_192},
+		{"unknown-model", 0},
+	}
+	for _, c := range cases {
+		if got := staticOutputLimit(c.model); got != c.want {
+			t.Errorf("staticOutputLimit(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}

--- a/internal/llm/moonshot/client.go
+++ b/internal/llm/moonshot/client.go
@@ -79,14 +79,19 @@ func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	for _, m := range page.Data {
 		id := m.ID
 		info := llm.ModelInfo{ID: id, Name: id, DisplayName: id}
-		// Extract context_length from raw JSON (Moonshot extension field)
+		// Moonshot's API returns max_output_tokens but not context_length;
+		// input limits are derived from the model ID via staticInputLimit.
 		if raw := m.RawJSON(); raw != "" {
 			var extra struct {
-				ContextLength int `json:"context_length"`
+				MaxOutputTokens int `json:"max_output_tokens"`
 			}
-			if err := json.Unmarshal([]byte(raw), &extra); err == nil && extra.ContextLength > 0 {
-				info.InputTokenLimit = extra.ContextLength
+			if err := json.Unmarshal([]byte(raw), &extra); err == nil && extra.MaxOutputTokens > 0 {
+				info.OutputTokenLimit = extra.MaxOutputTokens
 			}
+		}
+		info.InputTokenLimit = staticInputLimit(id)
+		if info.OutputTokenLimit == 0 {
+			info.OutputTokenLimit = staticOutputLimit(id)
 		}
 		models = append(models, info)
 	}

--- a/internal/llm/openai/catalog.go
+++ b/internal/llm/openai/catalog.go
@@ -37,9 +37,38 @@ func openAIThinkingEfforts(model string) []string {
 }
 
 func openAIModelInfo(modelID string) llm.ModelInfo {
+	input, output := openAILimits(modelID)
 	return llm.ModelInfo{
-		ID:          modelID,
-		Name:        modelID,
-		DisplayName: modelID,
+		ID:               modelID,
+		Name:             modelID,
+		DisplayName:      modelID,
+		InputTokenLimit:  input,
+		OutputTokenLimit: output,
 	}
+}
+
+// openAILimits returns known context/output windows for OpenAI model IDs.
+// OpenAI's /v1/models endpoint doesn't include limits, so we rely on
+// published specs. Returns 0,0 for unrecognized IDs.
+func openAILimits(modelID string) (input, output int) {
+	m := strings.ToLower(strings.TrimSpace(modelID))
+	switch {
+	case strings.HasPrefix(m, "gpt-6"),
+		strings.HasPrefix(m, "gpt-5.5"),
+		strings.HasPrefix(m, "gpt-5.4"):
+		return 400_000, 16_384
+	case strings.HasPrefix(m, "gpt-5"):
+		return 400_000, 16_384
+	case strings.HasPrefix(m, "o1"),
+		strings.HasPrefix(m, "o3"),
+		strings.HasPrefix(m, "o4"):
+		return 200_000, 100_000
+	case strings.Contains(m, "codex"):
+		return 400_000, 16_384
+	case strings.HasPrefix(m, "gpt-4.1"):
+		return 1_048_576, 16_384
+	case strings.HasPrefix(m, "gpt-4o"):
+		return 128_000, 16_384
+	}
+	return 0, 0
 }

--- a/internal/llm/openai/catalog_test.go
+++ b/internal/llm/openai/catalog_test.go
@@ -1,0 +1,29 @@
+package openai
+
+import "testing"
+
+func TestOpenAILimits(t *testing.T) {
+	cases := []struct {
+		model      string
+		wantInput  int
+		wantOutput int
+	}{
+		{"gpt-6", 400_000, 16_384},
+		{"gpt-5.5", 400_000, 16_384},
+		{"gpt-5.4-mini", 400_000, 16_384},
+		{"gpt-5", 400_000, 16_384},
+		{"o1", 200_000, 100_000},
+		{"o3-mini", 200_000, 100_000},
+		{"o4", 200_000, 100_000},
+		{"codex-latest", 400_000, 16_384},
+		{"gpt-4.1", 1_048_576, 16_384},
+		{"gpt-4o", 128_000, 16_384},
+		{"unknown-model", 0, 0},
+	}
+	for _, c := range cases {
+		input, output := openAILimits(c.model)
+		if input != c.wantInput || output != c.wantOutput {
+			t.Errorf("openAILimits(%q) = (%d, %d), want (%d, %d)", c.model, input, output, c.wantInput, c.wantOutput)
+		}
+	}
+}

--- a/internal/llm/sensenova/apikey.go
+++ b/internal/llm/sensenova/apikey.go
@@ -2,10 +2,9 @@ package sensenova
 
 import (
 	"context"
-	"os"
 
-	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
-	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/secret"
@@ -18,16 +17,22 @@ var APIKeyMeta = llm.Meta{
 	DisplayName: "Bearer Token API",
 }
 
+// NewAPIKeyClient creates a SenseNova client using the OpenAI-compatible
+// chat-completions endpoint. SenseNova also exposes an Anthropic-compatible
+// endpoint, but as of 2026-06 that endpoint reports input_tokens=0 and
+// output_tokens=0 in every SSE event, making context-usage tracking
+// impossible. The OpenAI endpoint honors stream_options.include_usage and
+// returns real counts in the final chunk.
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	baseURL := os.Getenv("SENSENOVA_BASE_URL")
+	baseURL := secret.Resolve("SENSENOVA_BASE_URL")
 	if baseURL == "" {
-		baseURL = "https://token.sensenova.cn"
+		baseURL = "https://token.sensenova.cn/v1"
 	}
 
-	client := anthropicsdk.NewClient(
-		anthropicoption.WithAuthToken(secret.Resolve("SENSENOVA_API_KEY")),
-		anthropicoption.WithBaseURL(baseURL),
-		anthropicoption.WithMaxRetries(0),
+	client := openai.NewClient(
+		option.WithAPIKey(secret.Resolve("SENSENOVA_API_KEY")),
+		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "sensenova:api_key"), nil
 }

--- a/internal/llm/sensenova/catalog.go
+++ b/internal/llm/sensenova/catalog.go
@@ -7,8 +7,15 @@ var catalog = []llm.ModelInfo{
 		ID:               "sensenova-6.7-flash-lite",
 		Name:             "SenseNova 6.7 Flash Lite",
 		DisplayName:      "SenseNova 6.7 Flash Lite",
-		InputTokenLimit:  128000,
+		InputTokenLimit:  256000,
 		OutputTokenLimit: 65536,
+	},
+	{
+		ID:               "deepseek-v4-flash",
+		Name:             "DeepSeek V4 Flash (via SenseNova)",
+		DisplayName:      "DeepSeek V4 Flash",
+		InputTokenLimit:  1_000_000,
+		OutputTokenLimit: 384000,
 	},
 }
 

--- a/internal/llm/sensenova/client.go
+++ b/internal/llm/sensenova/client.go
@@ -1,43 +1,52 @@
-// Package sensenova implements the Provider interface for SenseNova (商汤日日新).
-// SenseNova exposes an Anthropic Messages API-compatible endpoint, so we reuse
-// the Anthropic SDK with a custom base URL.
+// Package sensenova implements the Provider interface for SenseNova (商汤日日新)
+// using the OpenAI-compatible chat-completions endpoint.
+//
+// SenseNova also exposes an Anthropic Messages API-compatible endpoint, but
+// that endpoint reports input_tokens=0 / output_tokens=0 in every SSE event,
+// which makes context-usage tracking impossible. The OpenAI endpoint honors
+// stream_options.include_usage and returns real counts in the final chunk,
+// so we use it via the shared openaicompat layer.
 package sensenova
 
 import (
 	"context"
 
-	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/genai-io/san/internal/llm"
-	anthropicprovider "github.com/genai-io/san/internal/llm/anthropic"
+	"github.com/genai-io/san/internal/llm/openaicompat"
 )
 
-// Client wraps the Anthropic provider client for SenseNova's Messages API.
+// Client implements the Provider interface for SenseNova using the OpenAI SDK.
 type Client struct {
-	inner *anthropicprovider.Client
+	client openai.Client
+	name   string
 }
 
-// NewClient creates a new SenseNova client wrapping the given Anthropic SDK client.
-func NewClient(client anthropicsdk.Client, name string) *Client {
-	return &Client{
-		inner: anthropicprovider.NewClient(client, name),
-	}
+// NewClient creates a new SenseNova client with the given OpenAI SDK client.
+func NewClient(client openai.Client, name string) *Client {
+	return &Client{client: client, name: name}
 }
 
-func (c *Client) Name() string { return c.inner.Name() }
+// Name returns the provider name.
+func (c *Client) Name() string { return c.name }
 
+// Stream sends a completion request and returns a channel of streaming chunks.
 func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
-	return c.inner.Stream(ctx, opts)
+	return openaicompat.StreamChatCompletions(ctx, openaicompat.ChatStreamConfig{
+		Client:           c.client,
+		ProviderName:     c.name,
+		Options:          opts,
+		ConvertAssistant: openaicompat.DefaultAssistantMessage,
+	})
 }
 
 // ListModels returns the static model catalog.
-// Delegating to the inner Anthropic client is not appropriate because:
-//  1. SenseNova may not expose a /v1/models endpoint.
-//  2. On failure, the Anthropic client falls back to Anthropic's own static models,
-//     which are not SenseNova models.
 //
-// If SenseNova adds a model listing API in the future, this method can be updated
-// to fetch dynamically while keeping the static catalog as fallback.
+// The OpenAI /v1/models endpoint on SenseNova returns entries without
+// token-limit fields, so the static catalog is the authoritative source.
+// If SenseNova enriches the listing in the future, this method can fetch
+// dynamically while keeping the static catalog as fallback.
 func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	return StaticModels(), nil
 }

--- a/internal/llm/sensenova/client_test.go
+++ b/internal/llm/sensenova/client_test.go
@@ -3,14 +3,13 @@ package sensenova
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
-	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
-	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
@@ -19,29 +18,38 @@ import (
 // --- Unit tests ---
 
 func TestName(t *testing.T) {
-	c := NewClient(anthropicsdk.NewClient(), "sensenova:api_key")
+	c := NewClient(openai.NewClient(), "sensenova:api_key")
 	if got := c.Name(); got != "sensenova:api_key" {
 		t.Fatalf("Name() = %q, want %q", got, "sensenova:api_key")
 	}
 }
 
 func TestListModelsReturnsStaticCatalog(t *testing.T) {
-	c := NewClient(anthropicsdk.NewClient(), "sensenova:api_key")
+	c := NewClient(openai.NewClient(), "sensenova:api_key")
 	models, err := c.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels() error = %v", err)
 	}
-	if len(models) != 1 {
-		t.Fatalf("expected 1 model, got %d", len(models))
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
 	}
 	if models[0].ID != "sensenova-6.7-flash-lite" {
 		t.Fatalf("expected sensenova-6.7-flash-lite, got %q", models[0].ID)
 	}
-	if models[0].InputTokenLimit != 128000 {
-		t.Fatalf("expected input limit 128000, got %d", models[0].InputTokenLimit)
+	if models[0].InputTokenLimit != 256000 {
+		t.Fatalf("expected input limit 256000, got %d", models[0].InputTokenLimit)
 	}
 	if models[0].OutputTokenLimit != 65536 {
 		t.Fatalf("expected output limit 65536, got %d", models[0].OutputTokenLimit)
+	}
+	if models[1].ID != "deepseek-v4-flash" {
+		t.Fatalf("expected deepseek-v4-flash, got %q", models[1].ID)
+	}
+	if models[1].InputTokenLimit != 1_000_000 {
+		t.Fatalf("expected input limit 1000000, got %d", models[1].InputTokenLimit)
+	}
+	if models[1].OutputTokenLimit != 384000 {
+		t.Fatalf("expected output limit 384000, got %d", models[1].OutputTokenLimit)
 	}
 }
 
@@ -62,11 +70,14 @@ func TestCatalogModel(t *testing.T) {
 
 func TestStaticModels(t *testing.T) {
 	models := StaticModels()
-	if len(models) != 1 {
-		t.Fatalf("expected 1 static model, got %d", len(models))
+	if len(models) != 2 {
+		t.Fatalf("expected 2 static models, got %d", len(models))
 	}
 	if models[0].ID != "sensenova-6.7-flash-lite" {
 		t.Fatalf("expected sensenova-6.7-flash-lite, got %q", models[0].ID)
+	}
+	if models[1].ID != "deepseek-v4-flash" {
+		t.Fatalf("expected deepseek-v4-flash, got %q", models[1].ID)
 	}
 }
 
@@ -92,64 +103,43 @@ func TestProviderImplementsInterface(t *testing.T) {
 	var _ llm.Provider = (*Client)(nil)
 }
 
-// --- Integration tests with mocked SenseNova server ---
+// --- Integration tests with mocked OpenAI-compatible server ---
 
-// senseNovaServer returns an httptest.Server that mimics the SenseNova
-// Anthropic-compatible Messages API.
-func senseNovaServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/v1/messages":
-			handleMessagesEndpoint(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+type sseTransport struct {
+	body   []byte
+	auth   string
+	stream string
 }
 
-func handleMessagesEndpoint(w http.ResponseWriter, r *http.Request) {
-	// Verify Bearer auth
-	auth := r.Header.Get("Authorization")
-	if !strings.HasPrefix(auth, "Bearer ") {
-		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "Forbidden"}})
-		return
+func (t *sseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.auth = req.Header.Get("Authorization")
+	if req.Body != nil {
+		t.body, _ = io.ReadAll(req.Body)
 	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.WriteHeader(http.StatusOK)
-
-	// Send a minimal Anthropic-compatible SSE streaming response
-	events := []string{
-		`event: message_start
-data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"sensenova-6.7-flash-lite","usage":{"input_tokens":10,"output_tokens":0}}}`,
-		`event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
-		`event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}`,
-		`event: content_block_stop
-data: {"type":"content_block_stop","index":0}`,
-		`event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
-		`event: message_stop
-data: {"type":"message_stop"}`,
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(t.stream)),
 	}
-	for _, event := range events {
-		fmt.Fprintf(w, "%s\n\n", event)
-	}
-	if f, ok := w.(http.Flusher); ok {
-		f.Flush()
-	}
+	return resp, nil
 }
+
+// OpenAI-style SSE: deltas followed by a final chunk with usage and [DONE].
+const openAIStreamFixture = `data: {"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello!"},"finish_reason":null}]}
+
+data: {"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":3,"total_tokens":15}}
+
+data: [DONE]
+
+`
 
 func TestStreamIntegration(t *testing.T) {
-	server := senseNovaServer(t)
-	defer server.Close()
-
-	client := anthropicsdk.NewClient(
-		anthropicoption.WithAuthToken("test-key"),
-		anthropicoption.WithBaseURL(server.URL),
+	transport := &sseTransport{stream: openAIStreamFixture}
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	c := NewClient(client, "sensenova:api_key")
 
@@ -161,6 +151,7 @@ func TestStreamIntegration(t *testing.T) {
 	var text string
 	var gotDone bool
 	var gotError error
+	var inputTokens, outputTokens int
 	for chunk := range ch {
 		switch chunk.Type {
 		case llm.ChunkTypeText:
@@ -168,12 +159,8 @@ func TestStreamIntegration(t *testing.T) {
 		case llm.ChunkTypeDone:
 			gotDone = true
 			if chunk.Response != nil {
-				if chunk.Response.StopReason != "end_turn" {
-					t.Errorf("stop_reason = %q, want end_turn", chunk.Response.StopReason)
-				}
-				if chunk.Response.Usage.OutputTokens != 5 {
-					t.Errorf("output_tokens = %d, want 5", chunk.Response.Usage.OutputTokens)
-				}
+				inputTokens = chunk.Response.Usage.InputTokens
+				outputTokens = chunk.Response.Usage.OutputTokens
 			}
 		case llm.ChunkTypeError:
 			gotError = chunk.Error
@@ -189,21 +176,20 @@ func TestStreamIntegration(t *testing.T) {
 	if text != "Hello!" {
 		t.Fatalf("text = %q, want %q", text, "Hello!")
 	}
+	if inputTokens != 12 {
+		t.Errorf("input_tokens = %d, want 12", inputTokens)
+	}
+	if outputTokens != 3 {
+		t.Errorf("output_tokens = %d, want 3", outputTokens)
+	}
 }
 
 func TestStreamSendsBearerAuth(t *testing.T) {
-	var receivedAuth string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "data: [DONE]\n\n")
-	}))
-	defer server.Close()
-
-	client := anthropicsdk.NewClient(
-		anthropicoption.WithAuthToken("test-bearer-key"),
-		anthropicoption.WithBaseURL(server.URL),
+	transport := &sseTransport{stream: "data: [DONE]\n\n"}
+	client := openai.NewClient(
+		option.WithAPIKey("test-bearer-key"),
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
 	)
 	c := NewClient(client, "sensenova:api_key")
 
@@ -214,7 +200,39 @@ func TestStreamSendsBearerAuth(t *testing.T) {
 	for range ch {
 	}
 
-	if receivedAuth != "Bearer test-bearer-key" {
-		t.Fatalf("Authorization header = %q, want %q", receivedAuth, "Bearer test-bearer-key")
+	if transport.auth != "Bearer test-bearer-key" {
+		t.Fatalf("Authorization header = %q, want %q", transport.auth, "Bearer test-bearer-key")
+	}
+}
+
+func TestStreamSendsIncludeUsage(t *testing.T) {
+	transport := &sseTransport{stream: "data: [DONE]\n\n"}
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	c := NewClient(client, "sensenova:api_key")
+
+	ch := c.Stream(context.Background(), llm.CompletionOptions{
+		Model:    "sensenova-6.7-flash-lite",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	for range ch {
+	}
+
+	if len(transport.body) == 0 {
+		t.Fatal("no request body captured")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(transport.body, &payload); err != nil {
+		t.Fatalf("invalid json body: %v", err)
+	}
+	streamOpts, ok := payload["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatal("stream_options missing from request body")
+	}
+	if streamOpts["include_usage"] != true {
+		t.Errorf("stream_options.include_usage = %v, want true", streamOpts["include_usage"])
 	}
 }

--- a/internal/llm/volcengine/catalog.go
+++ b/internal/llm/volcengine/catalog.go
@@ -1,6 +1,8 @@
 package volcengine
 
 import (
+	"strings"
+
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/secret"
 )
@@ -10,10 +12,13 @@ func StaticModels() []llm.ModelInfo {
 	if modelID == "" {
 		return nil
 	}
+	input, output := staticLimits(modelID)
 	return []llm.ModelInfo{{
-		ID:          modelID,
-		Name:        modelID,
-		DisplayName: modelID,
+		ID:               modelID,
+		Name:             modelID,
+		DisplayName:      modelID,
+		InputTokenLimit:  input,
+		OutputTokenLimit: output,
 	}}
 }
 
@@ -24,4 +29,22 @@ func CatalogModel(modelID string) (llm.ModelInfo, bool) {
 		}
 	}
 	return llm.ModelInfo{}, false
+}
+
+// staticLimits returns known context/output windows for Volcengine Doubao
+// model IDs. Doubao model IDs embed the context length as a suffix
+// (e.g. "doubao-pro-256k"); fall back to 256K for seed/latest variants.
+func staticLimits(modelID string) (input, output int) {
+	m := strings.ToLower(modelID)
+	switch {
+	case strings.Contains(m, "256k"):
+		return 256_000, 8_000
+	case strings.Contains(m, "128k"):
+		return 128_000, 8_000
+	case strings.Contains(m, "32k"):
+		return 32_000, 4_000
+	case strings.Contains(m, "seed"), strings.Contains(m, "1.6"):
+		return 256_000, 8_000
+	}
+	return 0, 0
 }

--- a/internal/llm/volcengine/catalog_test.go
+++ b/internal/llm/volcengine/catalog_test.go
@@ -1,0 +1,23 @@
+package volcengine
+
+import "testing"
+
+func TestStaticLimits(t *testing.T) {
+	cases := []struct {
+		model      string
+		wantInput  int
+		wantOutput int
+	}{
+		{"doubao-pro-256k", 256_000, 8_000},
+		{"doubao-pro-128k", 128_000, 8_000},
+		{"doubao-pro-32k", 32_000, 4_000},
+		{"doubao-seed-1.6", 256_000, 8_000},
+		{"unknown-model", 0, 0},
+	}
+	for _, c := range cases {
+		input, output := staticLimits(c.model)
+		if input != c.wantInput || output != c.wantOutput {
+			t.Errorf("staticLimits(%q) = (%d, %d), want (%d, %d)", c.model, input, output, c.wantInput, c.wantOutput)
+		}
+	}
+}

--- a/notes/completed/status-bar-context-usage-plan.md
+++ b/notes/completed/status-bar-context-usage-plan.md
@@ -1,0 +1,1227 @@
+# Status Bar — Real-Time Context Usage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 10-cell context-usage bar with 4-tier color, a compressions badge, and a responsive segment allocator to SAN's TUI status line.
+
+**Architecture:** New `internal/app/conv/status_bar.go` module owns the bar, tier resolver, badge, and allocator. Existing plumbing (`env.InputTokens`, `kit.GetEffectiveInputLimit`, `OnCompacted`) stays; we add an `env.Compressions` counter and a `Compressions` field on `OperationModeParams`.
+
+**Tech Stack:** Go 1.x, `charm.land/lipgloss/v2` for styling, standard `testing` package.
+
+**Spec:** [`status-bar-context-usage.md`](status-bar-context-usage.md) · **PRD:** [`../../status-bar-context-usage-prd.md`](../../status-bar-context-usage-prd.md)
+
+---
+
+## File map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `internal/app/env.go` | Modify | Add `Compressions int` field; zero in `ResetTokens` only |
+| `internal/app/env_test.go` (NEW) | Create | Verify counter survives `ResetContextDisplay`, zeroes on `ResetTokens` |
+| `internal/app/model_compact.go` | Modify | Increment `env.Compressions` in `OnCompacted` |
+| `internal/app/conv/message.go` | Modify | Add `Compressions` to `OperationModeParams`; slim `renderModelWithTokens` to delegate to `status_bar.go` |
+| `internal/app/conv/status_bar.go` | Create | Bar, tier resolver, badge, segment allocator |
+| `internal/app/conv/status_bar_test.go` | Create | Unit tests for the new module |
+| `internal/app/conv/message_test.go` | Modify | Update expected strings; add badge tests |
+| `internal/app/view.go` | Modify | Pass `m.env.Compressions` into `OperationModeParams` |
+
+---
+
+## Task 1: Add `Compressions` counter to `env`
+
+**Files:**
+- Modify: `internal/app/env.go`
+- Create: `internal/app/env_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/app/env_test.go`:
+
+```go
+package app
+
+import "testing"
+
+func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
+	e := &env{Compressions: 3, InputTokens: 100, OutputTokens: 50}
+	e.ResetContextDisplay()
+	if e.Compressions != 3 {
+		t.Errorf("Compressions = %d, want 3 (must survive ResetContextDisplay)", e.Compressions)
+	}
+	if e.InputTokens != 0 || e.OutputTokens != 0 {
+		t.Errorf("InputTokens=%d OutputTokens=%d, want 0/0", e.InputTokens, e.OutputTokens)
+	}
+}
+
+func TestResetTokens_ZeroesCompressions(t *testing.T) {
+	e := &env{Compressions: 5, TurnInputTokens: 80, TurnOutputTokens: 40}
+	e.ResetTokens()
+	if e.Compressions != 0 {
+		t.Errorf("Compressions = %d, want 0 after ResetTokens", e.Compressions)
+	}
+	if e.TurnInputTokens != 0 || e.TurnOutputTokens != 0 {
+		t.Errorf("turn tokens not zeroed: %d/%d", e.TurnInputTokens, e.TurnOutputTokens)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/ -run TestResetContextDisplay_PreservesCompressions -v`
+Expected: compile error — `env.Compressions` undefined.
+
+- [ ] **Step 3: Add the field and update reset methods**
+
+In `internal/app/env.go`, add the field to the `env` struct (after `ConversationCost` around line 40):
+
+```go
+// Compressions counts auto + manual compacts this session. Survives
+// ResetContextDisplay (called per-compact); zeroed only by ResetTokens
+// (called on /reset, /new).
+Compressions int
+```
+
+Update `ResetTokens` (around line 238) to zero it:
+
+```go
+func (m *env) ResetTokens() {
+	m.ResetContextDisplay()
+	m.TurnInputTokens = 0
+	m.TurnOutputTokens = 0
+	m.turnUsageActive = false
+	m.Compressions = 0
+}
+```
+
+Leave `ResetContextDisplay` (around line 232) unchanged — it must NOT zero `Compressions`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/app/ -run 'TestResetContextDisplay_PreservesCompressions|TestResetTokens_ZeroesCompressions' -v`
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/env.go internal/app/env_test.go
+git commit -m "feat(app): add Compressions counter to env
+
+Survives ResetContextDisplay (fires per-compact); zeroed only by
+ResetTokens (/reset, /new). Backs the upcoming status-bar badge."
+```
+
+---
+
+## Task 2: Increment `Compressions` on every compact
+
+**Files:**
+- Modify: `internal/app/model_compact.go:39`
+- Modify: `internal/app/env_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/app/env_test.go`:
+
+```go
+func TestCompressions_StartsAtZero(t *testing.T) {
+	e := &env{}
+	if e.Compressions != 0 {
+		t.Errorf("Compressions = %d, want 0 at session start", e.Compressions)
+	}
+}
+```
+
+This is a guard against future regressions of the default value. The increment behavior itself is exercised in the manual smoke test (Task 10) since `OnCompacted` requires a fully-wired `model` that's expensive to construct in a unit test.
+
+- [ ] **Step 2: Run test to verify it passes (no impl change needed yet)**
+
+Run: `go test ./internal/app/ -run TestCompressions_StartsAtZero -v`
+Expected: PASS (zero-value default).
+
+- [ ] **Step 3: Add the increment line in `OnCompacted`**
+
+In `internal/app/model_compact.go`, inside `OnCompacted` (line 39), add the increment immediately after `m.env.ResetContextDisplay()`:
+
+```go
+func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
+	scrollbackCmds := m.commitAllMessages()
+
+	m.conv.Clear()
+	m.env.ResetContextDisplay()
+	m.env.Compressions++
+	token := m.userInput.Provider.SetStatusMessage("compacted")
+	// ... rest unchanged
+}
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `go build ./internal/app/...`
+Expected: no errors.
+
+- [ ] **Step 5: Run package tests to verify no regression**
+
+Run: `go test ./internal/app/...`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/app/model_compact.go internal/app/env_test.go
+git commit -m "feat(app): increment Compressions on every compact
+
+OnCompacted fires for both auto and manual compact; bump the counter
+there so the upcoming status-bar badge reflects lifetime compactions."
+```
+
+---
+
+## Task 3: Add `Compressions` field to `OperationModeParams` and wire through `view.go`
+
+**Files:**
+- Modify: `internal/app/conv/message.go:32`
+- Modify: `internal/app/view.go:243`
+
+- [ ] **Step 1: Add the field to the params struct**
+
+In `internal/app/conv/message.go`, extend `OperationModeParams` (line 32):
+
+```go
+type OperationModeParams struct {
+	Mode             setting.OperationMode
+	InputTokens      int
+	OutputTokens     int
+	InputLimit       int
+	ModelName        string
+	StatusMessage    string
+	ConversationCost llm.Money
+	Compressions     int  // NEW — session compact count, drives the badge
+	Width            int
+	ThinkingEffort   string
+	ShowThinking     bool
+	QueueCount       int
+}
+```
+
+- [ ] **Step 2: Pass it from the call site**
+
+In `internal/app/view.go`, inside `renderModeStatus` (line 242), add the new field to the literal:
+
+```go
+return conv.RenderModeStatus(conv.OperationModeParams{
+	Mode:             m.env.OperationMode,
+	InputTokens:      m.env.InputTokens,
+	OutputTokens:     m.env.OutputTokens,
+	InputLimit:       kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),
+	ModelName:        modelName,
+	StatusMessage:    m.userInput.Provider.StatusMessage,
+	ConversationCost: m.env.ConversationCost,
+	Compressions:     m.env.Compressions,
+	Width:            m.env.Width,
+	ThinkingEffort:   thinkingEffort,
+	ShowThinking:     showThinking,
+	QueueCount:       m.userInput.Queue.Len(),
+})
+```
+
+- [ ] **Step 3: Build and run existing conv tests**
+
+Run: `go build ./... && go test ./internal/app/conv/...`
+Expected: build clean; existing tests PASS (the new field defaults to 0, no behavior change yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/app/conv/message.go internal/app/view.go
+git commit -m "feat(tui): thread Compressions through OperationModeParams
+
+Plumbing only — no rendering change. The new field reaches the status
+bar via the existing renderModeStatus call site."
+```
+
+---
+
+## Task 4: Implement `classifyContextTier` and tier styling
+
+**Files:**
+- Create: `internal/app/conv/status_bar.go`
+- Create: `internal/app/conv/status_bar_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/app/conv/status_bar_test.go`:
+
+```go
+package conv
+
+import "testing"
+
+func TestClassifyContextTier_Boundaries(t *testing.T) {
+	cases := []struct {
+		pct float64
+		want contextTier
+	}{
+		{0, tierGood},      // empty context
+		{49, tierGood},     // just under warn
+		{50, tierGood},     // PRD §7.2: 50 stays good
+		{50.01, tierWarn},  // just past good
+		{51, tierWarn},
+		{79, tierWarn},
+		{80, tierWarn},     // PRD §7.2 off-by-one: 80 stays warn
+		{81, tierBad},      // only >80 is bad
+		{94, tierBad},
+		{94.99, tierBad},
+		{95, tierCritical}, // PRD §7.2: ≥95 is critical
+		{100, tierCritical},
+		{120, tierCritical}, // clamp handled upstream; classifier still critical
+	}
+	for _, c := range cases {
+		got := classifyContextTier(c.pct)
+		if got != c.want {
+			t.Errorf("classifyContextTier(%.2f) = %v, want %v", c.pct, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/conv/ -run TestClassifyContextTier_Boundaries -v`
+Expected: compile error — `classifyContextTier` and the `contextTier` constants undefined.
+
+- [ ] **Step 3: Implement the classifier and constants**
+
+Create `internal/app/conv/status_bar.go`:
+
+```go
+// Package conv: status-bar components — context bar, color tiers,
+// compressions badge, and the responsive segment allocator. Pure
+// functions over primitives; the orchestrator (RenderModeStatus) wires
+// them to env state.
+package conv
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/genai-io/san/internal/app/kit"
+)
+
+// Threshold percentages for the 4 PRD §7.2 color tiers.
+const (
+	pctGood     = 50.0
+	pctWarn     = 80.0
+	pctCritical = 95.0
+
+	// contextBarWidth is the cell count for the visual bar (PRD §7.1).
+	contextBarWidth = 10
+)
+
+// contextTier classifies a context-window fill percentage into one of
+// the 4 PRD §7.2 tiers. Off-by-one preserved: 80 itself falls into warn,
+// only strictly-greater-than-80 is bad. ≥95 is critical.
+type contextTier int
+
+const (
+	tierNone contextTier = iota // pct unknown — denominator missing
+	tierGood                    // [0, 50]    healthy
+	tierWarn                    // (50, 80]   watch
+	tierBad                     // (80, 95)   pressure
+	tierCritical                // [95, 100+] imminent compression
+)
+
+// classifyContextTier maps a clamped percentage to its tier. Callers
+// must clamp pct to [0, 100] before calling; values >100 still classify
+// as critical (defensive).
+func classifyContextTier(pct float64) contextTier {
+	switch {
+	case pct < pctGood:
+		return tierGood
+	case pct <= pctWarn: // 50 < pct ≤ 80
+		return tierWarn
+	case pct < pctCritical: // 80 < pct < 95
+		return tierBad
+	default: // pct ≥ 95
+		return tierCritical
+	}
+}
+
+// style resolves a tier to a lipgloss style composed from existing
+// theme tokens (per project decision: no new theme infrastructure).
+func (t contextTier) style() lipgloss.Style {
+	switch t {
+	case tierGood:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
+	case tierWarn:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+	case tierBad:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+	case tierCritical:
+		// Critical = Error + Bold. Distinct from "bad" without adding a
+		// new theme token.
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error).Bold(true)
+	default: // tierNone
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	}
+}
+
+// silence unused-import errors until later tasks add callers of fmt/strings.
+var _, _ = fmt.Sprintf, strings.Repeat
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/app/conv/ -run TestClassifyContextTier_Boundaries -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/conv/status_bar.go internal/app/conv/status_bar_test.go
+git commit -m "feat(tui): add 4-tier context classifier
+
+PRD §7.2 boundaries (50/80/95) with the exact off-by-one: 80 stays warn,
+only >80 is bad. Styles compose from existing theme tokens."
+```
+
+---
+
+## Task 5: Implement `RenderContextBar`
+
+**Files:**
+- Modify: `internal/app/conv/status_bar.go`
+- Modify: `internal/app/conv/status_bar_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/app/conv/status_bar_test.go`:
+
+```go
+func TestRenderContextBar_FillLevels(t *testing.T) {
+	cases := []struct {
+		name     string
+		used     int
+		limit    int
+		wantFill int // expected number of '█' characters
+		wantPct  string
+	}{
+		{"empty", 0, 200000, 0, "0%"},
+		{"half", 100000, 200000, 5, "50%"},
+		{"near-full", 190000, 200000, 10, "95%"}, // 95% rounds to 10 cells (9.5 → 10)
+		{"full", 200000, 200000, 10, "100%"},
+		{"oversend-clamped", 240000, 200000, 10, "100%"}, // pct > 100 clamped
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderContextBar(c.used, c.limit)
+			if strings.Count(got, "█") != c.wantFill {
+				t.Errorf("fill cells = %d, want %d (rendered: %q)", strings.Count(got, "█"), c.wantFill, got)
+			}
+			if !strings.Contains(got, c.wantPct) {
+				t.Errorf("pct label %q missing from %q", c.wantPct, got)
+			}
+		})
+	}
+}
+
+func TestRenderContextBar_NoLimit(t *testing.T) {
+	got := RenderContextBar(100, 0)
+	if !strings.Contains(got, "--") {
+		t.Errorf("missing '--' label for unknown limit; got %q", got)
+	}
+	// No fill cells when denominator is unknown.
+	if strings.Contains(got, "█") {
+		t.Errorf("should not render fill cells for unknown limit; got %q", got)
+	}
+}
+
+func TestRenderContextBar_NoNegativePercent(t *testing.T) {
+	// Defensive: callers should pass non-negative, but the renderer
+	// must never emit a negative percentage.
+	got := RenderContextBar(-1, 200000)
+	if strings.Contains(got, "-") {
+		t.Errorf("negative percent rendered: %q", got)
+	}
+}
+```
+
+(Also add `"strings"` to the import block at the top of the test file.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/app/conv/ -run 'TestRenderContextBar_' -v`
+Expected: compile error — `RenderContextBar` undefined.
+
+- [ ] **Step 3: Implement `RenderContextBar`**
+
+In `internal/app/conv/status_bar.go`, remove the `var _, _ = fmt.Sprintf, strings.Repeat` placeholder line and add:
+
+```go
+// RenderContextBar renders the 10-cell bar with a percentage label:
+//
+//	"[██████░░░░] 71%"   normal case
+//	"[----------] --"    when limit is 0 (unknown)
+//
+// The percentage is rounded to an integer at this layer (PRD §4.2); the
+// engine itself never rounds. `used` is clamped to [0, limit] before
+// computing pct so callers cannot accidentally render negatives or >100%.
+func RenderContextBar(used, limit int) string {
+	if limit <= 0 {
+		dim := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+		return dim.Render("[" + strings.Repeat("-", contextBarWidth) + "] --")
+	}
+	if used < 0 {
+		used = 0
+	}
+	pct := float64(used) / float64(limit) * 100
+	if pct > 100 {
+		pct = 100
+	}
+	filled := int((pct / 100) * float64(contextBarWidth) + 0.5) // round to nearest cell
+	if filled > contextBarWidth {
+		filled = contextBarWidth
+	}
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", contextBarWidth-filled)
+	style := classifyContextTier(pct).style()
+	return style.Render(fmt.Sprintf("[%s] %d%%", bar, int(pct+0.5)))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/app/conv/ -run 'TestRenderContextBar_' -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/conv/status_bar.go internal/app/conv/status_bar_test.go
+git commit -m "feat(tui): render 10-cell context bar
+
+PRD §7.1: █/░ cells inside brackets with integer percent label. Color
+tier applied via classifyContextTier. Unknown limit renders '--' dim."
+```
+
+---
+
+## Task 6: Implement `RenderContextLabel`
+
+**Files:**
+- Modify: `internal/app/conv/status_bar.go`
+- Modify: `internal/app/conv/status_bar_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/app/conv/status_bar_test.go`:
+
+```go
+func TestRenderContextLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		used  int
+		limit int
+		want  string
+	}{
+		{"compact", 142_000, 200_000, "ctx 142K/200K"},
+		{"millions", 1_500_000, 2_000_000, "ctx 1.5M/2M"},
+		{"unknown-limit", 5000, 0, "ctx --/200K"}, // used shown, limit dim
+		{"zero-used", 0, 200_000, "ctx 0/200K"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderContextLabel(c.used, c.limit)
+			visible := stripANSI(got)
+			if visible != c.want {
+				t.Errorf("RenderContextLabel(%d, %d) visible = %q, want %q (raw: %q)", c.used, c.limit, visible, c.want, got)
+			}
+		})
+	}
+}
+```
+
+Add the ANSI-stripping helper to the test file (Lipgloss sets color codes that interfere with substring checks):
+
+```go
+// stripANSI removes ANSI escape sequences so tests can compare visible text.
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRegexp.ReplaceAllString(s, "")
+}
+```
+
+Add `"regexp"` to the test file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/conv/ -run TestRenderContextLabel -v`
+Expected: compile error — `RenderContextLabel` and `stripANSI` undefined.
+
+- [ ] **Step 3: Implement `RenderContextLabel`**
+
+In `internal/app/conv/status_bar.go`, add:
+
+```go
+// RenderContextLabel renders the "ctx X/Y" segment using compact
+// humanized numbers (PRD §7.4). Limit renders as "--" when unknown.
+func RenderContextLabel(used, limit int) string {
+	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	if limit <= 0 {
+		return muted.Render(fmt.Sprintf("ctx %s/--", kit.FormatTokenCount(used)))
+	}
+	return muted.Render(fmt.Sprintf("ctx %s/%s", kit.FormatTokenCount(used), kit.FormatTokenCount(limit)))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/app/conv/ -run TestRenderContextLabel -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/conv/status_bar.go internal/app/conv/status_bar_test.go
+git commit -m "feat(tui): render ctx X/Y label segment
+
+Compact humanized format via kit.FormatTokenCount. Renders 'ctx X/--'
+when the model's context length is unknown."
+```
+
+---
+
+## Task 7: Implement `RenderCompressionsBadge` and `compressionBadgeStyle`
+
+**Files:**
+- Modify: `internal/app/conv/status_bar.go`
+- Modify: `internal/app/conv/status_bar_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/app/conv/status_bar_test.go`:
+
+```go
+func TestRenderCompressionsBadge(t *testing.T) {
+	cases := []struct {
+		name    string
+		n       int
+		visible string // empty means badge should not render
+	}{
+		{"zero-hidden", 0, ""},
+		{"one", 1, "🗜️ 1"},
+		{"four-dim", 4, "🗜️ 4"},
+		{"five-warn", 5, "🗜️ 5"},
+		{"nine-warn", 9, "🗜️ 9"},
+		{"ten-error", 10, "🗜️ 10"},
+		{"twenty-error", 20, "🗜️ 20"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RenderCompressionsBadge(c.n)
+			visible := stripANSI(got)
+			if c.visible == "" {
+				if got != "" {
+					t.Errorf("RenderCompressionsBadge(%d) = %q, want empty", c.n, got)
+				}
+				return
+			}
+			if visible != c.visible {
+				t.Errorf("RenderCompressionsBadge(%d) visible = %q, want %q", c.n, visible, c.visible)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/conv/ -run TestRenderCompressionsBadge -v`
+Expected: compile error — `RenderCompressionsBadge` undefined.
+
+- [ ] **Step 3: Implement the badge**
+
+In `internal/app/conv/status_bar.go`, add:
+
+```go
+// compressionBadgeStyle escalates color with count (PRD §7.5):
+//
+//	<5     muted
+//	5–9    warn
+//	≥10    error
+func compressionBadgeStyle(n int) lipgloss.Style {
+	switch {
+	case n >= 10:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+	case n >= 5:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+	default:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	}
+}
+
+// RenderCompressionsBadge returns the "🗜️ N" badge or "" when n ≤ 0.
+// Color escalates per compressionBadgeStyle.
+func RenderCompressionsBadge(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return compressionBadgeStyle(n).Render(fmt.Sprintf("🗜️ %d", n))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/app/conv/ -run TestRenderCompressionsBadge -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/conv/status_bar.go internal/app/conv/status_bar_test.go
+git commit -m "feat(tui): add compressions badge
+
+PRD §7.5: '🗜️ N' shown only when N>0, with color escalation at 5 and 10."
+```
+
+---
+
+## Task 8: Implement `statusSegment` and `AllocateStatusSegments`
+
+**Files:**
+- Modify: `internal/app/conv/status_bar.go`
+- Modify: `internal/app/conv/status_bar_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/app/conv/status_bar_test.go`:
+
+```go
+func TestAllocateStatusSegments_DropsInPriorityOrder(t *testing.T) {
+	// Priorities: 1=highest (drops last), 4=lowest (drops first).
+	segments := []statusSegment{
+		{render: func() string { return "[bar] 71%" }, width: 11, priority: 1},
+		{render: func() string { return "ctx 142K/200K" }, width: 14, priority: 2},
+		{render: func() string { return "🗜️ 2" }, width: 5, priority: 3},
+		{render: func() string { return "$0.04" }, width: 5, priority: 4},
+	}
+
+	// Wide: everything fits with separators.
+	got := AllocateStatusSegments(segments, 100)
+	for _, s := range segments {
+		if !strings.Contains(got, stripANSI(s.render())) {
+			t.Errorf("wide: segment %q dropped from %q", stripANSI(s.render()), got)
+		}
+	}
+
+	// Narrow (~30 cols): lowest-priority segments drop first.
+	got = AllocateStatusSegments(segments, 30)
+	if !strings.Contains(got, "[bar] 71%") {
+		t.Errorf("priority-1 segment should survive at width 30; got %q", got)
+	}
+	if strings.Contains(got, "$0.04") {
+		t.Errorf("priority-4 (cost) should drop first at width 30; got %q", got)
+	}
+}
+
+func TestAllocateStatusSegments_NeverTruncatesMidSegment(t *testing.T) {
+	segments := []statusSegment{
+		{render: func() string { return "exactly12ch" }, width: 11, priority: 1},
+	}
+	// Just enough room.
+	got := AllocateStatusSegments(segments, 11)
+	if !strings.Contains(got, "exactly12ch") {
+		t.Errorf("segment should fit at width=its own width; got %q", got)
+	}
+	// One col too narrow.
+	got = AllocateStatusSegments(segments, 10)
+	if strings.Contains(got, "exactly12") {
+		t.Errorf("segment must drop, not truncate, when it doesn't fit; got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/app/conv/ -run 'TestAllocateStatusSegments_' -v`
+Expected: compile error — `statusSegment` and `AllocateStatusSegments` undefined.
+
+- [ ] **Step 3: Implement the type and allocator**
+
+In `internal/app/conv/status_bar.go`, add:
+
+```go
+// segmentSep is the visible separator inserted between surviving segments.
+const segmentSep = "  " // two spaces — wider than a single space to read as a gap
+
+// statusSegment is a unit the allocator can keep or drop atomically.
+// Lower priority drops first when width is constrained (PRD §8.3).
+type statusSegment struct {
+	render   func() string // lazy — only invoked if the segment survives
+	width    int           // precomputed visible width (excluding separators)
+	priority int           // 1 = highest (drops last); larger = drops first
+}
+
+// AllocateStatusSegments walks segments in priority order, keeping each
+// segment that fits in the remaining budget plus its leading separator.
+// Segments are never truncated mid-render. Returns the joined string.
+//
+// "Fits" means: width(remaining segments in priority order, including
+// separators between them) ≤ availableWidth. We walk greedily from
+// highest priority to lowest, subtracting each accepted segment's width
+// (and a separator) from the budget.
+func AllocateStatusSegments(segments []statusSegment, availableWidth int) string {
+	if availableWidth <= 0 || len(segments) == 0 {
+		return ""
+	}
+	// Sort by priority ascending (1 first). Stable so equal-priority
+	// segments keep their original order.
+	order := make([]int, len(segments))
+	for i := range order {
+		order[i] = i
+	}
+	// Insertion sort — n is tiny (≤6 segments in practice).
+	for i := 1; i < len(order); i++ {
+		for j := i; j > 0 && segments[order[j-1]].priority > segments[order[j]].priority {
+			order[j-1], order[j] = order[j], order[j-1]
+		}
+	}
+
+	type kept struct {
+		idx    int
+		render string
+		width  int
+	}
+	var survivors []kept
+	budget := availableWidth
+	for _, idx := range order {
+		s := segments[idx]
+		need := s.width
+		if len(survivors) > 0 {
+			need += len(segmentSep)
+		}
+		if need > budget {
+			continue
+		}
+		survivors = append(survivors, kept{idx: idx, render: s.render(), width: s.width})
+		budget -= need
+	}
+
+	// Re-emit in the original (caller-supplied) order so the layout reads
+	// naturally regardless of priority.
+	byIdx := make(map[int]int, len(survivors))
+	for i, k := range survivors {
+		byIdx[k.idx] = i
+	}
+	out := make([]string, 0, len(survivors))
+	for origIdx := range segments {
+		if i, ok := byIdx[origIdx]; ok {
+			out = append(out, survivors[i].render)
+		}
+	}
+	return strings.Join(out, segmentSep)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/app/conv/ -run 'TestAllocateStatusSegments_' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/conv/status_bar.go internal/app/conv/status_bar_test.go
+git commit -m "feat(tui): add tail-budget segment allocator
+
+PRD §8.3: walks segments in priority order, drops lowest-priority first
+when width-constrained. Never truncates mid-segment. Reassembles in
+caller-supplied order so layout reads naturally."
+```
+
+---
+
+## Task 9: Wire `status_bar.go` into `RenderModeStatus`
+
+**Files:**
+- Modify: `internal/app/conv/message.go` (lines 47–111, 23–24)
+- Modify: `internal/app/conv/message_test.go`
+
+- [ ] **Step 1: Update existing tests to expect the new layout**
+
+In `internal/app/conv/message_test.go`, find `TestRenderModeStatusShowsTokenUsageWithModel` (around line 92) and update the expected substring. The right-side cluster now contains the bar instead of `(NN%)`:
+
+```go
+func TestRenderModeStatusShowsTokenUsageWithModel(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:   "claude-sonnet-4-6",
+		InputTokens: 142000,
+		InputLimit:  200000,
+		Width:       120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "claude-sonnet-4-6") {
+		t.Fatalf("RenderModeStatus() = %q, want model name", visible)
+	}
+	if !strings.Contains(visible, "[") || !strings.Contains(visible, "] 71%") {
+		t.Fatalf("RenderModeStatus() = %q, want bar with percent", visible)
+	}
+	// Old per-call percent format must NOT appear anymore.
+	if strings.Contains(visible, "(71%)") {
+		t.Fatalf("RenderModeStatus() = %q, should not contain old (NN%%) format", visible)
+	}
+}
+```
+
+Find `TestRenderModeStatusKeepsContextDisplayOnRightOnly` (around line 117) and update it to verify the bar appears once (not the old bare percent):
+
+```go
+func TestRenderModeStatusKeepsContextDisplayOnRightOnly(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:   "claude-sonnet-4-6",
+		InputTokens: 142000,
+		InputLimit:  200000,
+		Width:       120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "claude-sonnet-4-6") {
+		t.Fatalf("want model name in %q", visible)
+	}
+	// Bar should appear exactly once.
+	if strings.Count(visible, "] ") != 1 && strings.Count(visible, "%") != 1 {
+		t.Fatalf("want unified context display (single bar + percent) in %q", visible)
+	}
+	if !strings.Contains(visible, "compact at") && !strings.Contains(visible, "auto-compact") {
+		t.Fatalf("want auto-compact hint in %q", visible)
+	}
+}
+```
+
+(If these tests already use a different helper name to strip ANSI, use that. If not, add the same `stripANSI`/`ansiRegexp` helper to `message_test.go` or refactor it into a shared `testutil_test.go`.)
+
+Add two new tests:
+
+```go
+func TestRenderModeStatusShowsCompressionsBadgeWhenNonZero(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:    "claude-sonnet-4-6",
+		InputTokens:  1000,
+		InputLimit:   200000,
+		Compressions: 3,
+		Width:        120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "🗜️ 3") {
+		t.Fatalf("want '🗜️ 3' badge in %q", visible)
+	}
+}
+
+func TestRenderModeStatusHidesBadgeWhenZero(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:    "claude-sonnet-4-6",
+		InputTokens:  1000,
+		InputLimit:   200000,
+		Compressions: 0,
+		Width:        120,
+	})
+	visible := stripANSI(rendered)
+	if strings.Contains(visible, "🗜️") {
+		t.Fatalf("badge should be hidden when zero; got %q", visible)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/app/conv/ -run 'TestRenderModeStatus' -v`
+Expected: FAIL — old `(NN%)` format still rendered, badge missing.
+
+- [ ] **Step 3: Replace `renderModelWithTokens` with a segment-based orchestrator**
+
+In `internal/app/conv/message.go`:
+
+1. Update the constant block (lines 19–29) — drop the old `autoCompactThreshold` and rely on `pctCritical` from `status_bar.go`:
+
+```go
+const (
+	// minWrapWidth is the minimum markdown wrap width.
+	minWrapWidth = 40
+
+	// agentContentIndent is the extra indent for agent prompt/response content
+	// beyond toolResultExpandedStyle's PaddingLeft(4). Total indent = 4 + 4 = 8 chars.
+	agentContentIndent = "    "
+)
+```
+
+2. Replace the body of `renderModelWithTokens` (lines 76–111) with a thin delegate:
+
+```go
+// renderModelWithTokens composes the right-side cluster of the status
+// bar: model name, context label, bar, optional compressions badge,
+// optional cost. The actual rendering lives in status_bar.go; this
+// function preserves the existing call shape from RenderModeStatus.
+func renderModelWithTokens(
+	modelName, statusMessage string,
+	inputTokens, inputLimit int,
+	conversationCost llm.Money,
+	compressions int,
+	width int,
+) string {
+	if modelName == "" {
+		return ""
+	}
+	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	sep := muted.Render(" · ")
+
+	// Pre-render once; lipgloss.Width strips ANSI automatically so we
+	// can measure the styled output directly without a helper.
+	labelText := ""
+	barText := ""
+	if inputLimit > 0 {
+		labelText = RenderContextLabel(inputTokens, inputLimit)
+		barText = RenderContextBar(inputTokens, inputLimit)
+		if hint := compactStatusHint(float64(inputTokens) / float64(inputLimit) * 100); hint != "" {
+			barText += sep + muted.Render(hint)
+		}
+	}
+	badgeText := RenderCompressionsBadge(compressions)
+	costText := ""
+	if !conversationCost.IsZero() {
+		costText = muted.Render(kit.FormatMoney(conversationCost))
+	}
+
+	segments := []statusSegment{
+		{render: func() string { return muted.Render(modelName) }, width: lipgloss.Width(modelName), priority: 1},
+	}
+	if statusMessage != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return muted.Render(statusMessage) },
+			width:    lipgloss.Width(statusMessage),
+			priority: 2,
+		})
+	}
+	if labelText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return labelText },
+			width:    lipgloss.Width(labelText),
+			priority: 3,
+		})
+		segments = append(segments, statusSegment{
+			render:   func() string { return barText },
+			width:    lipgloss.Width(barText),
+			priority: 4,
+		})
+	}
+	if badgeText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return badgeText },
+			width:    lipgloss.Width(badgeText),
+			priority: 5,
+		})
+	}
+	if costText != "" {
+		segments = append(segments, statusSegment{
+			render:   func() string { return costText },
+			width:    lipgloss.Width(costText),
+			priority: 6,
+		})
+	}
+
+	// AllocateStatusSegments joins survivors with its internal two-space
+	// separator; we swap that for " · " to match the existing aesthetic.
+	allocated := AllocateStatusSegments(segments, width)
+	parts := strings.Split(allocated, segmentSep)
+	return strings.Join(parts, sep)
+}
+```
+
+(No `stripStylingForWidth` helper or new import needed — `lipgloss.Width` strips ANSI codes itself, so we measure the styled output directly.)
+
+3. Update the call site in `RenderModeStatus` (line 66) to pass the new args:
+
+```go
+right := renderModelWithTokens(
+	params.ModelName, params.StatusMessage,
+	params.InputTokens, params.InputLimit,
+	params.ConversationCost,
+	params.Compressions,
+	params.Width,
+)
+```
+
+4. Update `RenderTokenWarning` (lines 182–204) to use `pctCritical` and `pctWarn` instead of the old `autoCompactThreshold`:
+
+```go
+func RenderTokenWarning(inputTokens, inputLimit int, compactSuppressed bool) string {
+	if inputLimit == 0 || inputTokens == 0 || compactSuppressed {
+		return ""
+	}
+	percent := float64(inputTokens) / float64(inputLimit) * 100
+	if percent < pctWarn {
+		return ""
+	}
+	untilCompact := max(int(pctCritical-percent), 0)
+	if percent >= pctCritical {
+		style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+		return "  " + style.Render(fmt.Sprintf("⚠ Context nearly full (%d%% used) — auto-compact imminent", int(percent)))
+	}
+	if percent > pctWarn {
+		style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
+		return "  " + style.Render(fmt.Sprintf("⚡ %d%% until auto-compact", untilCompact))
+	}
+	return ""
+}
+```
+
+(Note: this preserves the off-by-one — exactly 80 no longer triggers the warning, only `>80` does.)
+
+5. Update `compactStatusHint` (lines 129–138):
+
+```go
+func compactStatusHint(percent float64) string {
+	switch {
+	case percent >= pctCritical:
+		return "auto-compact"
+	case percent > pctWarn:
+		return fmt.Sprintf("compact at %d%%", int(pctCritical))
+	default:
+		return ""
+	}
+}
+```
+
+- [ ] **Step 4: Run all conv tests**
+
+Run: `go test ./internal/app/conv/... -v`
+Expected: all PASS, including updated `TestRenderModeStatus*` tests and the two new badge tests.
+
+- [ ] **Step 5: Run the full app test suite**
+
+Run: `go test ./internal/app/...`
+Expected: all PASS.
+
+- [ ] **Step 6: Build the whole project**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/app/conv/message.go internal/app/conv/message_test.go internal/app/conv/status_bar.go
+git commit -m "feat(tui): wire status_bar module into RenderModeStatus
+
+renderModelWithTokens now composes a segment list and routes through
+AllocateStatusSegments, yielding [bar] NN% + ctx X/Y + compressions
+badge + cost. Drops the local autoCompactThreshold constant in favor
+of pctCritical/pctWarn from status_bar.go."
+```
+
+---
+
+## Task 10: Acceptance verification
+
+**Files:**
+- Modify: `notes/active/status-bar-context-usage.md` (acceptance checkboxes)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 2: Run vet and gofmt**
+
+Run: `go vet ./... && gofmt -l internal/app/`
+Expected: vet clean; gofmt lists no files (empty output).
+
+If gofmt lists files, run `gofmt -w <file>` and amend the relevant commit (or new "style: gofmt" commit).
+
+- [ ] **Step 3: Build the binary**
+
+Run: `go build -o /tmp/san-statusbar ./cmd/san`
+Expected: clean build.
+
+- [ ] **Step 4: Manual smoke at three widths**
+
+Run the binary against a real model in three terminal sizes:
+
+1. **Wide (≥96 cols):**
+   - Send a message, wait for response.
+   - Confirm status bar shows: `{mode}    {model}  ctx X/Y [██████░░░░] NN%  🗜️ N  $cost`
+   - After `/compact`, confirm `🗜️ 1` appears and bar resets to `0%`.
+
+2. **Medium (~80 cols):**
+   - Resize terminal.
+   - Confirm cost and badge drop first; bar and percent remain.
+
+3. **Narrow (~40 cols):**
+   - Confirm bar and label hide; bare `NN%` shows next to model.
+
+- [ ] **Step 5: Verify acceptance criteria**
+
+In `notes/active/status-bar-context-usage.md`, tick each box in the "Acceptance criteria" section that the smoke test confirmed:
+
+- [x] After every assistant turn, bar reflects `env.InputTokens / InputLimit`.
+- [x] Color flips at exactly 50 / 80 / 95 (80 stays warn, only `>80` is bad).
+- [x] No negative percentages ever render.
+- [x] Status bar fits on a single row at every column width from 40 to 200.
+- [x] At `cols < 52`, bar hides and only `NN%` shows.
+- [x] `/reset` returns the bar to `0%` and clears the compressions badge.
+- [x] Switching models updates the denominator within one turn.
+- [x] `🗜️ N` appears only after the first compact, never at session start.
+- [x] `go test ./internal/app/...` is green.
+
+- [ ] **Step 6: Move plan to completed**
+
+Once all criteria pass, move the plan and spec from `notes/active/` to `notes/completed/`:
+
+```bash
+git mv notes/active/status-bar-context-usage.md notes/completed/
+git mv notes/active/status-bar-context-usage-plan.md notes/completed/
+```
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add notes/active/status-bar-context-usage.md notes/completed/status-bar-context-usage.md notes/completed/status-bar-context-usage-plan.md
+git commit -m "docs: mark status-bar feature complete
+
+Acceptance criteria verified; moves plan and spec from notes/active/ to
+notes/completed/ per repo convention."
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec section | Covered by task(s) |
+|---|---|
+| §4 Components — `classifyContextTier` | Task 4 |
+| §4 Components — `RenderContextBar` | Task 5 |
+| §4 Components — `RenderContextLabel` | Task 6 |
+| §4 Components — `RenderCompressionsBadge` | Task 7 |
+| §4 Components — `AllocateStatusSegments` | Task 8 |
+| §5 `env.Compressions` field + reset semantics | Task 1 |
+| §5 Increment on `OnCompacted` | Task 2 |
+| §5 `OperationModeParams` plumbing | Task 3 |
+| §5 Lifecycle boundaries (re-render on every tea.Msg) | Already exists; verified in Task 10 |
+| §6 Edge cases (no-limit, oversend clamp, post-compact, etc.) | Tasks 5, 7, 10 |
+| §7 Testing | Tasks 1–8 (TDD inline) + Task 10 smoke |
+| §8 Acceptance criteria | Task 10 |
+| §9 Files touched | All seven files appear in tasks above |
+
+No spec gaps.
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or unspecified code blocks. Every code step shows the actual code; every test step shows the actual test.
+
+**Type consistency:**
+- `contextTier` enum defined in Task 4, used in Tasks 4 and 5.
+- `statusSegment` struct defined in Task 8, used in Task 9.
+- Function names match across tasks: `RenderContextBar`, `RenderContextLabel`, `RenderCompressionsBadge`, `AllocateStatusSegments`, `classifyContextTier`, `compressionBadgeStyle`.
+- `pctGood` / `pctWarn` / `pctCritical` constants defined in Task 4, used in Tasks 5, 7, 9.
+- `segmentSep` defined in Task 8, referenced in Task 9.
+
+No naming drift.

--- a/notes/completed/status-bar-context-usage.md
+++ b/notes/completed/status-bar-context-usage.md
@@ -1,0 +1,260 @@
+# Status Bar — Real-Time Context Usage
+
+Port of the Hermes-authored PRD at [`../../status-bar-context-usage-prd.md`](../../status-bar-context-usage-prd.md):
+a permanent single-line status bar that shows context-window fill as a 10-cell
+bar with 4 color tiers, plus a compressions badge. SAN already implements
+~80% of the plumbing — this plan covers the rendering layer plus a new
+compressions counter.
+
+## Context
+
+Existing pieces in SAN that the PRD's "backend contract" maps onto:
+
+- **Numerator:** `env.InputTokens` (`internal/app/env.go:31`), updated per LLM
+  response in `OnTokenUsage` (`internal/app/model_agent_events.go:45`).
+- **Denominator:** `kit.GetEffectiveInputLimit()` via `env.CurrentModel`
+  (`internal/app/view.go:246`).
+- **Cost:** `env.ConversationCost`, accumulated in `OnTokenUsage`.
+- **Status line:** `renderModeStatus` → `conv.RenderModeStatus` →
+  `renderModelWithTokens` (`internal/app/conv/message.go:76`) already renders
+  `{model} · {tokens}/{limit} ({pct}%) · {hint}`.
+- **Compact handling:** `OnCompacted` (`internal/app/model_compact.go:39`)
+  calls `env.ResetContextDisplay()`.
+- **Auto-compact trigger:** `NeedsCompaction`
+  (`internal/core/message.go:293`) fires at 95%.
+- **Humanized format:** `kit.FormatTokenCount` exists.
+- **Width-aware rendering:** `RenderModeStatus` already takes `Width`.
+
+What's missing: the visual bar, 4-tier color (currently 3 at 85/95),
+compressions counter and badge, responsive segment allocator.
+
+## Decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Scope | Full PRD | All four pieces: bar, tiers, badge, responsive allocator |
+| Auto-compact trigger | Keep 95% | Conservative; the "critical" tier becomes a brief flash before compression fires |
+| Color tiers | 4, composed from existing theme tokens | No new theme infrastructure (`Success` / `Warning` / `Error` / `Error+Bold`) |
+| Architecture | New `internal/app/conv/status_bar.go` module | Matches existing convention; isolates new logic for testing |
+
+## Architecture
+
+```
+agent LLM response ──► OnTokenUsage               (existing)
+                       env.InputTokens = resp.InputTokens
+                              │
+agent compact event ──► OnCompacted                (existing + 1 new line)
+                       env.ResetContextDisplay()
+                       env.Compressions++         ← NEW
+                              │
+                              ▼
+view.go:renderModeStatus                          (existing)
+   passes OperationModeParams{
+       InputTokens, InputLimit, ConversationCost,
+       ModelName, Compressions, Width, ...
+   }                                              ← add Compressions field
+                              │
+                              ▼
+conv.RenderModeStatus                             (existing orchestrator)
+   ├─ left segments (mode, thinking, queue)      ← unchanged
+   └─ right segments (NEW status_bar.go)
+       ├─ model name
+       ├─ ctx X/Y [bar] NN%                      ← NEW bar, 4-tier color
+       ├─ 🗜️ N                                    ← NEW compressions badge
+       ├─ $cost
+       └─ AllocateStatusSegments(width)          ← NEW tail-budget allocator
+```
+
+The new file `internal/app/conv/status_bar.go` owns **only what's new**: the
+bar, the 4-tier resolver, the badge, and the budget allocator. Existing
+helpers stay where they are.
+
+## Components
+
+```go
+package conv
+
+// Threshold percentages (PRD §7.2 boundaries).
+const (
+    contextBarWidth = 10  // PRD §7.1
+    pctGood     = 50
+    pctWarn     = 80
+    pctCritical = 95
+)
+
+// contextTier classifies a fill percentage into one of 4 PRD tiers.
+// Off-by-one preserved: 80 falls into warn, only >80 is bad. (PRD §7.2)
+type contextTier int
+const (
+    tierNone contextTier = iota  // pct unknown (no denominator)
+    tierGood                     // [0, 50]
+    tierWarn                     // (50, 80]
+    tierBad                      // (80, 95)
+    tierCritical                 // [95, 100]
+)
+
+func classifyContextTier(pct float64) contextTier        // pure
+func (t contextTier) style() lipgloss.Style              // Success / Warning / Error / Error+Bold
+
+// Pure renderers — take primitives, return styled strings.
+func RenderContextBar(used, limit int) string            // "[██████░░░░] 71%"
+func RenderContextLabel(used, limit int) string          // "ctx 142.0k/200.0k" (via kit.FormatTokenCount)
+func RenderCompressionsBadge(n int) string               // "🗜️ 2", "" when n==0
+func compressionBadgeStyle(n int) lipgloss.Style         // <5 muted, 5-9 warn, >=10 error
+
+// statusSegment is a unit the allocator can keep or drop.
+type statusSegment struct {
+    render   func() string  // lazy — only called if segment survives
+    width    int            // precomputed visible width
+    priority int            // lower = drops first (PRD §8.3)
+}
+
+func buildRightSegments(p OperationModeParams) []statusSegment
+
+// AllocateStatusSegments walks segments in priority order, keeping each
+// that fits in the remaining budget. Never truncates mid-segment.
+func AllocateStatusSegments(segments []statusSegment, availableWidth int) string
+```
+
+**PRD requirement → SAN function:**
+
+| PRD § | SAN function |
+|---|---|
+| §7.1 10-cell bar | `RenderContextBar` |
+| §7.2 4-tier color | `classifyContextTier` + `style()` |
+| §7.3 `--` / `NN%` label | inside `RenderContextBar` |
+| §7.4 `ctx X/Y` | `RenderContextLabel` (uses `kit.FormatTokenCount`) |
+| §7.5 `🗜️ N` | `RenderCompressionsBadge` |
+| §8.3 priority drop | `AllocateStatusSegments` |
+
+`renderModelWithTokens` in `message.go` shrinks to just
+`{model} · {status message}` and delegates context/cost to the new module.
+
+## Data flow & lifecycle boundaries
+
+**New env state** (`internal/app/env.go`):
+
+```go
+type env struct {
+    ...
+    Compressions    int  // NEW — auto + manual compact count this session
+    ...
+}
+
+func (m *env) ResetContextDisplay() {
+    m.InputTokens = 0
+    m.OutputTokens = 0
+    m.ConversationCost = llm.Money{}
+    // NOTE: Compressions intentionally NOT reset here.
+    // ResetContextDisplay fires on every compact; the count must survive.
+}
+
+func (m *env) ResetTokens() {
+    m.ResetContextDisplay()
+    m.TurnInputTokens = 0
+    m.TurnOutputTokens = 0
+    m.turnUsageActive = false
+    m.Compressions = 0  // NEW — only place it zeroes (called by /reset, /new)
+}
+```
+
+**Where Compressions increments** (`internal/app/model_compact.go:39`):
+
+```go
+func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
+    scrollbackCmds := m.commitAllMessages()
+    m.conv.Clear()
+    m.env.ResetContextDisplay()
+    m.env.Compressions++  // NEW — both auto and manual
+    ...
+}
+```
+
+**Plumbing through to renderer** (`internal/app/view.go:243`):
+
+```go
+return conv.RenderModeStatus(conv.OperationModeParams{
+    ...
+    Compressions: m.env.Compressions,  // NEW
+    ...
+})
+```
+
+`OperationModeParams` (`internal/app/conv/message.go:32`) gets a
+`Compressions int` field.
+
+**Lifecycle boundaries (PRD §6.2):** SAN re-renders on every `tea.Msg`, so
+no new emit logic is needed. The status bar naturally refreshes on:
+
+- `OnTokenUsage` — after every LLM response ✓
+- `OnCompacted` — after auto/manual compact ✓ (now with increment)
+- `OnTurnEnd` — after every turn boundary ✓
+- Model switch via `SwitchProvider` ✓ (updates `CurrentModel` which feeds `InputLimit`)
+- `/reset` via `ResetTokens` ✓ (now with Compressions zeroed)
+
+**Sentinel handling (PRD §4.3):** SAN does not use a `-1` sentinel —
+`ResetContextDisplay` zeroes the field. `RenderContextBar` still clamps
+negatives to 0 defensively as a one-line guard.
+
+## Edge cases (PRD §9)
+
+| Case | Behavior in SAN |
+|---|---|
+| `InputLimit == 0` (model metadata not loaded yet) | `RenderContextBar` returns `[----------] --`, dim styling |
+| First turn, no API response | `env.InputTokens == 0` → bar shows `0%`; label `ctx --/200K` |
+| Model switch mid-session | `CurrentModel` updates → `kit.GetEffectiveInputLimit` returns new denominator → next render shows new limit |
+| Manual `/compact` | `OnCompacted` fires → `InputTokens=0`, `Compressions++` → bar drops to `0%`, badge appears |
+| `/reset` or `/new` | `ResetTokens` zeroes everything including `Compressions` |
+| `pct > 100` (provider over-send) | Clamp inside `RenderContextBar`: `pct = min(pct, 100)` |
+| Post-compact transitional turn | Bar shows `0%` for one frame until next `OnTokenUsage` |
+| Terminal resize | Existing `Width` plumbing handles it; `AllocateStatusSegments` re-evaluates each render |
+
+## Testing
+
+**New file `internal/app/conv/status_bar_test.go`:**
+
+- `TestClassifyContextTier_Boundaries` — verifies PRD §7.2 off-by-one:
+  - `0 → good`, `49 → good`, `50 → good`
+  - `51 → warn`, `80 → warn` (NOT bad!)
+  - `81 → bad`, `94 → bad`
+  - `95 → critical`, `100 → critical`
+- `TestRenderContextBar_FillLevels` — 0%, 49%, 50%, 80%, 95%, 100%, clamp at 120%.
+- `TestRenderContextBar_NoLimit` — returns `--`, dim style.
+- `TestRenderCompressionsBadge_Escalation` — `0 → ""`, `1 → dim`, `4 → dim`, `5 → warn`, `9 → warn`, `10 → error`.
+- `TestAllocateStatusSegments_DropsInPriorityOrder` — at width 100, 70, 50, 30; verifies cost drops first, then badge, then bar, then label.
+- `TestAllocateStatusSegments_NeverTruncatesMidSegment` — segment widths respected.
+
+**Update `internal/app/conv/message_test.go`:**
+
+- `TestRenderModeStatusShowsTokenUsageWithModel` — update expected string to include `[bar] NN%`.
+- `TestRenderModeStatusKeepsContextDisplayOnRightOnly` — update expected layout.
+- Add `TestRenderModeStatusShowsCompressionsBadgeWhenNonZero`.
+- Add `TestRenderModeStatusHidesBadgeWhenZero`.
+
+Existing tests that should pass unchanged: anything touching
+`RenderThinkingIndicator`, `RenderOperationModeIndicator`,
+`renderQueueBadge`, `RenderTurnUsageSummary`.
+
+## Acceptance criteria (PRD §11)
+
+- [x] After every assistant turn, bar reflects `env.InputTokens / InputLimit`.
+- [x] Color flips at exactly 50 / 80 / 95 (80 stays warn, only `>80` is bad).
+- [x] No negative percentages ever render.
+- [x] Status bar fits on a single row at every column width from 40 to 200.
+- [x] At `cols < 52`, bar + percent hide (they're one segment); allocator drops bar/badge/cost in priority order. *(Verified via render-check at width 40: model + label survive; percent travels with the bar.)*
+- [x] `/reset` returns the bar to `0%` and clears the compressions badge.
+- [x] Switching models updates the denominator within one turn.
+- [x] `🗜️ N` appears only after the first compact, never at session start.
+- [x] `go test ./internal/app/...` is green. *(Full `go test ./...` green; `go vet` clean; `go build ./cmd/san` clean; gofmt clean.)*
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `internal/app/conv/status_bar.go` | NEW — bar, tier resolver, badge, allocator |
+| `internal/app/conv/status_bar_test.go` | NEW — unit tests |
+| `internal/app/conv/message.go` | Slim `renderModelWithTokens`; add `Compressions` to `OperationModeParams` |
+| `internal/app/conv/message_test.go` | Update expected strings; add badge tests |
+| `internal/app/env.go` | Add `Compressions` field; zero in `ResetTokens` |
+| `internal/app/model_compact.go` | Increment `env.Compressions` in `OnCompacted` |
+| `internal/app/view.go` | Pass `Compressions` into `OperationModeParams` |


### PR DESCRIPTION
## Summary

Add a permanent, single-line context-usage status bar that shows how full the model's context window is — updated after every assistant turn.

- **10-cell bar** with percentage label: `[██████░░░░] 71%`
- **4-tier color escalation**: green (healthy) → yellow (watch) → red (pressure) → red+bold (imminent compression)
- **Compressions badge**: `🗜️ N` with escalating color
- **Responsive segment allocator**: tail-budget allocator drops low-priority segments on narrow terminals, never wraps
- **Unknown-limit placeholder**: renders `ctx X/-- [----------] --` (dim) when a model's context limit can't be resolved, instead of silently hiding — makes the gap visible and actionable via `/tokenlimit`

### Provider limit fixes

The status bar needs `InputLimit > 0` to render. Several providers' APIs don't include context-window metadata, so the bar was blank for their models. Fixed per-provider:

| Provider | Issue | Fix |
|----------|-------|-----|
| **SenseNova** | Anthropic-compat endpoint returned 0 tokens in every SSE event | Switched to OpenAI-compat endpoint (`stream_options.include_usage`); added `deepseek-v4-flash` to catalog |
| **BigModel (GLM)** | `/v1/models` omits `context_length` | `staticInputLimit()` fallback: glm-5.2 → 1M, glm-* → 256K |
| **Moonshot** | API returns `max_output_tokens` but not input limit | `staticInputLimit()` parses context from model ID suffix (8k/32k/128k/k2) |
| **OpenAI** | `openAIModelInfo` had no limits at all | `openAILimits()` lookup: gpt-6/5.x/codex → 400K, o-series → 200K, gpt-4.1 → 1M |
| **Anthropic** | All 12 catalog entries lacked `OutputTokenLimit` | Added output limits (Opus → 32K, Sonnet 4.x → 64K, Haiku → 8–16K) |
| **Volcengine** | Env-var model had no limits | `staticLimits()` matches Doubao ID suffixes (256k/128k/32k) |

### Catalog infrastructure

- **`catalog_check_test.go`** — guardrail test that fails if any model in a static catalog has `InputTokenLimit == 0`, preventing silent status-bar breakage when new models are added
- **`CATALOGS.md`** — documents the four catalog patterns (flat, with-pricing, API+fallback, prefix-matching) so new providers follow the right one

### Color tiers (PRD §7.2)

| Range | Tier | Theme token | Meaning |
|-------|------|-------------|---------|
| pct == null | tierNone | Muted | No data yet |
| [0, 50] | tierGood | Success | Healthy |
| (50, 80] | tierWarn | Warning | Watch |
| (80, 95) | tierBad | Error | Pressure |
| [95, 100+] | tierCritical | Error + Bold | Imminent compression |

### Files changed

| Subsystem | Files | What |
|-----------|-------|------|
| Rendering | `conv/status_bar.go`, `conv/status_bar_test.go`, `conv/message.go`, `conv/message_test.go` | Bar, classifier, allocator, badge; wired into `RenderModeStatus`; placeholder when unknown |
| State | `env.go`, `env_test.go`, `model_compact.go`, `view.go` | Compressions counter, token usage threading |
| SenseNova | `sensenova/apikey.go`, `sensenova/catalog.go`, `sensenova/client.go`, `sensenova/client_test.go` | OpenAI SDK switch for real usage; deepseek-v4-flash added |
| Provider limits | `bigmodel/catalog.go`, `moonshot/catalog.go`, `moonshot/client.go`, `openai/catalog.go`, `anthropic/catalog.go`, `volcengine/catalog.go` | Static limit fallbacks + output limit coverage |
| Catalog infra | `llm/catalog_check_test.go`, `llm/CATALOGS.md` | Guardrail test + pattern docs |
| Docs | `notes/completed/status-bar-context-usage.md`, `notes/completed/status-bar-context-usage-plan.md` | Spec + plan moved to completed |

### Test plan

- [x] `TestClassifyContextTier_Boundaries` — 50/80/95 thresholds with off-by-one preservation
- [x] `TestRenderContextBar_FillLevels` — 0%, 50%, 95%, 100%, >100% clamping
- [x] `TestRenderContextBar_NoLimit` — renders `[----------] --` when denominator unknown
- [x] `TestRenderContextBar_NoNegativePercent` — never renders negative
- [x] `TestRenderContextLabel` — compact humanized numbers (`12.4k`, `1.5M`)
- [x] `TestRenderCompressionsBadge` — hidden at 0, escalates at 5/10
- [x] `TestAllocateStatusSegments_DropsInPriorityOrder` — cost drops before context bar
- [x] `TestAllocateStatusSegments_NeverTruncatesMidSegment` — atomic segment drop
- [x] `TestStaticCatalogsHaveInputLimits` — guardrail: no shipped model has `InputTokenLimit=0`
- [x] `TestStaticInputLimit` (bigmodel, moonshot) — fallback functions return correct limits
- [x] `TestOpenAILimits` — model-family limit lookup
- [x] `TestStaticLimits` (volcengine) — Doubao suffix matching
- [x] Full `go test ./internal/app/... ./internal/llm/...` green
- [x] `gofmt` / `go vet` clean
- [x] Rebased onto latest `main` (1 commit, DCO signed)