### PR TITLE
feat(plugin): manifest-style marketplaces + add-dialog paste/UI

### DIFF
--- a/docs/packages/2-feature/plugin.md
+++ b/docs/packages/2-feature/plugin.md
@@ -5,6 +5,8 @@ layer: feature
 
 # plugin
 
+> 中文版本：[`plugin.zh.md`](plugin.zh.md)
+
 Plugin loader, installer, marketplace, and aggregator. A plugin is a
 single package (directory) that may contribute skills, subagent
 definitions, slash commands, MCP servers, hooks, and env vars — this

--- a/docs/packages/2-feature/plugin.md
+++ b/docs/packages/2-feature/plugin.md
@@ -128,7 +128,7 @@ flowchart TD
     L --> M["record in installed_plugins.json"]
     M --> N["LoadPlugin → Register → Enable"]
     N --> O["resolve components:<br/>skills / agents / commands / hooks / mcp / lsp"]
-    O --> P["push contributions to feature packages"]
+    O --> P["app feeds them to the feature packages<br/>skill / subagent / command / mcp / hook"]
 ```
 
 **Plugin `source` formats** (in `marketplace.json` `plugins[]`):

--- a/docs/packages/2-feature/plugin.md
+++ b/docs/packages/2-feature/plugin.md
@@ -100,11 +100,56 @@ func ResetDefaultRegistry()           // test-only
 - Reload: enabling/disabling a plugin triggers a reload of the
   affected feature packages (commands/skills/subagents/MCP).
 
+## Marketplace & install flow
+
+A marketplace is a catalog. Its `marketplace.json` *declares* plugins;
+each plugin's `source` says where its content actually lives — a path
+inside the marketplace repo, or its own external repo (Claude Code's
+model). "N available" is the count of declared plugins, independent of
+what is cloned on disk.
+
+```mermaid
+flowchart TD
+    A["/plugin → Marketplaces → Add"] --> B["AddGitHub / AddDirectory<br/>record source in known_marketplaces.json"]
+    B --> C["Sync: git clone --depth 1<br/>→ ~/.san/plugins/marketplaces/&lt;id&gt;"]
+    C --> D{"marketplace.json<br/>has plugins[] ?"}
+    D -- yes --> E["MarketplacePlugins:<br/>declared plugins (manifest)"]
+    D -- no --> F["scan vendored subdirs<br/>(fallback)"]
+    E --> G["Discover / Browse list<br/>N available = count"]
+    F --> G
+    G --> H["Install: name@marketplace + scope"]
+    H --> I{"plugin source type ?"}
+    I -- "path (in repo)" --> J["ResolveLocalPluginPath<br/>inside the marketplace clone"]
+    I -- "github / url / git-subdir" --> K["fetchExternalPlugin:<br/>git clone the plugin's own repo<br/>honoring ref/sha, strip .git"]
+    J --> L["copyDir → scope dir"]
+    K --> L
+    L --> M["record in installed_plugins.json"]
+    M --> N["LoadPlugin → Register → Enable"]
+    N --> O["resolve components:<br/>skills / agents / commands / hooks / mcp / lsp"]
+    O --> P["push contributions to feature packages"]
+```
+
+**Plugin `source` formats** (in `marketplace.json` `plugins[]`):
+
+| Form | Example | Content fetched from |
+|------|---------|----------------------|
+| relative path (string) | `"./plugins/foo"` | a directory inside the marketplace repo |
+| `github` | `{"source":"github","repo":"owner/repo","ref?":"","sha?":""}` | that GitHub repo |
+| `url` (alias `git`) | `{"source":"url","url":"https://host/p.git","ref?":""}` | that git repo (any host) |
+| `git-subdir` | `{"source":"git-subdir","url":"…","path":"sub/dir"}` | a subdirectory of that repo |
+| `npm` | `{"source":"npm","package":"@scope/p"}` | npm (parsed; install not yet supported) |
+
+**Scope → install dir:** user → `~/.san/plugins/cache/`, project →
+`.san/plugins/`, local → `.san/plugins-local/`. Enable state lives in
+the scope's `settings.json` under `enabledPlugins`.
+
 ## Tests
 
 ```
-internal/plugin/plugin_test.go      — large suite covering load /
-                                       install / enable / contributions.
+internal/plugin/plugin_test.go              — large suite covering load /
+                                              install / enable / contributions.
+internal/plugin/marketplace_manifest_test.go — manifest source parsing,
+                                              available listing, path install.
 ```
 
 ## See Also

--- a/docs/packages/2-feature/plugin.zh.md
+++ b/docs/packages/2-feature/plugin.zh.md
@@ -120,7 +120,7 @@ flowchart TD
     L --> M["写入 installed_plugins.json"]
     M --> N["LoadPlugin → Register → Enable"]
     N --> O["解析组件：<br/>skills / agents / commands / hooks / mcp / lsp"]
-    O --> P["把贡献推送给 feature 包"]
+    O --> P["app 把它们交给 feature 包<br/>skill / subagent / command / mcp / hook"]
 ```
 
 **插件 `source` 格式**（位于 `marketplace.json` 的 `plugins[]`）：

--- a/docs/packages/2-feature/plugin.zh.md
+++ b/docs/packages/2-feature/plugin.zh.md
@@ -1,0 +1,154 @@
+---
+package: github.com/genai-io/san/internal/plugin
+layer: feature
+---
+
+# plugin
+
+> English version: [`plugin.md`](plugin.md)
+
+插件的加载器、安装器、marketplace 和聚合器。一个插件就是一个包（目录），
+它可以贡献 skills、subagent 定义、斜杠命令、MCP servers、hooks 和环境
+变量——本包负责发现它们、启用/禁用它们，并把它们的贡献暴露给上层的
+feature 包。
+
+## 用途
+
+San 的"其余一切"扩展面。插件让用户一次性安装一整套 skills + agents +
+commands + MCP servers + hooks。本包处理安装/卸载、marketplace 查找、
+加载顺序，以及那些跨切面的回调——让 `skill`、`subagent`、`command`、
+`mcp`、`hook`、`setting` 无需直接 import `plugin` 就能看到每个已启用插件
+贡献了什么。
+
+## 契约
+
+本包直接暴露 `*Registry`，外加一组包级自由函数作为跨域集成面。没有
+生产者侧的接口——每个下游消费者（skill / subagent / command / mcp /
+setting）各自取用一小撮不同的自由函数，统一成一个接口只会把互不相关的
+方法凑到一起。
+
+```go
+package plugin
+
+// Registry 是已加载插件集合 + 各 scope 启用状态的不透明句柄。
+// 类型导出，字段不导出。
+type Registry struct { /* 内部字段 */ }
+
+// 加载
+func (r *Registry) Load(ctx context.Context, cwd string) error
+func (r *Registry) LoadFromPath(ctx context.Context, path string) error
+func (r *Registry) LoadClaudePlugins(ctx context.Context) error
+
+// 查询
+func (r *Registry) Get(name string) (*Plugin, bool)
+func (r *Registry) List() []*Plugin
+func (r *Registry) GetEnabled() []*Plugin
+func (r *Registry) Count() int
+func (r *Registry) EnabledCount() int
+func (r *Registry) GetByScope(scope Scope) []*Plugin
+
+// 变更
+func (r *Registry) Enable(name string, scope Scope) error
+func (r *Registry) Disable(name string, scope Scope) error
+func (r *Registry) Register(p *Plugin)
+func (r *Registry) Unregister(name string)
+
+// 构造 Installer（包级自由函数）
+func NewInstaller(reg *Registry, cwd string) *Installer
+
+// 跨域集成（包级自由函数；从包级默认 registry 读取）。
+// 每个需要插件贡献数据的消费者 import plugin 并调用其中之一：
+func GetPluginAgentPaths() []PluginPath
+func GetPluginSkillPaths() []PluginPath
+func GetPluginCommandPaths() []PluginPath
+func GetPluginMCPServers() []PluginMCPServer
+func GetPluginHooks() map[string][]setting.Hook
+func PluginEnv() []string
+
+// 插件根目录追踪（进程级全局状态；包级函数）
+func SetActivePluginRoot(path string)
+func ClearActivePluginRoot()
+func FindPluginRootForPath(path string) string
+
+// 包级访问
+func Initialize(ctx context.Context, opts Options) error
+func Default() *Registry
+func SetDefaultRegistry(r *Registry)  // 仅测试
+func ResetDefaultRegistry()           // 仅测试
+```
+
+## 内部实现
+
+- `Registry`（`registry.go`）——以 name 为键的 `Plugin` map，按 scope
+  （user / project）保存启用状态。
+- `loader.go`——发现 `.san/plugins/`、`~/.san/plugins/`、
+  `.claude/plugins/`、`~/.claude/plugins/`。
+- `installer.go`——安装/卸载逻辑、依赖检查、版本固定（~13 KB）。
+- `marketplace.go`——registry-of-registries 查找（去哪里找插件来源）。
+- `resolver.go`——name → 安装规格 的解析。
+- `integration.go`——跨域回调的接线。
+
+## 生命周期
+
+- 构造：`Initialize(ctx, Options{CWD})` 是最早一批 `Initialize` 调用之一，
+  因为每个 feature 包的 `Initialize` 都会拉 `plugin.*Paths()`。
+- 重载：启用/禁用一个插件会触发受影响 feature 包
+  （commands/skills/subagents/MCP）的重载。
+
+## Marketplace 与安装流程
+
+marketplace 是一个目录册。它的 `marketplace.json` *声明*插件；每个插件的
+`source` 说明其内容真正在哪——可能是 marketplace 仓库内的一个路径，也可能
+是插件自己的外部仓库（Claude Code 的模型）。"N available" 是被声明插件的
+数量，与磁盘上 clone 了什么无关。
+
+```mermaid
+flowchart TD
+    A["/plugin → Marketplaces → 添加"] --> B["AddGitHub / AddDirectory<br/>把来源记入 known_marketplaces.json"]
+    B --> C["Sync：git clone --depth 1<br/>→ ~/.san/plugins/marketplaces/&lt;id&gt;"]
+    C --> D{"marketplace.json<br/>有 plugins[] 吗？"}
+    D -- "有" --> E["MarketplacePlugins：<br/>清单声明的插件"]
+    D -- "无" --> F["扫描内置子目录<br/>（回退）"]
+    E --> G["Discover / Browse 列表<br/>N available = 数量"]
+    F --> G
+    G --> H["安装：name@marketplace + scope"]
+    H --> I{"插件 source 类型？"}
+    I -- "path（仓库内）" --> J["ResolveLocalPluginPath<br/>在 marketplace clone 内定位"]
+    I -- "github / url / git-subdir" --> K["fetchExternalPlugin：<br/>clone 插件自己的仓库<br/>遵循 ref/sha，剥离 .git"]
+    J --> L["copyDir → scope 目录"]
+    K --> L
+    L --> M["写入 installed_plugins.json"]
+    M --> N["LoadPlugin → Register → Enable"]
+    N --> O["解析组件：<br/>skills / agents / commands / hooks / mcp / lsp"]
+    O --> P["把贡献推送给 feature 包"]
+```
+
+**插件 `source` 格式**（位于 `marketplace.json` 的 `plugins[]`）：
+
+| 形式 | 示例 | 内容来源 |
+|------|------|----------|
+| 相对路径（字符串） | `"./plugins/foo"` | marketplace 仓库内的一个目录 |
+| `github` | `{"source":"github","repo":"owner/repo","ref?":"","sha?":""}` | 该 GitHub 仓库 |
+| `url`（别名 `git`） | `{"source":"url","url":"https://host/p.git","ref?":""}` | 该 git 仓库（任意 host） |
+| `git-subdir` | `{"source":"git-subdir","url":"…","path":"sub/dir"}` | 该仓库的一个子目录 |
+| `npm` | `{"source":"npm","package":"@scope/p"}` | npm（可解析；暂不支持安装） |
+
+**scope → 安装目录：** user → `~/.san/plugins/cache/`，project →
+`.san/plugins/`，local → `.san/plugins-local/`。启用状态保存在对应 scope
+的 `settings.json` 的 `enabledPlugins` 字段下。
+
+## 测试
+
+```
+internal/plugin/plugin_test.go              — 覆盖加载 / 安装 / 启用 /
+                                              贡献的大型测试套件。
+internal/plugin/marketplace_manifest_test.go — 清单 source 解析、
+                                              available 列表、path 安装。
+```
+
+## 另见
+
+- 代码：`internal/plugin/`
+- 消费者：[`packages/skill.md`](skill.md)、[`packages/subagent.md`](subagent.md)、[`packages/command.md`](command.md)、[`packages/mcp.md`](mcp.md)、[`packages/hook.md`](hook.md)、[`packages/setting.md`](setting.md)
+- 概念：[`concepts/extension-model.md`](../../concepts/extension-model.md)
+- 层级：`feature`

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -134,16 +134,13 @@ type PluginSelector struct {
 	installer          *coreplugin.Installer
 }
 
