### PR TITLE
feat(llm): unified transient-failure handling for LLM streams

### DIFF
--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -111,6 +111,20 @@ func (m *ConversationModel) AppendCancelledToolResults(calls []core.ToolCall, co
 	}
 }
 
+// DropStreamingAssistant removes the trailing assistant row that the in-flight
+// (now failed) inference was streaming into, so a retry re-streams onto a clean
+// tail instead of duplicating or interleaving partial output. Only uncommitted
+// rows are eligible, so committed scrollback is never touched.
+func (m *ConversationModel) DropStreamingAssistant() {
+	n := len(m.Messages)
+	if n == 0 || n <= m.CommittedCount {
+		return
+	}
+	if m.Messages[n-1].Role == core.RoleAssistant {
+		m.Messages = m.Messages[:n-1]
+	}
+}
+
 func (m *ConversationModel) RemoveEmptyLastAssistant() {
 	if len(m.Messages) > 0 {
 		last := m.Messages[len(m.Messages)-1]

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -135,6 +135,12 @@ func applyAgentEvent(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 		return applyPreInfer(rt, m)
 	case core.OnChunk:
 		return applyChunk(rt, m, ev)
+	case core.OnStreamReset:
+		// Transient failure about to be retried: drop the partial assistant
+		// row and stop streaming so the retry's PreInfer starts a clean one.
+		m.Stream.Stop()
+		m.DropStreamingAssistant()
+		return nil
 	case core.PostInfer:
 		return applyPostInfer(rt, m, ev)
 	case core.PreTool:

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"time"
 )
 
 // Agent is the core abstraction — an autonomous entity that reasons and acts.
@@ -104,17 +105,20 @@ type Agent interface {
 // Permission is a tool-layer concern — use tool.WithPermission to wrap Tools
 // before passing them to NewAgent. See docs/concepts/permission-model.md.
 type Config struct {
-	ID                string
-	LLM               LLM                                                       // required: inference backend
-	System            System                                                    // required: system prompt layers
-	Tools             Tools                                                     // required: available tools (wrap with tool.WithPermission for permission)
-	AgentType         string                                                    // optional: agent type identifier for hook events
-	CompactFunc       func(ctx context.Context, msgs []Message) (string, error) // optional: summarize messages for compaction
-	CWD               string
-	MaxSteps          int // max LLM inference steps per turn, 0 = unlimited
-	MaxOutputRecovery int // max retries on truncated output, 0 = use default (3)
-	InboxBuf          int // inbox channel buffer size, default 16
-	OutboxBuf         int // outbox channel buffer size, default 64; -1 = no outbox (subagent path)
+	ID                      string
+	LLM                     LLM                                                       // required: inference backend
+	System                  System                                                    // required: system prompt layers
+	Tools                   Tools                                                     // required: available tools (wrap with tool.WithPermission for permission)
+	AgentType               string                                                    // optional: agent type identifier for hook events
+	CompactFunc             func(ctx context.Context, msgs []Message) (string, error) // optional: summarize messages for compaction
+	CWD                     string
+	MaxSteps                int           // max LLM inference steps per turn, 0 = unlimited
+	MaxOutputRecovery       int           // max retries on truncated output, 0 = use default (3)
+	MaxTurnRetries          int           // max retries per inference step on transient stream errors, 0 = use default (2)
+	StreamFirstChunkTimeout time.Duration // abort if no first chunk arrives within this long, 0 = use default (5m)
+	StreamIdleTimeout       time.Duration // abort a stream that goes silent between chunks for this long, 0 = use default (60s)
+	InboxBuf                int           // inbox channel buffer size, default 16
+	OutboxBuf               int           // outbox channel buffer size, default 64; -1 = no outbox (subagent path)
 	// OnEvent observes lifecycle events synchronously, even when OutboxBuf is -1.
 	OnEvent func(Event)
 }
@@ -140,6 +144,15 @@ func NewAgent(cfg Config) Agent {
 	if cfg.OutboxBuf == 0 {
 		cfg.OutboxBuf = 64
 	}
+	if cfg.MaxTurnRetries <= 0 {
+		cfg.MaxTurnRetries = defaultMaxTurnRetries
+	}
+	if cfg.StreamFirstChunkTimeout <= 0 {
+		cfg.StreamFirstChunkTimeout = defaultFirstChunkTimeout
+	}
+	if cfg.StreamIdleTimeout <= 0 {
+		cfg.StreamIdleTimeout = defaultStreamIdleTimeout
+	}
 
 	var outbox chan Event
 	if cfg.OutboxBuf > 0 {
@@ -156,6 +169,9 @@ func NewAgent(cfg Config) Agent {
 		cwd:               cfg.CWD,
 		maxSteps:          cfg.MaxSteps,
 		maxOutputRecovery: cfg.MaxOutputRecovery,
+		maxTurnRetries:    cfg.MaxTurnRetries,
+		firstChunkTimeout: cfg.StreamFirstChunkTimeout,
+		idleTimeout:       cfg.StreamIdleTimeout,
 		inbox:             make(chan Message, cfg.InboxBuf),
 		outbox:            outbox,
 		onEvent:           cfg.OnEvent,
@@ -195,12 +211,17 @@ const (
 	PreInfer  EventType = "PreInfer"   // before LLM call
 	PostInfer EventType = "PostInfer"  // after LLM response (*InferResponse in Data)
 	OnChunk   EventType = "Chunk"      // streaming chunk (Chunk in Data)
-	PreTool   EventType = "PreTool"    // before tool execution (ToolCall in Data)
-	PostTool  EventType = "PostTool"   // after tool execution (ToolResult in Data)
-	OnMessage EventType = "Message"    // message received on inbox (Message in Data)
-	OnAppend  EventType = "Append"     // message appended to conversation chain (Message in Data)
-	OnTurn    EventType = "Turn"       // think+act cycle completed (Result in Data)
-	OnCompact EventType = "Compact"    // conversation compacted (CompactInfo in Data)
+
+	// OnStreamReset fires when a transient stream failure is about to be
+	// retried: the partial assistant output streamed so far must be discarded
+	// before the next attempt re-streams from scratch (no payload).
+	OnStreamReset EventType = "StreamReset"
+	PreTool       EventType = "PreTool"  // before tool execution (ToolCall in Data)
+	PostTool      EventType = "PostTool" // after tool execution (ToolResult in Data)
+	OnMessage     EventType = "Message"  // message received on inbox (Message in Data)
+	OnAppend      EventType = "Append"   // message appended to conversation chain (Message in Data)
+	OnTurn        EventType = "Turn"     // think+act cycle completed (Result in Data)
+	OnCompact     EventType = "Compact"  // conversation compacted (CompactInfo in Data)
 
 	// OnSystemChange fires when a system-prompt section is added, replaced,
 	// or removed. Data is SystemChange. Non-critical telemetry — never blocks
@@ -296,6 +317,7 @@ func StopEvent(agentID string, err error) Event {
 	return Event{Type: OnStop, Source: agentID, Data: err}
 }
 func ChunkEvent(agentID string, c Chunk) Event { return Event{Type: OnChunk, Source: agentID, Data: c} }
+func StreamResetEvent(agentID string) Event    { return Event{Type: OnStreamReset, Source: agentID} }
 func MessageEvent(agentID string, msg Message) Event {
 	return Event{Type: OnMessage, Source: agentID, Data: msg}
 }

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -25,6 +25,9 @@ type agent struct {
 	cwd               string
 	maxSteps          int
 	maxOutputRecovery int
+	maxTurnRetries    int
+	firstChunkTimeout time.Duration
+	idleTimeout       time.Duration
 	inbox             chan Message
 	outbox            chan Event
 	onEvent           func(Event)
@@ -296,6 +299,7 @@ func (a *agent) ingest(ctx context.Context, msg Message) bool {
 func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 	var steps, toolUses, tokensIn, tokensOut, lastInputTokens, lastPromptTextLen int
 	var maxOutputRecoveryCount int
+	var turnRetries int
 
 	makeResult := func(content string, stop StopReason, detail string) *Result {
 		return &Result{
@@ -347,8 +351,24 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 			if errors.Is(err, context.Canceled) {
 				return makeResult("", StopCancelled, ""), err
 			}
+			// Transient stream failure (network blip, 5xx/529 overload,
+			// 429, idle stall, truncation): discard the partial assistant
+			// output and retry this inference step after a backoff. Bounded
+			// by maxTurnRetries so a sustained outage still surfaces.
+			var re RetryableError
+			if errors.As(err, &re) {
+				if turnRetries < a.maxTurnRetries {
+					turnRetries++
+					a.emit(ctx, StreamResetEvent(a.id))
+					if werr := BackoffSleep(ctx, turnRetries, re.RetryAfter()); werr != nil {
+						return makeResult("", StopCancelled, ""), werr
+					}
+					continue
+				}
+			}
 			return nil, err
 		}
+		turnRetries = 0 // reset budget once a step completes
 
 		steps++
 		lastInputTokens = resp.InputTokens
@@ -603,7 +623,13 @@ func (a *agent) streamInfer(ctx context.Context) (*InferResponse, error) {
 		MessageIDs:   messageIDs(msgs),
 	}))
 
-	chunks, err := a.llm.Infer(ctx, InferRequest{
+	// Per-inference child ctx so an idle stall can be torn down without
+	// cancelling the whole turn. The provider and bridge goroutines are
+	// ctx-aware, so cancelling inferCtx unwinds them cleanly.
+	inferCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	chunks, err := a.llm.Infer(inferCtx, InferRequest{
 		System:   sys,
 		Messages: msgs,
 		Tools:    tools,
@@ -612,6 +638,12 @@ func (a *agent) streamInfer(ctx context.Context) (*InferResponse, error) {
 		return nil, fmt.Errorf("infer: %w", err)
 	}
 
+	// First chunk gets the generous TTFT budget (a reasoning model may emit
+	// nothing while it thinks); every chunk thereafter rearms the timer with
+	// the tighter inter-chunk idle budget.
+	idle := time.NewTimer(a.firstChunkTimeout)
+	defer idle.Stop()
+
 	var resp *InferResponse
 	for {
 		select {
@@ -619,18 +651,21 @@ func (a *agent) streamInfer(ctx context.Context) (*InferResponse, error) {
 			if !ok {
 				// ctx-cancellation racing the bridge's defer close(ch)
 				// produces both ok==false and ctx.Done() ready at the
-				// same time — select picks randomly. Check ctx.Err()
-				// first so a cancel is always reported as
-				// context.Canceled, never as "stream closed without
-				// response" (which Run does not treat as an interrupt).
+				// same time — select picks randomly. Check the caller
+				// ctx first so a user interrupt is always reported as
+				// context.Canceled, never as a (retryable) truncation.
 				if err := ctx.Err(); err != nil {
 					return nil, err
 				}
 				if resp == nil {
-					return nil, fmt.Errorf("infer: stream closed without response")
+					// Closed without a Done chunk: the provider always
+					// emits Done on success, so this is an abnormal
+					// truncation — retryable.
+					return nil, errStreamTruncated
 				}
 				return resp, nil
 			}
+			idle.Reset(a.idleTimeout)
 			if chunk.Err != nil {
 				return nil, fmt.Errorf("infer: %w", chunk.Err)
 			}
@@ -640,6 +675,13 @@ func (a *agent) streamInfer(ctx context.Context) (*InferResponse, error) {
 			if chunk.Done {
 				resp = chunk.Response
 			}
+		case <-idle.C:
+			// The stream went silent (connection alive but no bytes —
+			// half-open socket, stalled provider). Tear it down and let
+			// the turn loop retry. Caller ctx is still live, so this is
+			// classified retryable, not a cancel.
+			cancel()
+			return nil, errStreamStalled
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/internal/core/retry.go
+++ b/internal/core/retry.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Retry tuning for transient LLM stream failures. These are deliberately
+// small: the goal is to ride out a brief blip (provider overload, a rate
+// limit, a dropped connection), not to mask a sustained outage.
+const (
+	defaultMaxTurnRetries = 2
+	// defaultFirstChunkTimeout bounds time-to-first-chunk. It is generous
+	// because a reasoning model may think for a while (and emit nothing) before
+	// the first token; it exists only to catch a connection that hangs at open.
+	defaultFirstChunkTimeout = 5 * time.Minute
+	// defaultStreamIdleTimeout bounds the gap *between* chunks once a response
+	// has started — a much tighter signal that an in-flight stream has stalled.
+	defaultStreamIdleTimeout = 60 * time.Second
+
+	retryBaseDelay = 500 * time.Millisecond
+	retryMaxDelay  = 30 * time.Second
+)
+
+// RetryableError marks a stream error that the turn loop may retry. The llm
+// layer attaches it via classification (429/5xx/network), so core can decide
+// to retry without importing llm; core's own stall/truncation sentinels
+// implement it directly.
+//
+// RetryAfter is a server-provided floor (e.g. a 429 Retry-After header), or 0
+// when there is no hint.
+type RetryableError interface {
+	error
+	RetryAfter() time.Duration
+}
+
+// streamIncomplete is a core-originated retryable failure: the stream either
+// ended without a terminal Done chunk (truncated) or went silent past the idle
+// deadline (stalled). Neither carries a server hint, so RetryAfter is 0.
+type streamIncomplete struct{ reason string }
+
+func (e streamIncomplete) Error() string             { return "stream " + e.reason }
+func (e streamIncomplete) RetryAfter() time.Duration { return 0 }
+
+var (
+	errStreamStalled   = streamIncomplete{"stalled (no data within idle timeout)"}
+	errStreamTruncated = streamIncomplete{"closed before completion"}
+)
+
+// backoffDelay returns the pre-sleep delay for a 1-based attempt: exponential
+// (base·2^(n-1)) capped at retryMaxDelay, full-jittered by frac (in [0,1)),
+// then floored at `floor` (a server Retry-After hint). Pure, so the policy is
+// unit-testable without a clock.
+func backoffDelay(attempt int, floor time.Duration, frac float64) time.Duration {
+	d := float64(retryBaseDelay) * math.Pow(2, float64(attempt-1))
+	if d > float64(retryMaxDelay) {
+		d = float64(retryMaxDelay)
+	}
+	delay := time.Duration(d * frac) // full jitter
+	return max(delay, floor)
+}
+
+// BackoffSleep waits out the backoff for `attempt`, returning ctx.Err() if the
+// caller cancels mid-wait so a retry never blocks past an interrupt. Exported
+// so the llm layer's utility-call retry (Complete) shares one policy.
+func BackoffSleep(ctx context.Context, attempt int, floor time.Duration) error {
+	d := backoffDelay(attempt, floor, rand.Float64())
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/core/retry_test.go
+++ b/internal/core/retry_test.go
@@ -1,0 +1,177 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBackoffDelayFloorWins(t *testing.T) {
+	// frac=0 zeroes the exponential term, so the Retry-After floor stands.
+	if got := backoffDelay(1, 5*time.Second, 0); got != 5*time.Second {
+		t.Fatalf("backoffDelay floor = %v, want 5s", got)
+	}
+}
+
+func TestBackoffDelayGrowsAndCaps(t *testing.T) {
+	// frac=1 (upper edge of full jitter): attempt n ≈ base·2^(n-1), capped.
+	a1 := backoffDelay(1, 0, 1)
+	a2 := backoffDelay(2, 0, 1)
+	if a1 != retryBaseDelay {
+		t.Fatalf("attempt1 = %v, want %v", a1, retryBaseDelay)
+	}
+	if a2 != 2*retryBaseDelay {
+		t.Fatalf("attempt2 = %v, want %v", a2, 2*retryBaseDelay)
+	}
+	if capped := backoffDelay(20, 0, 1); capped != retryMaxDelay {
+		t.Fatalf("attempt20 = %v, want cap %v", capped, retryMaxDelay)
+	}
+}
+
+func TestBackoffSleepHonorsCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Use a floor large enough that, without the cancel check, the call would
+	// block well past the test. A canceled ctx must return immediately.
+	if err := BackoffSleep(ctx, 1, 10*time.Second); !errors.Is(err, context.Canceled) {
+		t.Fatalf("BackoffSleep on canceled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestStreamSentinelsAreRetryable(t *testing.T) {
+	for _, e := range []error{errStreamStalled, errStreamTruncated} {
+		var re RetryableError
+		if !errors.As(e, &re) {
+			t.Fatalf("%v should satisfy RetryableError", e)
+		}
+		if re.RetryAfter() != 0 {
+			t.Fatalf("%v RetryAfter = %v, want 0", e, re.RetryAfter())
+		}
+	}
+}
+
+// scriptedLLM fails the first `failures` Infer calls with failErr, then
+// completes with a text-only end_turn response.
+type scriptedLLM struct {
+	failErr  error
+	failures int
+	calls    int
+}
+
+func (s *scriptedLLM) InputLimit() int { return 0 }
+
+func (s *scriptedLLM) Infer(_ context.Context, _ InferRequest) (<-chan Chunk, error) {
+	s.calls++
+	fail := s.calls <= s.failures
+	ch := make(chan Chunk, 1)
+	go func() {
+		defer close(ch)
+		if fail {
+			ch <- Chunk{Err: s.failErr}
+			return
+		}
+		ch <- Chunk{Done: true, Response: &InferResponse{Content: "ok", StopReason: StopEndTurn}}
+	}()
+	return ch, nil
+}
+
+// hangLLM never produces a chunk; it unblocks only when the per-inference ctx
+// is canceled (by the idle-timeout watchdog).
+type hangLLM struct{ calls int }
+
+func (h *hangLLM) InputLimit() int { return 0 }
+
+func (h *hangLLM) Infer(ctx context.Context, _ InferRequest) (<-chan Chunk, error) {
+	h.calls++
+	ch := make(chan Chunk)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func newRetryAgent(t *testing.T, llm LLM, maxRetries int, timeout time.Duration) *agent {
+	t.Helper()
+	ag := NewAgent(Config{
+		ID:                      "test",
+		LLM:                     llm,
+		System:                  NewSystem(),
+		Tools:                   NewTools(),
+		MaxTurnRetries:          maxRetries,
+		StreamFirstChunkTimeout: timeout,
+		StreamIdleTimeout:       timeout,
+	})
+	go func() {
+		for range ag.Outbox() {
+		}
+	}()
+	a := ag.(*agent)
+	a.SetMessages([]Message{UserMessage("hi", nil)})
+	return a
+}
+
+func TestThinkActRetriesTransientStreamError(t *testing.T) {
+	llm := &scriptedLLM{failErr: errStreamStalled, failures: 2}
+	a := newRetryAgent(t, llm, 2, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := a.ThinkAct(ctx)
+	if err != nil {
+		t.Fatalf("ThinkAct returned error after retries: %v", err)
+	}
+	if result.Content != "ok" {
+		t.Fatalf("content = %q, want ok", result.Content)
+	}
+	if llm.calls != 3 {
+		t.Fatalf("Infer calls = %d, want 3 (2 failures + 1 success)", llm.calls)
+	}
+}
+
+func TestThinkActSurfacesErrorAfterMaxRetries(t *testing.T) {
+	llm := &scriptedLLM{failErr: errStreamStalled, failures: 99}
+	a := newRetryAgent(t, llm, 2, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := a.ThinkAct(ctx); err == nil {
+		t.Fatal("ThinkAct should surface the error after exhausting retries")
+	}
+	if llm.calls != 3 { // 1 initial + 2 retries
+		t.Fatalf("Infer calls = %d, want 3", llm.calls)
+	}
+}
+
+func TestThinkActDoesNotRetryFatalError(t *testing.T) {
+	llm := &scriptedLLM{failErr: errors.New("400 bad request"), failures: 99}
+	a := newRetryAgent(t, llm, 3, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := a.ThinkAct(ctx); err == nil {
+		t.Fatal("ThinkAct should surface a fatal error")
+	}
+	if llm.calls != 1 {
+		t.Fatalf("Infer calls = %d, want 1 (no retry on fatal)", llm.calls)
+	}
+}
+
+func TestStreamInferIdleTimeoutRetries(t *testing.T) {
+	llm := &hangLLM{}
+	a := newRetryAgent(t, llm, 1, 40*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := a.ThinkAct(ctx); err == nil {
+		t.Fatal("ThinkAct should fail once a stalled stream exhausts retries")
+	}
+	if llm.calls != 2 { // 1 initial + 1 retry, each stalls
+		t.Fatalf("Infer calls = %d, want 2 (idle-timeout retry)", llm.calls)
+	}
+}

--- a/internal/llm/alibaba/apikey.go
+++ b/internal/llm/alibaba/apikey.go
@@ -29,6 +29,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := openai.NewClient(
 		option.WithAPIKey(secret.Resolve("DASHSCOPE_API_KEY")),
 		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "alibaba:api_key"), nil
 }

--- a/internal/llm/anthropic/apikey.go
+++ b/internal/llm/anthropic/apikey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 
 	"github.com/genai-io/san/internal/llm"
 )
@@ -18,7 +19,8 @@ var APIKeyMeta = llm.Meta{
 
 // NewAPIKeyClient creates a new Anthropic client using API Key authentication
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	client := anthropic.NewClient()
+	// Retries are owned by the app-level decorator; disable the SDK's own.
+	client := anthropic.NewClient(option.WithMaxRetries(0))
 	return NewClient(client, "anthropic:api_key"), nil
 }
 

--- a/internal/llm/anthropic/vertex.go
+++ b/internal/llm/anthropic/vertex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/vertex"
 
 	"github.com/genai-io/san/internal/llm"
@@ -74,8 +75,10 @@ func NewVertexClient(ctx context.Context) (llm.Provider, error) {
 	}
 	projectID := secret.Resolve("ANTHROPIC_VERTEX_PROJECT_ID")
 
+	// Retries are owned by the app-level decorator; disable the SDK's own.
 	client := anthropic.NewClient(
 		vertex.WithGoogleAuth(ctx, region, projectID),
+		option.WithMaxRetries(0),
 	)
 
 	baseClient := NewClient(client, "anthropic:vertex")

--- a/internal/llm/bigmodel/apikey.go
+++ b/internal/llm/bigmodel/apikey.go
@@ -30,6 +30,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := openai.NewClient(
 		option.WithAPIKey(secret.Resolve("BIGMODEL_API_KEY")),
 		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "bigmodel:api_key"), nil
 }

--- a/internal/llm/deepseek/apikey.go
+++ b/internal/llm/deepseek/apikey.go
@@ -29,6 +29,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := openai.NewClient(
 		option.WithAPIKey(secret.Resolve("DEEPSEEK_API_KEY")),
 		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "deepseek:api_key"), nil
 }

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -2,14 +2,19 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm/llmerr"
 )
 
 // defaultMaxTokens is the fallback max output tokens when neither the caller
 // nor the provider specifies a limit.
 const defaultMaxTokens = 8192
+
+// completeMaxAttempts bounds in-place retries for one-shot utility completions.
+const completeMaxAttempts = 3
 
 // Client adapts a Provider to core.LLM.
 //
@@ -85,7 +90,9 @@ func (l *Client) Infer(ctx context.Context, req core.InferRequest) (<-chan core.
 					return
 				}
 			case ChunkTypeError:
-				send(core.Chunk{Err: sc.Error})
+				// Classify here so the agent loop can decide whether to
+				// retry without importing the provider SDKs.
+				send(core.Chunk{Err: llmerr.Wrap(sc.Error)})
 				return
 			}
 		}
@@ -134,13 +141,31 @@ func (l *Client) Complete(ctx context.Context,
 	thinking := l.thinkingEffort
 	l.mu.RUnlock()
 
-	return Complete(ctx, p, CompletionOptions{
+	opts := CompletionOptions{
 		Model:          model,
 		SystemPrompt:   sysPrompt,
 		Messages:       msgs,
 		MaxTokens:      maxTokens,
 		ThinkingEffort: thinking,
-	})
+	}
+
+	// Utility calls (e.g. compaction) are not streamed to the UI, so retry
+	// them in place on transient failures, sharing the agent loop's backoff.
+	var resp CompletionResponse
+	var err error
+	for attempt := 1; attempt <= completeMaxAttempts; attempt++ {
+		if resp, err = Complete(ctx, p, opts); err == nil {
+			return resp, nil
+		}
+		var re core.RetryableError
+		if !errors.As(llmerr.Wrap(err), &re) || attempt == completeMaxAttempts {
+			return resp, err
+		}
+		if werr := core.BackoffSleep(ctx, attempt, re.RetryAfter()); werr != nil {
+			return resp, werr
+		}
+	}
+	return resp, err
 }
 
 // send sends a non-streaming completion request and returns the full response.

--- a/internal/llm/llmerr/llmerr.go
+++ b/internal/llm/llmerr/llmerr.go
@@ -1,0 +1,148 @@
+// Package llmerr classifies LLM provider/stream errors so the agent loop can
+// decide whether a failure is worth retrying. It maps each provider SDK's error
+// type onto a small, provider-agnostic taxonomy and exposes a single Wrap entry
+// point that tags retryable errors with core.RetryableError.
+package llmerr
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"google.golang.org/genai"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+// class is the provider-agnostic failure category.
+type class int
+
+const (
+	fatal       class = iota // never retry: bad request, auth, not-found, content policy, context window
+	retryable                // transient: 408/409, all 5xx (incl. 529), connection/network errors
+	rateLimited              // 429 — retry, honoring Retry-After when present
+)
+
+// Wrap classifies err and, when it is worth retrying, returns an error that
+// satisfies core.RetryableError (carrying any Retry-After hint). Fatal errors
+// and nil are returned unchanged, so they do NOT satisfy the interface and the
+// turn loop surfaces them immediately. The original error always stays in the
+// chain — context-window messages must survive for isPromptTooLong.
+func Wrap(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch c, after := classify(err); c {
+	case retryable:
+		return retryErr{err: err}
+	case rateLimited:
+		return retryErr{err: err, after: after}
+	default:
+		return err
+	}
+}
+
+// retryErr satisfies core.RetryableError while preserving the original error.
+type retryErr struct {
+	err   error
+	after time.Duration
+}
+
+func (e retryErr) Error() string             { return e.err.Error() }
+func (e retryErr) Unwrap() error             { return e.err }
+func (e retryErr) RetryAfter() time.Duration { return e.after }
+
+var _ core.RetryableError = retryErr{}
+
+// classify maps err onto the taxonomy, returning a Retry-After hint when the
+// provider supplied one (429 responses); 0 otherwise.
+func classify(err error) (class, time.Duration) {
+	// Provider SDK typed errors carry an HTTP status — the most reliable
+	// signal. (openai.Error.Code is a string, so use .StatusCode.)
+	var anthErr *anthropic.Error
+	if errors.As(err, &anthErr) {
+		return fromStatus(anthErr.StatusCode, anthErr.Response)
+	}
+	var oaiErr *openai.Error
+	if errors.As(err, &oaiErr) {
+		return fromStatus(oaiErr.StatusCode, oaiErr.Response)
+	}
+	var gErr genai.APIError
+	if errors.As(err, &gErr) {
+		// genai.APIError exposes no response headers, so there is no
+		// Retry-After to honor — fall back to plain backoff.
+		c, _ := fromStatus(gErr.Code, nil)
+		return c, 0
+	}
+
+	// Transport-level failures with no HTTP status: connection dropped,
+	// refused, reset, or a timeout. All worth a retry.
+	if isNetworkError(err) {
+		return retryable, 0
+	}
+
+	return fatal, 0
+}
+
+// fromStatus classifies an HTTP status code and extracts Retry-After for 429.
+func fromStatus(code int, resp *http.Response) (class, time.Duration) {
+	switch {
+	case code == http.StatusTooManyRequests: // 429
+		return rateLimited, retryAfter(resp)
+	case code == http.StatusRequestTimeout, // 408
+		code == http.StatusConflict, // 409
+		code >= 500:                 // all 5xx, incl. Anthropic 529 overloaded
+		return retryable, 0
+	default:
+		// 400/401/403/404/422, content policy, model-not-found, and
+		// context-window-exceeded all land here: retrying cannot help.
+		return fatal, 0
+	}
+}
+
+// isNetworkError reports whether err is a transport failure worth retrying. A
+// dropped/refused/reset connection surfaces as a net.Error (e.g. *net.OpError);
+// a mid-stream cutoff surfaces as io.EOF / io.ErrUnexpectedEOF.
+//
+// net.Error intentionally also matches a per-request timeout
+// (context.DeadlineExceeded satisfies net.Error): a request that timed out is
+// worth retrying. A user interrupt (context.Canceled) is NOT a net.Error and
+// stays fatal — and the turn loop checks the caller ctx before classifying, so
+// a cancel never reaches here.
+func isNetworkError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+// retryAfter parses a Retry-After header (delta-seconds or HTTP-date). Returns
+// 0 when absent or unparseable.
+func retryAfter(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	v := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}

--- a/internal/llm/llmerr/llmerr_test.go
+++ b/internal/llm/llmerr/llmerr_test.go
@@ -1,0 +1,162 @@
+package llmerr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"google.golang.org/genai"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+// retryInfo reports whether Wrap tagged err as retryable and, if so, its
+// Retry-After hint.
+func retryInfo(err error) (after time.Duration, retryable bool) {
+	var re core.RetryableError
+	if errors.As(err, &re) {
+		return re.RetryAfter(), true
+	}
+	return 0, false
+}
+
+func dummyReq() *http.Request {
+	r, _ := http.NewRequest(http.MethodPost, "https://example.com/v1/x", nil)
+	return r
+}
+
+func httpResp(code int, hdr http.Header) *http.Response {
+	if hdr == nil {
+		hdr = http.Header{}
+	}
+	return &http.Response{StatusCode: code, Header: hdr, Request: dummyReq()}
+}
+
+type fakeTimeout struct{}
+
+func (fakeTimeout) Error() string   { return "i/o timeout" }
+func (fakeTimeout) Timeout() bool   { return true }
+func (fakeTimeout) Temporary() bool { return true }
+
+var _ net.Error = fakeTimeout{}
+
+func TestWrapNilIsNil(t *testing.T) {
+	if got := Wrap(nil); got != nil {
+		t.Fatalf("Wrap(nil) = %v, want nil", got)
+	}
+}
+
+func TestWrapClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantRetryable bool
+		wantAfter     time.Duration
+	}{
+		{
+			name:          "anthropic 529 overloaded is retryable",
+			err:           &anthropic.Error{StatusCode: 529, Request: dummyReq(), Response: httpResp(529, nil)},
+			wantRetryable: true,
+		},
+		{
+			name:          "anthropic 400 bad request is fatal",
+			err:           &anthropic.Error{StatusCode: 400, Request: dummyReq(), Response: httpResp(400, nil)},
+			wantRetryable: false,
+		},
+		{
+			name:          "anthropic 401 auth is fatal",
+			err:           &anthropic.Error{StatusCode: 401, Request: dummyReq(), Response: httpResp(401, nil)},
+			wantRetryable: false,
+		},
+		{
+			name:          "openai 429 honors Retry-After",
+			err:           &openai.Error{StatusCode: 429, Request: dummyReq(), Response: httpResp(429, http.Header{"Retry-After": {"8"}})},
+			wantRetryable: true,
+			wantAfter:     8 * time.Second,
+		},
+		{
+			name:          "openai 429 without header still retryable",
+			err:           &openai.Error{StatusCode: 429, Request: dummyReq(), Response: httpResp(429, nil)},
+			wantRetryable: true,
+		},
+		{
+			name:          "openai 503 is retryable",
+			err:           &openai.Error{StatusCode: 503, Request: dummyReq(), Response: httpResp(503, nil)},
+			wantRetryable: true,
+		},
+		{
+			name:          "openai 422 is fatal",
+			err:           &openai.Error{StatusCode: 422, Request: dummyReq(), Response: httpResp(422, nil)},
+			wantRetryable: false,
+		},
+		{
+			name:          "genai 503 is retryable (no Retry-After header available)",
+			err:           genai.APIError{Code: 503, Message: "unavailable"},
+			wantRetryable: true,
+		},
+		{
+			name:          "genai 404 is fatal",
+			err:           genai.APIError{Code: 404, Message: "model not found"},
+			wantRetryable: false,
+		},
+		{
+			name:          "io.EOF is retryable",
+			err:           io.EOF,
+			wantRetryable: true,
+		},
+		{
+			name:          "net timeout is retryable",
+			err:           fakeTimeout{},
+			wantRetryable: true,
+		},
+		{
+			name:          "context canceled is fatal",
+			err:           context.Canceled,
+			wantRetryable: false,
+		},
+		{
+			name:          "plain error is fatal",
+			err:           errors.New("something opaque"),
+			wantRetryable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			after, retryable := retryInfo(Wrap(tc.err))
+			if retryable != tc.wantRetryable {
+				t.Fatalf("retryable = %v, want %v", retryable, tc.wantRetryable)
+			}
+			if retryable && after != tc.wantAfter {
+				t.Fatalf("RetryAfter = %v, want %v", after, tc.wantAfter)
+			}
+		})
+	}
+}
+
+// Wrap must preserve the original error in the chain so substring-based
+// detection (e.g. isPromptTooLong) and errors.Is keep working.
+func TestWrapPreservesOriginalError(t *testing.T) {
+	wrapped := Wrap(io.EOF)
+	if !errors.Is(wrapped, io.EOF) {
+		t.Fatal("wrapped retryable error should still match io.EOF")
+	}
+	if wrapped.Error() != io.EOF.Error() {
+		t.Fatalf("Error() = %q, want %q", wrapped.Error(), io.EOF.Error())
+	}
+}
+
+func TestRetryAfterParsesHTTPDate(t *testing.T) {
+	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	resp := httpResp(429, http.Header{"Retry-After": {future}})
+	d := retryAfter(resp)
+	if d <= 0 || d > 31*time.Second {
+		t.Fatalf("retryAfter(http-date) = %v, want ~30s", d)
+	}
+}

--- a/internal/llm/mimo/apikey.go
+++ b/internal/llm/mimo/apikey.go
@@ -29,6 +29,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := anthropicsdk.NewClient(
 		anthropicoption.WithAPIKey(secret.Resolve("MIMO_API_KEY")),
 		anthropicoption.WithBaseURL(baseURL),
+		anthropicoption.WithMaxRetries(0),
 	)
 	return NewClient(client, "mimo:api_key"), nil
 }

--- a/internal/llm/minmax/apikey.go
+++ b/internal/llm/minmax/apikey.go
@@ -33,10 +33,12 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := anthropicsdk.NewClient(
 		anthropicoption.WithAPIKey(apiKey),
 		anthropicoption.WithBaseURL(baseURL),
+		anthropicoption.WithMaxRetries(0),
 	)
 	modelClient := openai.NewClient(
 		openaioption.WithAPIKey(apiKey),
 		openaioption.WithBaseURL(openAIBaseURL),
+		openaioption.WithMaxRetries(0),
 	)
 	return NewClient(client, modelClient, "minmax:api_key"), nil
 }

--- a/internal/llm/moonshot/apikey.go
+++ b/internal/llm/moonshot/apikey.go
@@ -29,6 +29,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := openai.NewClient(
 		option.WithAPIKey(secret.Resolve("MOONSHOT_API_KEY")),
 		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "moonshot:api_key"), nil
 }

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -53,6 +53,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := openai.NewClient(
 		option.WithAPIKey("ollama"),
 		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
 	)
 	return NewClient(client, "ollama:api_key"), nil
 }

--- a/internal/llm/openai/apikey.go
+++ b/internal/llm/openai/apikey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 
 	"github.com/genai-io/san/internal/llm"
 )
@@ -18,7 +19,8 @@ var APIKeyMeta = llm.Meta{
 
 // NewAPIKeyClient creates a new OpenAI client using API Key authentication
 func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
-	client := openai.NewClient()
+	// Retries are owned by the app-level decorator; disable the SDK's own.
+	client := openai.NewClient(option.WithMaxRetries(0))
 	return NewClient(client, "openai:api_key"), nil
 }
 

--- a/internal/llm/sensenova/apikey.go
+++ b/internal/llm/sensenova/apikey.go
@@ -27,6 +27,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := anthropicsdk.NewClient(
 		anthropicoption.WithAuthToken(secret.Resolve("SENSENOVA_API_KEY")),
 		anthropicoption.WithBaseURL(baseURL),
+		anthropicoption.WithMaxRetries(0),
 	)
 	return NewClient(client, "sensenova:api_key"), nil
 }

--- a/internal/llm/volcengine/apikey.go
+++ b/internal/llm/volcengine/apikey.go
@@ -29,6 +29,7 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 	client := anthropicsdk.NewClient(
 		anthropicoption.WithAuthToken(apiKey),
 		anthropicoption.WithBaseURL(baseURL),
+		anthropicoption.WithMaxRetries(0),
 	)
 	return NewClientWithConfig(client, "volcengine:api_key", baseURL, apiKey), nil
 }


### PR DESCRIPTION
Classify LLM stream errors and retry transient failures at the agent turn loop instead of relying on invisible SDK defaults. Previously any non-auth, non-context-window stream error ended the whole agent `Run`; now a blip is ridden out and only a sustained failure surfaces.

- **`internal/llm/llmerr`** — `Wrap()` classifies SDK/net errors into fatal / retryable / rate-limited (honoring `Retry-After`), tagging retryable ones with `core.RetryableError` while keeping the original error in the chain (so context-window messages still reach `isPromptTooLong`).
- **`core`** — `RetryableError` contract + `BackoffSleep` (full jitter, ctx-aware) + stalled/truncated sentinels; `streamInfer` gains a per-inference **idle timeout** (catches half-open/stalled streams that never error); `ThinkAct` retries a step on a `RetryableError` (bounded by `MaxTurnRetries`, default 2) and emits `OnStreamReset` so the TUI drops the partial row before regenerating.
- **bridge** — `Client.Infer` classifies stream errors; `Client.Complete` (compaction) retries with the same policy.
- **`WithMaxRetries(0)`** on all anthropic/openai SDK clients so the app owns retry.

Caveats: no provider stream-resume (emitted-then-dropped regenerates from scratch, bounded); Google `genai.APIError` has no headers and a non-configurable built-in retry, so it's left as-is.

Tests cover classification (all SDKs + net/EOF + Retry-After), backoff, and the turn-loop retry / give-up / fatal / idle-timeout paths.

Refs #169