-// Plugin messages
+// Plugin intent messages — each requests one async mutating operation. They
+// bridge from keybindings / executeAction into UpdatePlugin, where deps (cwd,
+// reload) and the spinner live.
 type PluginEnableMsg struct{ PluginName string }
 type PluginDisableMsg struct{ PluginName string }
-
-type PluginToggleResultMsg struct {
-	PluginName string
-	Enable     bool
-	Success    bool
-	Error      error
-}
+type PluginUninstallMsg struct{ PluginName string }
+type PluginMarketplaceRemoveMsg struct{ ID string }
 
 type PluginInstallMsg struct {
 	PluginName  string
@@ -151,20 +148,15 @@ type PluginInstallMsg struct {
 	Scope       coreplugin.Scope
 }
 
-type PluginUninstallMsg struct{ PluginName string }
-
-type PluginInstallResultMsg struct {
-	PluginName string
-	Success    bool
-	Error      error
-}
-
-type PluginMarketplaceRemoveMsg struct{ ID string }
-
-type PluginMarketplaceSyncResultMsg struct {
-	ID      string
-	Success bool
-	Error   error
+// pluginOpResultMsg is the unified outcome of every async mutating operation
+// (install / sync / remove / uninstall / enable / disable). One spinner path,
+// one result handler — see runPluginOp and the pluginOpResultMsg case.
+type pluginOpResultMsg struct {
+	okMsg  string // success status, e.g. "Installed foo"
+	errCtx string // failure verb + subject, e.g. "install foo"
+	err    error
+	pop    bool // goBack() on success (leave the detail / options view)
+	reload bool // ReloadAfterPluginChange() on success
 }
 
 // NewPluginSelector creates a new PluginSelector
@@ -192,40 +184,64 @@ func (s *PluginSelector) IsActive() bool {
 func UpdatePlugin(deps OverlayDeps, state *PluginSelector, msg tea.Msg) (tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case PluginEnableMsg:
-		tick := state.beginLoading(fmt.Sprintf("Enabling %s...", msg.PluginName))
-		return tea.Batch(pluginToggleCmd(state.registry, msg.PluginName, true), tick), true
+		reg, name := state.registry, msg.PluginName
+		return tea.Batch(
+			state.beginLoading("Enabling "+name+"..."),
+			runPluginOp(pluginOpResultMsg{okMsg: "Enabled " + name, errCtx: "enable " + name},
+				func() error { return reg.Enable(name, coreplugin.ScopeUser) }),
+		), true
 
 	case PluginDisableMsg:
-		tick := state.beginLoading(fmt.Sprintf("Disabling %s...", msg.PluginName))
-		return tea.Batch(pluginToggleCmd(state.registry, msg.PluginName, false), tick), true
-
-	case PluginToggleResultMsg:
-		state.HandleToggleResult(msg)
-		return nil, true
-
-	case PluginUninstallMsg:
-		uninstalled := state.HandleUninstall(msg.PluginName)
-		if uninstalled {
-			_ = deps.ReloadAfterPluginChange()
-		}
-		return nil, true
+		reg, name := state.registry, msg.PluginName
+		return tea.Batch(
+			state.beginLoading("Disabling "+name+"..."),
+			runPluginOp(pluginOpResultMsg{okMsg: "Disabled " + name, errCtx: "disable " + name},
+				func() error { return reg.Disable(name, coreplugin.ScopeUser) }),
+		), true
 
 	case PluginInstallMsg:
-		return tea.Batch(pluginInstallCmd(state.registry, deps.Cwd, msg), state.startLoadingTick()), true
+		reg, cwd := state.registry, deps.Cwd
+		name, market, scope := msg.PluginName, msg.Marketplace, msg.Scope
+		return tea.Batch(
+			state.beginLoading("Installing "+name+"..."),
+			runPluginOp(pluginOpResultMsg{okMsg: "Installed " + name, errCtx: "install " + name, pop: true, reload: true},
+				func() error {
+					ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+					defer cancel()
+					return coreplugin.Install(ctx, reg, cwd, coreplugin.FormatPluginRef(name, market), scope)
+				}),
+		), true
 
-	case PluginInstallResultMsg:
-		state.HandleInstallResult(msg)
-		if msg.Success {
-			_ = deps.ReloadAfterPluginChange()
-		}
-		return nil, true
+	case PluginUninstallMsg:
+		inst, name := state.installer, msg.PluginName
+		return tea.Batch(
+			state.beginLoading("Uninstalling "+name+"..."),
+			runPluginOp(pluginOpResultMsg{okMsg: "Uninstalled " + name, errCtx: "uninstall " + name, pop: true, reload: true},
+				func() error { return inst.Uninstall(name, coreplugin.ScopeUser) }),
+		), true
 
 	case PluginMarketplaceRemoveMsg:
-		state.HandleMarketplaceRemove(msg.ID)
-		return nil, true
+		mgr, id := state.marketplaceManager, msg.ID
+		return tea.Batch(
+			state.beginLoading("Removing "+id+"..."),
+			runPluginOp(pluginOpResultMsg{okMsg: "Removed " + id, errCtx: "remove " + id, pop: true},
+				func() error { return mgr.Remove(id) }),
+		), true
 
-	case PluginMarketplaceSyncResultMsg:
-		state.HandleMarketplaceSync(msg)
+	case pluginOpResultMsg:
+		state.endLoading()
+		if msg.err != nil {
+			state.setError(fmt.Sprintf("Failed to %s: %v", msg.errCtx, msg.err))
+		} else {
+			state.setSuccess(msg.okMsg)
+			if msg.pop {
+				state.goBack()
+			}
+		}
+		state.refreshAfterOp()
+		if msg.err == nil && msg.reload {
+			_ = deps.ReloadAfterPluginChange()
+		}
 		return nil, true
 
 	case pluginLoadingTickMsg:
@@ -265,30 +281,20 @@ func (s *PluginSelector) startLoadingTick() tea.Cmd {
 	return pluginLoadingTick()
 }
 
-// pluginToggleCmd enables or disables a plugin in the user scope.
-func pluginToggleCmd(reg *coreplugin.Registry, name string, enable bool) tea.Cmd {
-	return func() tea.Msg {
-		var err error
-		if enable {
-			err = reg.Enable(name, coreplugin.ScopeUser)
-		} else {
-			err = reg.Disable(name, coreplugin.ScopeUser)
-		}
-		return PluginToggleResultMsg{PluginName: name, Enable: enable, Success: err == nil, Error: err}
-	}
+// endLoading clears the spinner. The in-flight tick stops itself on the next
+// frame once it sees isLoading false.
+func (s *PluginSelector) endLoading() {
+	s.isLoading = false
+	s.loadingMsg = ""
 }
 
-// pluginInstallCmd creates a tea.Cmd that installs the requested plugin.
-func pluginInstallCmd(reg *coreplugin.Registry, cwd string, msg PluginInstallMsg) tea.Cmd {
+// runPluginOp wraps a blocking mutation in a command that reports the unified
+// pluginOpResultMsg. Pair it with beginLoading so the spinner runs until the
+// result lands.
+func runPluginOp(res pluginOpResultMsg, work func() error) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-		defer cancel()
-
-		ref := coreplugin.FormatPluginRef(msg.PluginName, msg.Marketplace)
-		if err := coreplugin.Install(ctx, reg, cwd, ref, msg.Scope); err != nil {
-			return PluginInstallResultMsg{PluginName: msg.PluginName, Success: false, Error: err}
-		}
-		return PluginInstallResultMsg{PluginName: msg.PluginName, Success: true}
+		res.err = work()
+		return res
 	}
 }
 
@@ -813,8 +819,8 @@ func (s *PluginSelector) installPlugin(scope coreplugin.Scope) tea.Cmd {
 	}
 	name := s.detailDiscover.Name
 	marketplace := s.detailDiscover.Marketplace
-	s.isLoading = true
-	s.loadingMsg = fmt.Sprintf("Installing %s...", name)
+	// The spinner starts when UpdatePlugin handles PluginInstallMsg, so install
+	// shares the one beginLoading path with every other mutating op.
 	return func() tea.Msg {
 		return PluginInstallMsg{
 			PluginName:  name,
@@ -852,19 +858,18 @@ func (s *PluginSelector) browseMarketplace() {
 	s.scrollOffset = 0
 }
 
-// syncMarketplace creates a sync command for a marketplace.
+// syncMarketplace clones or updates a marketplace, driving the shared spinner.
 func (s *PluginSelector) syncMarketplace(id string) tea.Cmd {
-	s.isLoading = true
-	s.loadingMsg = fmt.Sprintf("Syncing %s...", id)
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-
-		if err := s.marketplaceManager.SyncOrPrune(ctx, id); err != nil {
-			return PluginMarketplaceSyncResultMsg{ID: id, Success: false, Error: err}
-		}
-		return PluginMarketplaceSyncResultMsg{ID: id, Success: true}
-	}
+	mgr := s.marketplaceManager
+	return tea.Batch(
+		s.beginLoading("Syncing "+id+"..."),
+		runPluginOp(pluginOpResultMsg{okMsg: "Synced " + id, errCtx: "sync " + id},
+			func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer cancel()
+				return mgr.SyncOrPrune(ctx, id)
+			}),
+	)
 }
 
 // toggleSelectedPlugin toggles enable/disable for the selected plugin.
@@ -878,79 +883,6 @@ func (s *PluginSelector) toggleSelectedPlugin() tea.Cmd {
 		}
 	}
 	return nil
-}
-
-// HandleToggleResult handles plugin enable/disable results.
-func (s *PluginSelector) HandleToggleResult(msg PluginToggleResultMsg) {
-	s.isLoading = false
-	s.loadingMsg = ""
-	if msg.Success {
-		past := "Disabled"
-		if msg.Enable {
-			past = "Enabled"
-		}
-		s.setSuccess(fmt.Sprintf("%s %s", past, msg.PluginName))
-	} else {
-		action := "disable"
-		if msg.Enable {
-			action = "enable"
-		}
-		s.setError(fmt.Sprintf("Failed to %s: %v", action, msg.Error))
-	}
-	s.refreshAndUpdateView()
-}
-
-// HandleUninstall removes a plugin and reports whether the on-disk state
-// changed (so the caller can trigger a registry reload).
-func (s *PluginSelector) HandleUninstall(name string) bool {
-	if err := s.installer.Uninstall(name, coreplugin.ScopeUser); err != nil {
-		s.setError(fmt.Sprintf("Failed to uninstall: %v", err))
-		s.refreshAndUpdateView()
-		return false
-	}
-	s.setSuccess(fmt.Sprintf("Uninstalled %s", name))
-	s.goBack()
-	s.refreshAndUpdateView()
-	return true
-}
-
-// HandleInstallResult handles the result of plugin installation.
-func (s *PluginSelector) HandleInstallResult(msg PluginInstallResultMsg) {
-	s.isLoading = false
-	s.loadingMsg = ""
-	if !msg.Success {
-		s.setError(fmt.Sprintf("Failed to install: %v", msg.Error))
-	} else {
-		s.setSuccess(fmt.Sprintf("Installed %s", msg.PluginName))
-		s.goBack()
-	}
-	s.refreshAndUpdateView()
-}
-
-// HandleMarketplaceSync handles marketplace sync result.
-func (s *PluginSelector) HandleMarketplaceSync(msg PluginMarketplaceSyncResultMsg) {
-	s.isLoading = false
-	s.loadingMsg = ""
-	if !msg.Success {
-		// A broken GitHub source is pruned inside SyncOrPrune; here we just
-		// surface the failure and let the refresh reflect any pruning.
-		s.setError(fmt.Sprintf("Failed to sync %s: %v", msg.ID, msg.Error))
-	} else {
-		s.setSuccess(fmt.Sprintf("Synced %s", msg.ID))
-	}
-	s.refreshMarketplaces()
-	s.refreshDiscoverPlugins()
-}
-
-// HandleMarketplaceRemove handles marketplace removal.
-func (s *PluginSelector) HandleMarketplaceRemove(id string) {
-	if err := s.marketplaceManager.Remove(id); err != nil {
-		s.setError(fmt.Sprintf("Failed to remove: %v", err))
-	} else {
-		s.setSuccess(fmt.Sprintf("Removed %s", id))
-		s.goBack()
-	}
-	s.refreshMarketplaces()
 }
 
 // setError sets an error message.
@@ -1203,9 +1135,14 @@ func (s *PluginSelector) enrichDiscoverItem(item *pluginDiscoverItem) {
 	}
 }
 
-// refreshAndUpdateView refreshes plugins and updates the detail view if active
-func (s *PluginSelector) refreshAndUpdateView() {
-	s.refreshCurrentTab()
+// refreshAfterOp reloads every tab's data and the open detail view after a
+// mutation, so counts and lists stay consistent no matter which tab the op was
+// triggered from. Runs on the warm post-op path, not per keystroke.
+func (s *PluginSelector) refreshAfterOp() {
+	s.refreshMarketplaces()
+	s.refreshDiscoverPlugins()
+	s.refreshInstalledPlugins()
+	s.updateFilter()
 	if s.level == pluginLevelDetail && s.detailPlugin != nil {
 		s.refreshDetailView()
 	}

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -631,6 +631,7 @@ func (s *PluginSelector) ensureVisible() {
 // enterDetail enters the detail view for the selected item.
 func (s *PluginSelector) enterDetail() {
 	s.parentIdx = s.selectedIdx
+	s.clearMessage() // a fresh action view shouldn't show a prior op's result
 
 	switch s.activeTab {
 	case pluginTabInstalled:

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -308,6 +308,23 @@ func (s *PluginSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 	return s.handleListKeypress(key)
 }
 
+// HandlePaste appends bracketed-paste content to the marketplace-source field.
+// A source is a single token (URL, owner/repo, or local path), so embedded
+// newlines and surrounding whitespace are stripped rather than inserted.
+func (s *PluginSelector) HandlePaste(content string) tea.Cmd {
+	if s.level != pluginLevelAddMarketplace {
+		return nil
+	}
+	content = strings.NewReplacer("\r", "", "\n", "").Replace(content)
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	s.addMarketplaceInput += content
+	s.clearMessage()
+	return nil
+}
+
 func (s *PluginSelector) handleAddMarketplaceKeypress(key tea.KeyMsg) tea.Cmd {
 	switch key.String() {
 	case "esc":
@@ -318,12 +335,14 @@ func (s *PluginSelector) handleAddMarketplaceKeypress(key tea.KeyMsg) tea.Cmd {
 	case "backspace":
 		if len(s.addMarketplaceInput) > 0 {
 			s.addMarketplaceInput = s.addMarketplaceInput[:len(s.addMarketplaceInput)-1]
+			s.clearMessage()
 		}
 		return nil
 	default:
 		// Typed text capture: append printable characters to the input.
 		if text := key.Key().Text; text != "" {
 			s.addMarketplaceInput += text
+			s.clearMessage()
 		}
 		return nil
 	}
@@ -814,20 +833,17 @@ func (s *PluginSelector) browseMarketplace() {
 	s.browseMarketplaceID = s.detailMarketplace.ID
 	s.browsePlugins = []pluginDiscoverItem{}
 
-	plugins, err := s.marketplaceManager.ListPlugins(s.detailMarketplace.ID)
+	plugins, err := s.marketplaceManager.MarketplacePlugins(s.detailMarketplace.ID)
 	if err != nil {
 		s.setError(fmt.Sprintf("Failed to list plugins: %v", err))
 		return
 	}
 
 	installedNames := s.getInstalledNames()
-	for _, pluginName := range plugins {
-		item := s.newDiscoverItem(pluginName, s.detailMarketplace.ID, installedNames)
-		if pluginPath, err := s.marketplaceManager.GetPluginPath(s.detailMarketplace.ID, pluginName); err == nil {
-			if p, err := coreplugin.LoadPlugin(pluginPath, coreplugin.ScopeUser, pluginName+"@"+s.detailMarketplace.ID); err == nil {
-				item.Description = p.Manifest.Description
-			}
-		}
+	for _, mp := range plugins {
+		item := s.newDiscoverItem(mp.Name, s.detailMarketplace.ID, installedNames)
+		applyMarketplacePlugin(&item, mp)
+		s.enrichDiscoverItem(&item)
 		s.browsePlugins = append(s.browsePlugins, item)
 	}
 
@@ -1054,13 +1070,14 @@ func (s *PluginSelector) refreshDiscoverPlugins() {
 	installedNames := s.getInstalledNames()
 
 	for _, marketplaceID := range s.marketplaceManager.List() {
-		plugins, err := s.marketplaceManager.ListPlugins(marketplaceID)
+		plugins, err := s.marketplaceManager.MarketplacePlugins(marketplaceID)
 		if err != nil {
 			continue
 		}
 
-		for _, pluginName := range plugins {
-			item := s.newDiscoverItem(pluginName, marketplaceID, installedNames)
+		for _, mp := range plugins {
+			item := s.newDiscoverItem(mp.Name, marketplaceID, installedNames)
+			applyMarketplacePlugin(&item, mp)
 			s.enrichDiscoverItem(&item)
 			s.discoverPlugins = append(s.discoverPlugins, item)
 		}
@@ -1105,7 +1122,7 @@ func (s *PluginSelector) refreshMarketplaces() {
 			item.Source = entry.Source.Path
 		}
 
-		if plugins, err := s.marketplaceManager.ListPlugins(id); err == nil {
+		if plugins, err := s.marketplaceManager.MarketplacePlugins(id); err == nil {
 			item.Available = len(plugins)
 		}
 
@@ -1147,7 +1164,21 @@ func (s *PluginSelector) newDiscoverItem(name, marketplaceID string, installed m
 	}
 }
 
-// enrichDiscoverItem loads manifest details into an item.
+// applyMarketplacePlugin copies the metadata a marketplace.json entry declares
+// into a discover item. This is the only metadata available for plugins whose
+// content lives in another repo and isn't fetched until install.
+func applyMarketplacePlugin(item *pluginDiscoverItem, mp coreplugin.MarketplacePlugin) {
+	item.Description = mp.Description
+	item.Version = mp.Version
+	if mp.Author != nil {
+		item.Author = mp.Author.Name
+	}
+}
+
+// enrichDiscoverItem fills any fields the marketplace.json entry left empty from
+// the plugin's own manifest on disk. It is best-effort: plugins whose content
+// isn't vendored in the marketplace repo (external sources, not yet installed)
+// simply keep the marketplace metadata.
 func (s *PluginSelector) enrichDiscoverItem(item *pluginDiscoverItem) {
 	fullName := item.Name + "@" + item.Marketplace
 	pluginPath, err := s.marketplaceManager.GetPluginPath(item.Marketplace, item.Name)
@@ -1158,12 +1189,18 @@ func (s *PluginSelector) enrichDiscoverItem(item *pluginDiscoverItem) {
 	if err != nil {
 		return
 	}
-	item.Description = p.Manifest.Description
-	item.Version = p.Manifest.Version
-	if p.Manifest.Author != nil {
+	if item.Description == "" {
+		item.Description = p.Manifest.Description
+	}
+	if item.Version == "" {
+		item.Version = p.Manifest.Version
+	}
+	if item.Author == "" && p.Manifest.Author != nil {
 		item.Author = p.Manifest.Author.Name
 	}
-	item.Homepage = p.Manifest.Homepage
+	if item.Homepage == "" {
+		item.Homepage = p.Manifest.Homepage
+	}
 }
 
 // refreshAndUpdateView refreshes plugins and updates the detail view if active

--- a/internal/app/input/on_plugin_test.go
+++ b/internal/app/input/on_plugin_test.go
@@ -277,6 +277,36 @@ func TestHandlePluginCommandInstallFromMarketplace(t *testing.T) {
 	}
 }
 
+func TestHandlePasteAppendsMarketplaceSource(t *testing.T) {
+	m := NewPluginSelector(coreplugin.NewRegistry())
+	m.level = pluginLevelAddMarketplace
+	m.addMarketplaceInput = "owner/"
+	m.lastMessage = "Please enter a marketplace source"
+	m.isError = true
+
+	// Newlines/whitespace from a terminal paste are stripped, not embedded,
+	// and the stale validation error is cleared.
+	m.HandlePaste("repo\n")
+
+	if m.addMarketplaceInput != "owner/repo" {
+		t.Fatalf("HandlePaste = %q, want %q", m.addMarketplaceInput, "owner/repo")
+	}
+	if m.lastMessage != "" || m.isError {
+		t.Fatal("HandlePaste should clear the stale error message")
+	}
+}
+
+func TestHandlePasteIgnoredOutsideAddDialog(t *testing.T) {
+	m := NewPluginSelector(coreplugin.NewRegistry())
+	m.level = pluginLevelTabList
+
+	m.HandlePaste("owner/repo")
+
+	if m.addMarketplaceInput != "" {
+		t.Fatalf("HandlePaste outside add dialog mutated input: %q", m.addMarketplaceInput)
+	}
+}
+
 func createTestPluginMarketplace(t *testing.T) string {
 	t.Helper()
 

--- a/internal/app/input/on_plugin_view.go
+++ b/internal/app/input/on_plugin_view.go
@@ -212,7 +212,10 @@ func (s *PluginSelector) renderInstalledList(sb *strings.Builder) {
 		return
 	}
 
-	visible := max(4, s.bodyHeight())
+	// Two lines per item (name row + indented description), like the Discover
+	// list, so a long description wraps onto its own bounded line instead of
+	// running to the right edge.
+	visible := max(2, s.bodyHeight()/2)
 	endIdx := min(s.scrollOffset+visible, len(s.filteredItems))
 	cw := s.contentWidth()
 
@@ -233,20 +236,16 @@ func (s *PluginSelector) renderInstalledList(sb *strings.Builder) {
 		if p.Marketplace != "" {
 			nameStr += dimStyle.Render(" · " + p.Marketplace)
 		}
-
-		line := fmt.Sprintf("%s %s", iconStyle.Render(icon), nameStr)
+		sb.WriteString(kit.RenderSelectableRow(fmt.Sprintf("%s %s", iconStyle.Render(icon), nameStr), i == s.selectedIdx))
+		sb.WriteString("\n")
 
 		if p.Description != "" {
-			// 4 = PaddingLeft(2) + cursor(2) from RenderSelectableRow; 3 = " · " separator
-			maxDescLen := cw - lipgloss.Width(line) - 4 - 3
+			maxDescLen := cw - 8
 			if maxDescLen > 20 {
-				desc := kit.TruncateText(p.Description, maxDescLen)
-				line += dimStyle.Render(" · " + desc)
+				sb.WriteString(dimStyle.PaddingLeft(6).Render(kit.TruncateText(p.Description, maxDescLen)))
+				sb.WriteString("\n")
 			}
 		}
-
-		sb.WriteString(kit.RenderSelectableRow(line, i == s.selectedIdx))
-		sb.WriteString("\n")
 	}
 
 	if endIdx < len(s.filteredItems) {
@@ -695,18 +694,34 @@ func (s *PluginSelector) renderActions(sb *strings.Builder) {
 		Foreground(kit.CurrentTheme.Text).
 		PaddingLeft(2)
 
-	spinnerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus)
 	for i, action := range s.actions {
 		if i == s.actionIdx {
+			// The active action carries its own status inline: the spinner while
+			// the op runs, then the ✓/⚠ result — so feedback stays on this row
+			// rather than dropping to the footer.
 			sb.WriteString(accentStyle.Render("❯ " + action.Label))
-			// The action being executed carries the spinner inline, on its row.
-			if s.isLoading {
-				sb.WriteString(spinnerStyle.Render("   " + s.spinnerFrame() + " " + s.loadingMsg))
-			}
+			sb.WriteString(s.inlineActionStatus())
 		} else {
 			sb.WriteString(normalStyle.Render("  " + action.Label))
 		}
 		sb.WriteString("\n")
+	}
+}
+
+// inlineActionStatus returns the trailing status for the active action row: the
+// spinner during a loading op, the ✓/⚠ result after one, or "" when idle.
+func (s *PluginSelector) inlineActionStatus() string {
+	switch {
+	case s.isLoading:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus).
+			Render("   " + s.spinnerFrame() + " " + s.loadingMsg)
+	case s.lastMessage == "":
+		return ""
+	case s.isError:
+		return kit.SelectorStatusError().Render("   ⚠ " + s.lastMessage)
+	default:
+		return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success).
+			Render("   ✓ " + s.lastMessage)
 	}
 }
 
@@ -720,23 +735,24 @@ func (s *PluginSelector) spinnerFrame() string {
 }
 
 func (s *PluginSelector) renderFooter(sb *strings.Builder, hint string) {
-	// In action views the spinner rides inline on the active action row (see
-	// renderActions), so the footer only carries it for list-style views.
+	// Action views carry the spinner and ✓/⚠ result inline on the active action
+	// row (see renderActions / inlineActionStatus); the footer shows them only
+	// for list-style views, which have no action row.
 	inActionView := s.level == pluginLevelDetail || s.level == pluginLevelInstallOptions
-	if s.isLoading {
-		if !inActionView {
+	if !inActionView {
+		if s.isLoading {
 			spinnerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus)
 			sb.WriteString(spinnerStyle.Render("  " + s.spinnerFrame() + " " + s.loadingMsg))
 			sb.WriteString("\n")
+		} else if s.lastMessage != "" {
+			if s.isError {
+				sb.WriteString(kit.SelectorStatusError().Render("  ⚠ " + s.lastMessage))
+			} else {
+				successStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
+				sb.WriteString(successStyle.Render("  ✓ " + s.lastMessage))
+			}
+			sb.WriteString("\n")
 		}
-	} else if s.lastMessage != "" {
-		if s.isError {
-			sb.WriteString(kit.SelectorStatusError().Render("  ⚠ " + s.lastMessage))
-		} else {
-			successStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
-			sb.WriteString(successStyle.Render("  ✓ " + s.lastMessage))
-		}
-		sb.WriteString("\n")
 	}
 	sb.WriteString(kit.DimStyle().Render(hint))
 }

--- a/internal/app/input/on_plugin_view.go
+++ b/internal/app/input/on_plugin_view.go
@@ -300,10 +300,9 @@ func (s *PluginSelector) renderDiscoverList(sb *strings.Builder) {
 		sb.WriteString("\n")
 
 		if p.Description != "" {
+			// Use the full available width (indent is PaddingLeft(6)) so wide
+			// terminals show more of the description instead of padding empty space.
 			maxDescLen := cw - 8
-			if maxDescLen > 100 {
-				maxDescLen = 100
-			}
 			if maxDescLen > 20 {
 				desc := kit.TruncateText(p.Description, maxDescLen)
 				sb.WriteString(dimStyle.PaddingLeft(6).Render(desc))
@@ -696,9 +695,14 @@ func (s *PluginSelector) renderActions(sb *strings.Builder) {
 		Foreground(kit.CurrentTheme.Text).
 		PaddingLeft(2)
 
+	spinnerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus)
 	for i, action := range s.actions {
 		if i == s.actionIdx {
 			sb.WriteString(accentStyle.Render("❯ " + action.Label))
+			// The action being executed carries the spinner inline, on its row.
+			if s.isLoading {
+				sb.WriteString(spinnerStyle.Render("   " + s.spinnerFrame() + " " + s.loadingMsg))
+			}
 		} else {
 			sb.WriteString(normalStyle.Render("  " + action.Label))
 		}
@@ -708,14 +712,23 @@ func (s *PluginSelector) renderActions(sb *strings.Builder) {
 
 // ── Footer ────────────────────────────────────────────────────────────────
 
-var pluginSpinnerFrames = [4]string{"◐", "◓", "◑", "◒"}
+var pluginSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// spinnerFrame returns the current spinner glyph for the loading animation.
+func (s *PluginSelector) spinnerFrame() string {
+	return pluginSpinnerFrames[s.loadingFrame%len(pluginSpinnerFrames)]
+}
 
 func (s *PluginSelector) renderFooter(sb *strings.Builder, hint string) {
+	// In action views the spinner rides inline on the active action row (see
+	// renderActions), so the footer only carries it for list-style views.
+	inActionView := s.level == pluginLevelDetail || s.level == pluginLevelInstallOptions
 	if s.isLoading {
-		spinnerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent)
-		frame := pluginSpinnerFrames[s.loadingFrame%len(pluginSpinnerFrames)]
-		sb.WriteString(spinnerStyle.Render("  " + frame + " " + s.loadingMsg))
-		sb.WriteString("\n")
+		if !inActionView {
+			spinnerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Focus)
+			sb.WriteString(spinnerStyle.Render("  " + s.spinnerFrame() + " " + s.loadingMsg))
+			sb.WriteString("\n")
+		}
 	} else if s.lastMessage != "" {
 		if s.isError {
 			sb.WriteString(kit.SelectorStatusError().Render("  ⚠ " + s.lastMessage))

--- a/internal/app/input/on_plugin_view.go
+++ b/internal/app/input/on_plugin_view.go
@@ -555,36 +555,61 @@ func (s *PluginSelector) renderMarketplaceDetail() string {
 
 func (s *PluginSelector) renderAddMarketplaceDialog() string {
 	var sb strings.Builder
-	cw := s.contentWidth()
+	innerWidth := max(20, s.contentWidth()-4)
 
 	dimStyle := kit.DimStyle()
-	brightStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextBright)
+	valStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Text)
+	sepStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDisabled)
 
 	sb.WriteString(s.sepLine())
 	sb.WriteString("\n")
 	sb.WriteString(kit.SelectorTitleStyle().Render("Add Marketplace"))
 	sb.WriteString("\n\n")
 
-	sb.WriteString(dimStyle.Render("Enter marketplace source:"))
-	sb.WriteString("\n\n")
-	sb.WriteString(dimStyle.Render("Examples:"))
-	sb.WriteString("\n")
-	sb.WriteString(dimStyle.Render("  • https://github.com/owner/repo"))
-	sb.WriteString("\n")
-	sb.WriteString(dimStyle.Render("  • owner/repo (GitHub shorthand)"))
-	sb.WriteString("\n")
-	sb.WriteString(dimStyle.Render("  • ./path/to/marketplace (local)"))
-	sb.WriteString("\n\n")
-
-	maxInputLen := cw - 6
-	inputLine := s.addMarketplaceInput + "│"
-	if len(inputLine) > maxInputLen {
-		inputLine = "…" + inputLine[len(inputLine)-maxInputLen+1:]
+	// Accepted formats, value left-aligned in a column with a dim note.
+	examples := []struct{ value, note string }{
+		{"https://github.com/owner/repo", "full GitHub URL"},
+		{"owner/repo", "GitHub shorthand"},
+		{"./path/to/marketplace", "local path"},
 	}
-	sb.WriteString(brightStyle.Render("> " + inputLine))
+	const valCol = 31
+	for _, ex := range examples {
+		pad := strings.Repeat(" ", max(2, valCol-lipgloss.Width(ex.value)))
+		sb.WriteString("  ")
+		sb.WriteString(valStyle.Render(ex.value))
+		sb.WriteString(pad)
+		sb.WriteString(sepStyle.Render("· "))
+		sb.WriteString(dimStyle.Render(ex.note))
+		sb.WriteString("\n")
+	}
 	sb.WriteString("\n")
 
-	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render("Paste or type a marketplace source:"))
+	sb.WriteString("\n\n")
+
+	// Input field — a filled box matching the plugin filter search box, with a
+	// ▏ caret. Empty shows a dim placeholder; a long source scrolls so the tail
+	// (where the caret sits) stays visible.
+	fieldFg := kit.CurrentTheme.TextBright
+	fieldText := s.addMarketplaceInput + "▏"
+	if s.addMarketplaceInput == "" {
+		fieldFg = kit.CurrentTheme.TextDim
+		fieldText = "▏ owner/repo, a GitHub URL, or a local path"
+	} else if lipgloss.Width(fieldText) > innerWidth-2 {
+		runes := []rune(s.addMarketplaceInput)
+		keep := max(1, innerWidth-4) // room for "…", caret, and padding
+		if keep < len(runes) {
+			fieldText = "…" + string(runes[len(runes)-keep:]) + "▏"
+		}
+	}
+	sb.WriteString(lipgloss.NewStyle().
+		Foreground(fieldFg).
+		Background(kit.SearchBg).
+		Padding(0, 1).
+		Width(innerWidth).
+		Render(fieldText))
+
+	sb.WriteString("\n\n")
 	sb.WriteString(s.sepLine())
 	sb.WriteString("\n")
 	s.renderFooter(&sb, "enter add · esc cancel")

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -39,6 +39,15 @@ type overlayPanel interface {
 	Render() string
 }
 
+// pasteHandler is the optional half of overlayPanel for text-entry dialogs.
+// Bracketed paste arrives as tea.PasteMsg, which is not a tea.KeyMsg, so it
+// never reaches HandleKeypress — it needs its own routing (see Update). An
+// overlay that accepts pasted text implements this; one that doesn't has the
+// paste dropped rather than leaking into the hidden prompt textarea behind it.
+type pasteHandler interface {
+	HandlePaste(content string) tea.Cmd
+}
+
 // overlayPanels lists every panel that may be in front, in keyboard-priority
 // order: the docked modals win over the slash-command pickers. At most one is
 // active at a time; activeOverlay returns the first that reports IsActive().
@@ -80,6 +89,17 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		if c, ok := m.routeKeypress(msg); ok {
 			return m, c
+		}
+	case tea.PasteMsg:
+		// Route paste to the foreground overlay, mirroring routeKeypress.
+		// When an overlay owns the screen but can't take paste, drop it so
+		// it doesn't leak into the prompt textarea hidden behind it. With no
+		// overlay up, fall through to the textarea's own paste handling.
+		if ov, ok := m.activeOverlay(); ok {
+			if ph, ok := ov.(pasteHandler); ok {
+				return m, ph.HandlePaste(msg.Content)
+			}
+			return m, nil
 		}
 	case tea.WindowSizeMsg:
 		return m, m.handleWindowResize(msg)

--- a/internal/mcp/transport/stdio.go
+++ b/internal/mcp/transport/stdio.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
 
+	"go.uber.org/zap"
+
+	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/proc"
 )
 
@@ -81,8 +83,16 @@ func (t *STDIOTransport) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 
-	// Redirect stderr to our stderr for debugging
-	t.cmd.Stderr = os.Stderr
+	// Capture the server's stderr and forward it to the debug log. Inheriting
+	// os.Stderr would write the server's diagnostics straight onto the terminal
+	// the TUI owns, corrupting the alt-screen (e.g. a plugin's MCP server
+	// printing startup banners over the prompt).
+	stderr, err := t.cmd.StderrPipe()
+	if err != nil {
+		_ = t.stdin.Close()
+		_ = t.stdout.Close()
+		return fmt.Errorf("failed to get stderr pipe: %w", err)
+	}
 
 	// Start the process
 	if err := t.cmd.Start(); err != nil {
@@ -90,6 +100,8 @@ func (t *STDIOTransport) Start(ctx context.Context) error {
 		_ = t.stdout.Close()
 		return fmt.Errorf("failed to start MCP server: %w", err)
 	}
+
+	go t.drainStderr(stderr)
 
 	t.scanner = bufio.NewScanner(t.stdout)
 	// Allow for large messages (up to 10MB)
@@ -102,6 +114,19 @@ func (t *STDIOTransport) Start(ctx context.Context) error {
 	go t.readLoop()
 
 	return nil
+}
+
+// drainStderr forwards the MCP server's stderr to the debug log line by line,
+// keeping server diagnostics available (under SAN_DEBUG) without writing to the
+// terminal the TUI owns.
+func (t *STDIOTransport) drainStderr(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		log.Logger().Debug("mcp server stderr",
+			zap.String("command", t.config.Command),
+			zap.String("line", scanner.Text()))
+	}
 }
 
 // readLoop continuously reads responses from stdout

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -153,18 +153,22 @@ func (i *Installer) Install(ctx context.Context, ref string, scope Scope) error 
 		return fmt.Errorf("could not find plugin: %s", name)
 	}
 
-	// Ensure a GitHub marketplace's repo (and its marketplace.json) is present
-	// locally before we read the plugin's declared source.
-	if i.marketplaces[marketplace].Type == "github" {
+	// Resolve the plugin's declared source from the local marketplace.json.
+	// Only refresh a GitHub marketplace from the network when its manifest
+	// isn't available yet: installing shouldn't force a re-sync, and a
+	// transient pull failure shouldn't block installing a plugin that lives in
+	// its own repo.
+	psrc, declared := i.resolvePluginSource(marketplace, name)
+	if !declared && i.marketplaces[marketplace].Type == "github" {
 		if err := i.marketplaceManager.Sync(ctx, marketplace); err != nil {
 			return fmt.Errorf("failed to sync marketplace %s: %w", marketplace, err)
 		}
+		psrc, declared = i.resolvePluginSource(marketplace, name)
 	}
 
 	// Locate the plugin's content. Following Claude Code's model, a marketplace
 	// may merely declare a plugin whose content lives in its own repo — fetch
 	// that; otherwise the content sits inside the marketplace repo.
-	psrc, declared := i.resolvePluginSource(marketplace, name)
 	var srcPath string
 	if declared && psrc.External() {
 		path, cleanup, err := fetchExternalPlugin(ctx, psrc)

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -166,14 +166,13 @@ func (i *Installer) Install(ctx context.Context, ref string, scope Scope) error 
 	// that; otherwise the content sits inside the marketplace repo.
 	psrc, declared := i.resolvePluginSource(marketplace, name)
 	var srcPath string
-	cleanup := func() {}
 	if declared && psrc.External() {
-		path, c, err := fetchExternalPlugin(ctx, psrc)
+		path, cleanup, err := fetchExternalPlugin(ctx, psrc)
 		if err != nil {
 			return fmt.Errorf("failed to fetch plugin %s: %w", name, err)
 		}
-		srcPath, cleanup = path, c
 		defer cleanup()
+		srcPath = path
 	} else {
 		path, err := i.marketplaceManager.ResolveLocalPluginPath(marketplace, name, psrc)
 		if err != nil {
@@ -318,14 +317,13 @@ func (i *Installer) findMarketplaceFor(name string) string {
 // returns the directory holding the plugin root (the repo, or a subdirectory of
 // it for git-subdir sources), along with a cleanup func the caller must defer.
 func fetchExternalPlugin(ctx context.Context, src PluginSource) (string, func(), error) {
-	noop := func() {}
 	if src.Type == SourceNPM {
-		return "", noop, fmt.Errorf("npm plugin sources are not supported yet")
+		return "", nil, fmt.Errorf("npm plugin sources are not supported yet")
 	}
 
 	tmp, err := os.MkdirTemp("", "san-plugin-*")
 	if err != nil {
-		return "", noop, err
+		return "", nil, err
 	}
 	cleanup := func() { _ = os.RemoveAll(tmp) }
 
@@ -336,21 +334,21 @@ func fetchExternalPlugin(ctx context.Context, src PluginSource) (string, func(),
 	url = normalizeGitURL(url)
 	if url == "" {
 		cleanup()
-		return "", noop, fmt.Errorf("plugin source has no repository URL")
+		return "", nil, fmt.Errorf("plugin source has no repository URL")
 	}
 
 	if err := cloneRepo(ctx, url, src.Ref, src.SHA, tmp); err != nil {
 		cleanup()
-		return "", noop, err
+		return "", nil, err
 	}
 	_ = os.RemoveAll(filepath.Join(tmp, ".git"))
 
 	root := tmp
 	if src.Type == SourceGitSubdir && src.Path != "" {
-		clean := filepath.Clean(src.Path)
-		if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+		clean, err := safeRelPath(src.Path)
+		if err != nil {
 			cleanup()
-			return "", noop, fmt.Errorf("invalid subdir path: %s", src.Path)
+			return "", nil, err
 		}
 		root = filepath.Join(tmp, clean)
 	}

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -137,68 +137,61 @@ func Install(ctx context.Context, reg *Registry, cwd, ref string, scope Scope) e
 func (i *Installer) Install(ctx context.Context, ref string, scope Scope) error {
 	name, marketplace := ParsePluginRef(ref)
 
-	// Find marketplace source
-	source, ok := i.marketplaces[marketplace]
-	if !ok && marketplace != "" {
-		// Fallback: try matching by marketplace.json "name" field
-		if resolved := i.resolveMarketplaceByName(marketplace); resolved != "" {
-			source, ok = i.marketplaces[resolved]
-			marketplace = resolved
+	// Resolve the marketplace: explicit ID, marketplace.json "name", or — when
+	// none is given — the first known marketplace that offers this plugin.
+	if marketplace != "" {
+		if _, ok := i.marketplaces[marketplace]; !ok {
+			if resolved := i.resolveMarketplaceByName(marketplace); resolved != "" {
+				marketplace = resolved
+			} else {
+				return fmt.Errorf("unknown marketplace: %s", marketplace)
+			}
 		}
-		if !ok {
-			return fmt.Errorf("unknown marketplace: %s", marketplace)
+	} else if found := i.findMarketplaceFor(name); found != "" {
+		marketplace = found
+	} else {
+		return fmt.Errorf("could not find plugin: %s", name)
+	}
+
+	// Ensure a GitHub marketplace's repo (and its marketplace.json) is present
+	// locally before we read the plugin's declared source.
+	if i.marketplaces[marketplace].Type == "github" {
+		if err := i.marketplaceManager.Sync(ctx, marketplace); err != nil {
+			return fmt.Errorf("failed to sync marketplace %s: %w", marketplace, err)
 		}
 	}
 
-	// Determine install path
+	// Locate the plugin's content. Following Claude Code's model, a marketplace
+	// may merely declare a plugin whose content lives in its own repo — fetch
+	// that; otherwise the content sits inside the marketplace repo.
+	psrc, declared := i.resolvePluginSource(marketplace, name)
+	var srcPath string
+	cleanup := func() {}
+	if declared && psrc.External() {
+		path, c, err := fetchExternalPlugin(ctx, psrc)
+		if err != nil {
+			return fmt.Errorf("failed to fetch plugin %s: %w", name, err)
+		}
+		srcPath, cleanup = path, c
+		defer cleanup()
+	} else {
+		path, err := i.marketplaceManager.ResolveLocalPluginPath(marketplace, name, psrc)
+		if err != nil {
+			return fmt.Errorf("plugin %s not found in marketplace %s: %w", name, marketplace, err)
+		}
+		srcPath = path
+	}
+
+	// Install into the scope dir as a fresh copy (no .git history).
 	installDir := i.getInstallDir(scope)
 	pluginPath := filepath.Join(installDir, name)
-
-	// Create install directory
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create install directory: %w", err)
 	}
-
-	// Install based on source type
-	var err error
-	switch source.Type {
-	case "directory":
-		// Use marketplace manager to find the correct plugin path
-		srcPath, pathErr := i.marketplaceManager.GetPluginPath(marketplace, name)
-		if pathErr != nil {
-			// Fallback to direct path
-			srcPath = filepath.Join(source.Path, name)
-		}
-		err = copyDir(srcPath, pluginPath)
-	case "github":
-		// First sync the marketplace to get the repo
-		if syncErr := i.marketplaceManager.Sync(ctx, marketplace); syncErr != nil {
-			return fmt.Errorf("failed to sync marketplace %s: %w", marketplace, syncErr)
-		}
-		// Then copy the specific plugin subdirectory
-		srcPath, pathErr := i.marketplaceManager.GetPluginPath(marketplace, name)
-		if pathErr != nil {
-			return fmt.Errorf("plugin %s not found in marketplace %s: %w", name, marketplace, pathErr)
-		}
-		err = copyDir(srcPath, pluginPath)
-	default:
-		// Try to find in any configured marketplace
-		if marketplace == "" {
-			for mktID := range i.marketplaces {
-				srcPath, pathErr := i.marketplaceManager.GetPluginPath(mktID, name)
-				if pathErr == nil {
-					err = copyDir(srcPath, pluginPath)
-					marketplace = mktID
-					break
-				}
-			}
-		}
-		if marketplace == "" {
-			return fmt.Errorf("could not find plugin: %s", name)
-		}
+	if err := os.RemoveAll(pluginPath); err != nil {
+		return fmt.Errorf("failed to clear previous install: %w", err)
 	}
-
-	if err != nil {
+	if err := copyDir(srcPath, pluginPath); err != nil {
 		return fmt.Errorf("failed to install plugin: %w", err)
 	}
 
@@ -286,6 +279,131 @@ func (i *Installer) getInstallDir(scope Scope) string {
 	default:
 		return filepath.Join(confdir.Dir(homeDir), "plugins", "cache")
 	}
+}
+
+// resolvePluginSource returns the source declared for a plugin in a
+// marketplace's marketplace.json, and whether such a declaration was found.
+func (i *Installer) resolvePluginSource(marketplaceID, name string) (PluginSource, bool) {
+	if marketplaceID == "" {
+		return PluginSource{}, false
+	}
+	meta, err := i.marketplaceManager.GetMarketplaceMetadata(marketplaceID)
+	if err != nil {
+		return PluginSource{}, false
+	}
+	for _, p := range meta.Plugins {
+		if p.Name == name {
+			return p.Source, true
+		}
+	}
+	return PluginSource{}, false
+}
+
+// findMarketplaceFor returns the first known marketplace that offers a plugin
+// with the given name — either declared in its marketplace.json or vendored as
+// a subdirectory.
+func (i *Installer) findMarketplaceFor(name string) string {
+	for _, id := range i.marketplaceManager.List() {
+		if _, ok := i.resolvePluginSource(id, name); ok {
+			return id
+		}
+		if _, err := i.marketplaceManager.GetPluginPath(id, name); err == nil {
+			return id
+		}
+	}
+	return ""
+}
+
+// fetchExternalPlugin clones a plugin's own git repository into a temp dir and
+// returns the directory holding the plugin root (the repo, or a subdirectory of
+// it for git-subdir sources), along with a cleanup func the caller must defer.
+func fetchExternalPlugin(ctx context.Context, src PluginSource) (string, func(), error) {
+	noop := func() {}
+	if src.Type == SourceNPM {
+		return "", noop, fmt.Errorf("npm plugin sources are not supported yet")
+	}
+
+	tmp, err := os.MkdirTemp("", "san-plugin-*")
+	if err != nil {
+		return "", noop, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+
+	url := src.URL
+	if src.Type == SourceGitHub {
+		url = "https://github.com/" + src.Repo + ".git"
+	}
+	url = normalizeGitURL(url)
+	if url == "" {
+		cleanup()
+		return "", noop, fmt.Errorf("plugin source has no repository URL")
+	}
+
+	if err := cloneRepo(ctx, url, src.Ref, src.SHA, tmp); err != nil {
+		cleanup()
+		return "", noop, err
+	}
+	_ = os.RemoveAll(filepath.Join(tmp, ".git"))
+
+	root := tmp
+	if src.Type == SourceGitSubdir && src.Path != "" {
+		clean := filepath.Clean(src.Path)
+		if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+			cleanup()
+			return "", noop, fmt.Errorf("invalid subdir path: %s", src.Path)
+		}
+		root = filepath.Join(tmp, clean)
+	}
+	return root, cleanup, nil
+}
+
+// normalizeGitURL expands a bare "owner/repo" shorthand into a full GitHub
+// HTTPS URL. Full URLs (https://, ssh://, git@) are returned unchanged.
+func normalizeGitURL(url string) string {
+	if url == "" || strings.Contains(url, "://") || strings.HasPrefix(url, "git@") {
+		return url
+	}
+	if strings.Count(url, "/") == 1 && !strings.ContainsAny(url, " \t") {
+		return "https://github.com/" + url + ".git"
+	}
+	return url
+}
+
+// cloneRepo shallow-clones url into dest, honoring an optional ref (branch/tag)
+// and sha (exact commit, which takes precedence). Pinning to a sha that a
+// shallow clone doesn't contain triggers a deepen-then-checkout fallback.
+func cloneRepo(ctx context.Context, url, ref, sha, dest string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" && sha == "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, dest)
+	if out, err := runGit(ctx, "", args...); err != nil {
+		return fmt.Errorf("git clone %s: %w: %s", url, err, strings.TrimSpace(out))
+	}
+
+	if sha != "" {
+		if _, err := runGit(ctx, dest, "checkout", sha); err != nil {
+			if _, ferr := runGit(ctx, dest, "fetch", "--unshallow"); ferr != nil {
+				_, _ = runGit(ctx, dest, "fetch", "--depth", "1", "origin", sha)
+			}
+			if out, cerr := runGit(ctx, dest, "checkout", sha); cerr != nil {
+				return fmt.Errorf("git checkout %s: %w: %s", sha, cerr, strings.TrimSpace(out))
+			}
+		}
+	}
+	return nil
+}
+
+// runGit runs a git command (optionally inside dir) and returns its combined
+// output for error context.
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
 // addToInstalled adds a plugin to installed_plugins.json using v2 format.

--- a/internal/plugin/integration.go
+++ b/internal/plugin/integration.go
@@ -96,13 +96,37 @@ func GetPluginMCPServers() []PluginMCPServer {
 	for _, p := range defaultRegistry.GetEnabled() {
 		for name, cfg := range p.Components.MCP {
 			servers = append(servers, PluginMCPServer{
-				Name:   p.Name() + ":" + name,
+				Name:   mcpServerNameSafe(p.Name() + ":" + name),
 				Config: cfg,
 				Scope:  p.Scope,
 			})
 		}
 	}
 	return servers
+}
+
+// mcpServerNameSafe makes a plugin's MCP server name safe to embed in an LLM
+// tool name (servers are exposed as "mcp__<server>__<tool>"). Providers require
+// tool names to match ^[a-zA-Z0-9_-]+$, and the plugin:server namespace
+// separator ":" in particular is rejected by OpenAI-compatible APIs (DeepSeek
+// returns 400 invalid_request_error). Out-of-set runes become "-" rather than
+// "_" so a separator next to an existing "_" can't forge the "__" delimiter
+// and confuse tool-name parsing.
+func mcpServerNameSafe(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r == '-' || r == '_',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
 }
 
 // GetPluginNamespace extracts the namespace from a plugin path or source.

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -63,6 +63,7 @@ func (m *MarketplaceManager) Load() error {
 	var v2 map[string]MarketplaceEntry
 	if err := json.Unmarshal(data, &v2); err == nil && len(v2) > 0 {
 		m.marketplaces = v2
+		m.healInstallLocations()
 		return nil
 	}
 
@@ -83,7 +84,36 @@ func (m *MarketplaceManager) Load() error {
 		}
 	}
 
+	m.healInstallLocations()
 	return nil
+}
+
+// healInstallLocations repairs github marketplaces whose recorded
+// InstallLocation is empty or stale (e.g. carried over from an older config
+// dir whose path no longer exists) by pointing them at the canonical clone
+// path. Run once at load so path lookups stay a plain field read rather than
+// a stat on every call.
+func (m *MarketplaceManager) healInstallLocations() {
+	for id, entry := range m.marketplaces {
+		if entry.Source.Source != "github" {
+			continue
+		}
+		canonical := filepath.Join(m.marketplacesDir, id)
+		if entry.InstallLocation == canonical {
+			continue
+		}
+		if entry.InstallLocation == "" {
+			entry.InstallLocation = canonical
+			m.marketplaces[id] = entry
+			continue
+		}
+		if _, err := os.Stat(entry.InstallLocation); err != nil {
+			if _, err := os.Stat(canonical); err == nil {
+				entry.InstallLocation = canonical
+				m.marketplaces[id] = entry
+			}
+		}
+	}
 }
 
 // Save saves marketplace configurations to known_marketplaces.json.
@@ -324,21 +354,12 @@ func (m *MarketplaceManager) getMarketplaceBasePath(marketplaceID string) (strin
 
 	switch entry.Source.Source {
 	case "github":
-		// Prefer the recorded clone path, but fall back to the canonical
-		// location when it's empty or stale (e.g. a config carried over from
-		// an older config dir whose path no longer exists).
-		loc := entry.InstallLocation
-		if loc == "" {
-			return filepath.Join(m.marketplacesDir, marketplaceID), nil
+		// InstallLocation is normalized at load (see healInstallLocations);
+		// fall back to the canonical path only if it was never recorded.
+		if entry.InstallLocation != "" {
+			return entry.InstallLocation, nil
 		}
-		if _, err := os.Stat(loc); err != nil {
-			if canonical := filepath.Join(m.marketplacesDir, marketplaceID); canonical != loc {
-				if _, err := os.Stat(canonical); err == nil {
-					return canonical, nil
-				}
-			}
-		}
-		return loc, nil
+		return filepath.Join(m.marketplacesDir, marketplaceID), nil
 	case "directory":
 		return entry.Source.Path, nil
 	default:
@@ -378,6 +399,17 @@ func (m *MarketplaceManager) MarketplacePlugins(marketplaceID string) ([]Marketp
 	return plugins, nil
 }
 
+// safeRelPath cleans a relative path and rejects absolute paths or any that
+// escape their base via "..". The returned path is safe to filepath.Join onto
+// a trusted base. Used to confine plugin sources to the directory they name.
+func safeRelPath(p string) (string, error) {
+	clean := filepath.Clean(p)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+		return "", fmt.Errorf("invalid path: %s", p)
+	}
+	return clean, nil
+}
+
 // ResolveLocalPluginPath returns the on-disk path of a plugin whose content
 // lives inside the marketplace repo: a declared relative "path" source, or —
 // as a fallback — a vendored subdirectory found by name.
@@ -387,9 +419,9 @@ func (m *MarketplaceManager) ResolveLocalPluginPath(marketplaceID, name string, 
 		if err != nil {
 			return "", err
 		}
-		clean := filepath.Clean(src.Path)
-		if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
-			return "", fmt.Errorf("invalid plugin path: %s", src.Path)
+		clean, err := safeRelPath(src.Path)
+		if err != nil {
+			return "", err
 		}
 		full := filepath.Join(base, clean)
 		if _, err := os.Stat(full); err == nil {

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -324,7 +324,21 @@ func (m *MarketplaceManager) getMarketplaceBasePath(marketplaceID string) (strin
 
 	switch entry.Source.Source {
 	case "github":
-		return entry.InstallLocation, nil
+		// Prefer the recorded clone path, but fall back to the canonical
+		// location when it's empty or stale (e.g. a config carried over from
+		// an older config dir whose path no longer exists).
+		loc := entry.InstallLocation
+		if loc == "" {
+			return filepath.Join(m.marketplacesDir, marketplaceID), nil
+		}
+		if _, err := os.Stat(loc); err != nil {
+			if canonical := filepath.Join(m.marketplacesDir, marketplaceID); canonical != loc {
+				if _, err := os.Stat(canonical); err == nil {
+					return canonical, nil
+				}
+			}
+		}
+		return loc, nil
 	case "directory":
 		return entry.Source.Path, nil
 	default:
@@ -332,7 +346,62 @@ func (m *MarketplaceManager) getMarketplaceBasePath(marketplaceID string) (strin
 	}
 }
 
-// ListPlugins returns all plugins in a marketplace.
+// MarketplacePlugins returns the plugins a marketplace offers. It prefers the
+// marketplace.json manifest — Claude Code's model, where plugins are declared
+// and each carries its own source (which may point to another repo). When a
+// marketplace has no manifest plugins[], it falls back to scanning the repo for
+// vendored plugin subdirectories so directory-style marketplaces keep working.
+func (m *MarketplaceManager) MarketplacePlugins(marketplaceID string) ([]MarketplacePlugin, error) {
+	if meta, err := m.GetMarketplaceMetadata(marketplaceID); err == nil && len(meta.Plugins) > 0 {
+		return meta.Plugins, nil
+	}
+
+	names, err := m.ListPlugins(marketplaceID)
+	if err != nil {
+		return nil, err
+	}
+	plugins := make([]MarketplacePlugin, 0, len(names))
+	for _, name := range names {
+		entry := MarketplacePlugin{
+			Name:   name,
+			Source: PluginSource{Type: SourcePath, Path: name},
+		}
+		if path, perr := m.GetPluginPath(marketplaceID, name); perr == nil {
+			if man, merr := loadManifest(path); merr == nil {
+				entry.Description = man.Description
+				entry.Version = man.Version
+				entry.Author = man.Author
+			}
+		}
+		plugins = append(plugins, entry)
+	}
+	return plugins, nil
+}
+
+// ResolveLocalPluginPath returns the on-disk path of a plugin whose content
+// lives inside the marketplace repo: a declared relative "path" source, or —
+// as a fallback — a vendored subdirectory found by name.
+func (m *MarketplaceManager) ResolveLocalPluginPath(marketplaceID, name string, src PluginSource) (string, error) {
+	if src.Type == SourcePath && src.Path != "" {
+		base, err := m.getMarketplaceBasePath(marketplaceID)
+		if err != nil {
+			return "", err
+		}
+		clean := filepath.Clean(src.Path)
+		if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+			return "", fmt.Errorf("invalid plugin path: %s", src.Path)
+		}
+		full := filepath.Join(base, clean)
+		if _, err := os.Stat(full); err == nil {
+			return full, nil
+		}
+	}
+	return m.GetPluginPath(marketplaceID, name)
+}
+
+// ListPlugins returns the names of vendored plugin subdirectories in a
+// marketplace. It scans the repo layout and does not read marketplace.json;
+// use MarketplacePlugins for the manifest-aware, declared plugin list.
 func (m *MarketplaceManager) ListPlugins(marketplaceID string) ([]string, error) {
 	basePath, err := m.getMarketplaceBasePath(marketplaceID)
 	if err != nil {

--- a/internal/plugin/marketplace_manifest_test.go
+++ b/internal/plugin/marketplace_manifest_test.go
@@ -1,0 +1,181 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPluginSourceUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want PluginSource
+	}{
+		{"relative path string", `"./plugins/foo"`, PluginSource{Type: SourcePath, Path: "./plugins/foo"}},
+		{"github", `{"source":"github","repo":"owner/repo","ref":"main"}`, PluginSource{Type: SourceGitHub, Repo: "owner/repo", Ref: "main"}},
+		{"url", `{"source":"url","url":"https://x.com/p.git"}`, PluginSource{Type: SourceURL, URL: "https://x.com/p.git"}},
+		{"git alias maps to url", `{"source":"git","url":"https://x.com/p.git"}`, PluginSource{Type: SourceURL, URL: "https://x.com/p.git"}},
+		{"git-subdir", `{"source":"git-subdir","url":"https://x.com/m.git","path":"tools/p","sha":"abc"}`, PluginSource{Type: SourceGitSubdir, URL: "https://x.com/m.git", Path: "tools/p", SHA: "abc"}},
+		{"npm", `{"source":"npm","package":"@a/b","version":"^2.0.0"}`, PluginSource{Type: SourceNPM, Package: "@a/b", Version: "^2.0.0"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got PluginSource
+			if err := json.Unmarshal([]byte(tc.in), &got); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginSourceExternal(t *testing.T) {
+	for _, typ := range []string{SourceGitHub, SourceURL, SourceGitSubdir, SourceNPM} {
+		if !(PluginSource{Type: typ}).External() {
+			t.Errorf("%s should be external", typ)
+		}
+	}
+	if (PluginSource{Type: SourcePath}).External() {
+		t.Error("path should not be external")
+	}
+}
+
+func TestNormalizeGitURL(t *testing.T) {
+	cases := map[string]string{
+		"owner/repo":             "https://github.com/owner/repo.git",
+		"https://x.com/p.git":    "https://x.com/p.git",
+		"git@github.com:o/r.git": "git@github.com:o/r.git",
+		"":                       "",
+	}
+	for in, want := range cases {
+		if got := normalizeGitURL(in); got != want {
+			t.Errorf("normalizeGitURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// writeMarketplaceJSON writes a raw .claude-plugin/marketplace.json so tests
+// exercise the real parse path (PluginSource has no symmetric MarshalJSON).
+func writeMarketplaceJSON(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ".claude-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "marketplace.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json): %v", err)
+	}
+}
+
+// TestMarketplacePlugins_ManifestFirst checks that declared plugins are read
+// from marketplace.json — including external sources that aren't vendored — so
+// the "available" count reflects the manifest, not the on-disk directory layout.
+func TestMarketplacePlugins_ManifestFirst(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	marketRoot := filepath.Join(t.TempDir(), "market")
+	writeTestPlugin(t, filepath.Join(marketRoot, "plugins", "local-tool"), "local-tool", "1.0.0", "Local tool", nil)
+	writeMarketplaceJSON(t, marketRoot, `{
+		"name": "mixed",
+		"plugins": [
+			{"name": "local-tool", "source": "./plugins/local-tool", "description": "Local tool"},
+			{"name": "remote-tool", "source": {"source": "url", "url": "https://example.com/remote.git"}, "description": "Remote tool", "version": "2.0.0"}
+		]
+	}`)
+
+	m := NewMarketplaceManager(tmp)
+	if err := m.Add("mixed", MarketplaceEntry{Source: MarketplaceSourceInfo{Source: "directory", Path: marketRoot}}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	plugins, err := m.MarketplacePlugins("mixed")
+	if err != nil {
+		t.Fatalf("MarketplacePlugins: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("got %d plugins, want 2: %+v", len(plugins), plugins)
+	}
+	byName := map[string]MarketplacePlugin{}
+	for _, p := range plugins {
+		byName[p.Name] = p
+	}
+	if byName["local-tool"].Source.Type != SourcePath {
+		t.Errorf("local-tool source = %+v, want path", byName["local-tool"].Source)
+	}
+	remote := byName["remote-tool"]
+	if !remote.Source.External() || remote.Source.URL != "https://example.com/remote.git" {
+		t.Errorf("remote-tool source = %+v, want external url", remote.Source)
+	}
+	if remote.Version != "2.0.0" {
+		t.Errorf("remote-tool version = %q, want 2.0.0", remote.Version)
+	}
+}
+
+// TestMarketplacePlugins_DirScanFallback covers a marketplace with no
+// marketplace.json: plugins are discovered by scanning vendored subdirectories
+// and enriched from each plugin's own manifest.
+func TestMarketplacePlugins_DirScanFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	marketRoot := filepath.Join(t.TempDir(), "market")
+	writeTestPlugin(t, filepath.Join(marketRoot, "plugins", "alpha"), "alpha", "1.0.0", "Alpha", nil)
+
+	m := NewMarketplaceManager(tmp)
+	if err := m.Add("scan", MarketplaceEntry{Source: MarketplaceSourceInfo{Source: "directory", Path: marketRoot}}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	plugins, err := m.MarketplacePlugins("scan")
+	if err != nil {
+		t.Fatalf("MarketplacePlugins: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0].Name != "alpha" {
+		t.Fatalf("got %+v, want one alpha plugin", plugins)
+	}
+	if plugins[0].Description != "Alpha" {
+		t.Errorf("description = %q, want Alpha (enriched from disk)", plugins[0].Description)
+	}
+}
+
+// TestInstall_RelativePathSourceFromManifest installs a plugin whose
+// marketplace.json source is a relative path inside the marketplace repo,
+// verifying the manifest-driven local-path resolution.
+func TestInstall_RelativePathSourceFromManifest(t *testing.T) {
+	tmpHome := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	marketRoot := filepath.Join(t.TempDir(), "market")
+	writeTestPlugin(t, filepath.Join(marketRoot, "plugins", "deploy"), "deploy", "1.2.3", "Deploy plugin", map[string]string{
+		"skills/deploy/SKILL.md": "---\nname: deploy\ndescription: Deploy skill\n---\nship it\n",
+	})
+	writeMarketplaceJSON(t, marketRoot, `{
+		"name": "local-market",
+		"plugins": [
+			{"name": "deploy", "source": "./plugins/deploy", "description": "Deploy plugin"}
+		]
+	}`)
+
+	mgr := NewMarketplaceManager(cwd)
+	if err := mgr.Add("local-market", MarketplaceEntry{Source: MarketplaceSourceInfo{Source: "directory", Path: marketRoot}}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	registry := NewRegistry()
+	if err := Install(context.Background(), registry, cwd, "deploy@local-market", ScopeProject); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	installPath := filepath.Join(cwd, ".san", "plugins", "deploy")
+	if _, err := os.Stat(filepath.Join(installPath, "skills", "deploy", "SKILL.md")); err != nil {
+		t.Fatalf("expected installed plugin content copied: %v", err)
+	}
+	if _, ok := registry.Get("deploy@local-market"); !ok {
+		t.Fatal("expected installed plugin registered")
+	}
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -839,5 +840,24 @@ func TestMCPConfigParsing(t *testing.T) {
 	expectedEnv := tmpDir + "/data"
 	if db.Env["DB_PATH"] != expectedEnv {
 		t.Errorf("Server env DB_PATH = %q, want %q", db.Env["DB_PATH"], expectedEnv)
+	}
+}
+
+func TestMCPServerNameSafe(t *testing.T) {
+	cases := map[string]string{
+		"superpowers-chrome:browsing": "superpowers-chrome-browsing",
+		"plug:srv":                    "plug-srv",
+		"already-fine_1":              "already-fine_1",
+		"weird.name/x y":              "weird-name-x-y",
+	}
+	valid := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	for in, want := range cases {
+		got := mcpServerNameSafe(in)
+		if got != want {
+			t.Errorf("mcpServerNameSafe(%q) = %q, want %q", in, got, want)
+		}
+		if !valid.MatchString(got) {
+			t.Errorf("mcpServerNameSafe(%q) = %q, not provider-safe", in, got)
+		}
 	}
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -74,6 +74,14 @@ func (r *Registry) Load(ctx context.Context, cwd string) error {
 			continue
 		}
 		for _, p := range plugins {
+			// A project/local install copies the plugin into a scope dir, so the
+			// scope scan above already loaded it under a bare name. Drop that
+			// duplicate — this entry carries the real "name@marketplace" source.
+			for k, existing := range r.plugins {
+				if existing.Path == p.Path {
+					delete(r.plugins, k)
+				}
+			}
 			key := p.FullName()
 			if enabled, ok := enabledPlugins[key]; ok {
 				p.Enabled = enabled

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -3,7 +3,11 @@
 // installable and shareable units. Compatible with Claude Code plugin format.
 package plugin
 
-import "github.com/genai-io/san/internal/setting"
+import (
+	"encoding/json"
+
+	"github.com/genai-io/san/internal/setting"
+)
 
 // Scope represents where a plugin is installed.
 type Scope string
@@ -302,14 +306,87 @@ func (m *MarketplaceMetadata) GetDescription() string {
 	return ""
 }
 
+// Plugin source kinds, mirroring Claude Code's marketplace.json plugin sources.
+const (
+	SourcePath      = "path"       // relative dir inside the marketplace repo
+	SourceGitHub    = "github"     // {"source":"github","repo":"owner/repo"}
+	SourceURL       = "url"        // {"source":"url","url":"https://...git"}
+	SourceGitSubdir = "git-subdir" // {"source":"git-subdir","url":..,"path":..}
+	SourceNPM       = "npm"        // {"source":"npm","package":..}
+)
+
+// PluginSource describes where a marketplace plugin's content comes from.
+// In marketplace.json a plugin's "source" is either a relative-path string
+// (the plugin lives inside the marketplace repo) or an object naming an
+// external location — its own git repo, a subdir of one, or an npm package.
+type PluginSource struct {
+	Type string // one of the Source* constants above
+
+	Path string // SourcePath relative dir, or SourceGitSubdir subdir within repo
+	Repo string // SourceGitHub "owner/repo"
+	URL  string // SourceURL / SourceGitSubdir git URL
+	Ref  string // optional branch/tag
+	SHA  string // optional commit pin (takes precedence over Ref)
+
+	Package  string // SourceNPM package name
+	Version  string // SourceNPM version or range
+	Registry string // SourceNPM custom registry URL
+}
+
+// UnmarshalJSON accepts either a relative-path string ("./plugins/foo") or a
+// source object. "git" is treated as an alias for the generic "url" kind.
+func (s *PluginSource) UnmarshalJSON(data []byte) error {
+	var path string
+	if err := json.Unmarshal(data, &path); err == nil {
+		*s = PluginSource{Type: SourcePath, Path: path}
+		return nil
+	}
+
+	var obj struct {
+		Source   string `json:"source"`
+		Path     string `json:"path"`
+		Repo     string `json:"repo"`
+		URL      string `json:"url"`
+		Ref      string `json:"ref"`
+		SHA      string `json:"sha"`
+		Package  string `json:"package"`
+		Version  string `json:"version"`
+		Registry string `json:"registry"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	*s = PluginSource{
+		Type: obj.Source, Path: obj.Path, Repo: obj.Repo, URL: obj.URL,
+		Ref: obj.Ref, SHA: obj.SHA,
+		Package: obj.Package, Version: obj.Version, Registry: obj.Registry,
+	}
+	if s.Type == "git" {
+		s.Type = SourceURL
+	}
+	return nil
+}
+
+// External reports whether the plugin's content is fetched from outside the
+// marketplace repo (its own git repo or an npm package) rather than living as
+// a path inside it.
+func (s PluginSource) External() bool {
+	switch s.Type {
+	case SourceGitHub, SourceURL, SourceGitSubdir, SourceNPM:
+		return true
+	default:
+		return false
+	}
+}
+
 // MarketplacePlugin represents a plugin entry in marketplace.json.
 type MarketplacePlugin struct {
-	Name        string  `json:"name"`
-	Source      string  `json:"source"`
-	Description string  `json:"description,omitempty"`
-	Version     string  `json:"version,omitempty"`
-	Author      *Author `json:"author,omitempty"`
-	Category    string  `json:"category,omitempty"`
+	Name        string       `json:"name"`
+	Source      PluginSource `json:"source"`
+	Description string       `json:"description,omitempty"`
+	Version     string       `json:"version,omitempty"`
+	Author      *Author      `json:"author,omitempty"`
+	Category    string       `json:"category,omitempty"`
 }
 
 // InstallCounts represents the install-counts-cache.json format.


### PR DESCRIPTION
Adds support for Claude Code's manifest-style plugin marketplaces (where `marketplace.json` declares plugins whose content may live in their own repos) and fixes the Add Marketplace dialog. Previously such a marketplace showed `0 available` because plugin discovery only scanned the repo for vendored subdirectories and never read `marketplace.json`.

- **Add Marketplace dialog**: route bracketed paste (`tea.PasteMsg`) to the active overlay instead of letting it leak into the hidden prompt textarea, so the source field is pasteable; redesign the dialog (filled input box, examples-first layout).
- **Manifest discovery**: parse a plugin's `source` as either a relative-path string or a `github`/`url`/`git-subdir`/`npm` object; list and count "available" from the manifest, falling back to a directory scan for vendored marketplaces.
- **Install**: fetch external plugin sources by cloning their own repo (honoring `ref`/`sha`); resolve relative-path sources inside the marketplace repo.
- **Robustness**: self-heal a stale marketplace `installLocation` to the canonical clone path so older configs still resolve.
- **Docs**: add a marketplace & install flow diagram (mermaid) and a `source`-format table to `docs/packages/2-feature/plugin.md`, plus a co-located Chinese translation `plugin.zh.md`.

npm sources are parsed but not yet installable (returns a clear error).