### PR TITLE
refactor(image): unify on core.Image, add Windows clipboard support

### DIFF
--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -302,11 +302,11 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 			continue
 		}
 
-		imgInfo, err := image.Load(absPath)
+		img, err := image.Load(absPath)
 		if err != nil {
 			return "", nil, fmt.Errorf("loading image %s: %w", absPath, err)
 		}
-		images = append(images, imgInfo.ToProviderData())
+		images = append(images, img)
 		loadedRefs = append(loadedRefs, match[0]) // full match including @
 	}
 

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -68,7 +68,7 @@ func (m *model) cancelRemainingToolCalls(startIdx int) {
 }
 
 func (m *model) pasteImageFromClipboard() (tea.Cmd, bool) {
-	imgData, err := image.ReadImageToProviderData()
+	imgData, err := image.ReadClipboard()
 	if err != nil {
 		m.conv.Append(core.ChatMessage{Role: core.RoleNotice, Content: "Image paste error: " + err.Error()})
 		return tea.Batch(m.CommitMessages()...), true

--- a/internal/image/clipboard.go
+++ b/internal/image/clipboard.go
@@ -83,6 +83,45 @@ func readClipboardLinux() (*core.Image, error) {
 	return newClipboardImage(data)
 }
 
+// readClipboardWindows reads image from the Windows clipboard using PowerShell.
+func readClipboardWindows() (*core.Image, error) {
+	tmp, err := os.CreateTemp("", "clipboard_*.png")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpFile := tmp.Name()
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmpFile) }()
+
+	// Clipboard.GetImage requires a single-threaded apartment (-STA). It returns
+	// $null when the clipboard holds no image; otherwise we save it as PNG.
+	script := fmt.Sprintf(`
+		Add-Type -AssemblyName System.Windows.Forms,System.Drawing
+		$img = [System.Windows.Forms.Clipboard]::GetImage()
+		if ($null -eq $img) { 'no image'; return }
+		$img.Save('%s', [System.Drawing.Imaging.ImageFormat]::Png)
+		'ok'
+	`, tmpFile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-STA", "-Command", script)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read clipboard: %w", err)
+	}
+
+	if strings.TrimSpace(string(output)) == "no image" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read clipboard image: %w", err)
+	}
+	return newClipboardImage(data)
+}
+
 // ReadClipboard reads an image from the clipboard as a core.Image.
 // Returns nil, nil if no image is available (not an error).
 func ReadClipboard() (*core.Image, error) {
@@ -91,6 +130,8 @@ func ReadClipboard() (*core.Image, error) {
 		return readClipboardMacOS()
 	case "linux":
 		return readClipboardLinux()
+	case "windows":
+		return readClipboardWindows()
 	default:
 		return nil, fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
 	}

--- a/internal/image/clipboard.go
+++ b/internal/image/clipboard.go
@@ -12,38 +12,22 @@ import (
 	"github.com/genai-io/san/internal/core"
 )
 
-// readImageFromClipboard reads an image from the clipboard.
-// Returns nil, nil if no image is available (not an error).
-func readImageFromClipboard() (*ImageInfo, error) {
-	switch runtime.GOOS {
-	case "darwin":
-		return readClipboardMacOS()
-	case "linux":
-		return readClipboardLinux()
-	default:
-		return nil, fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
-	}
-}
-
-// newClipboardImageInfo creates an ImageInfo from clipboard PNG data.
+// newClipboardImage builds a core.Image from clipboard PNG data.
 // Returns nil, nil if data is empty.
-func newClipboardImageInfo(data []byte) (*ImageInfo, error) {
+func newClipboardImage(data []byte) (*core.Image, error) {
 	if len(data) == 0 {
 		return nil, nil
 	}
 	if len(data) > maxImageSize {
 		return nil, fmt.Errorf("clipboard image too large: %d bytes (max %d)", len(data), maxImageSize)
 	}
-	return &ImageInfo{
-		MediaType: "image/png",
-		Data:      data,
-		Size:      len(data),
-		FileName:  fmt.Sprintf("clipboard_%s.png", time.Now().Format("150405")),
-	}, nil
+	fileName := fmt.Sprintf("clipboard_%s.png", time.Now().Format("150405"))
+	img := newImage("image/png", fileName, data)
+	return &img, nil
 }
 
 // readClipboardMacOS reads image from macOS clipboard using osascript.
-func readClipboardMacOS() (*ImageInfo, error) {
+func readClipboardMacOS() (*core.Image, error) {
 	tmp, err := os.CreateTemp("", "clipboard_*.png")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %w", err)
@@ -82,11 +66,11 @@ func readClipboardMacOS() (*ImageInfo, error) {
 		return nil, fmt.Errorf("failed to read clipboard image: %w", err)
 	}
 
-	return newClipboardImageInfo(data)
+	return newClipboardImage(data)
 }
 
 // readClipboardLinux reads image from Linux clipboard using xclip or xsel.
-func readClipboardLinux() (*ImageInfo, error) {
+func readClipboardLinux() (*core.Image, error) {
 	cmd := exec.Command("xclip", "-selection", "clipboard", "-t", "image/png", "-o")
 	data, err := cmd.Output()
 	if err != nil {
@@ -96,19 +80,18 @@ func readClipboardLinux() (*ImageInfo, error) {
 			return nil, nil
 		}
 	}
-	return newClipboardImageInfo(data)
+	return newClipboardImage(data)
 }
 
-// ReadImageToProviderData reads clipboard image directly to core.Image
-func ReadImageToProviderData() (*core.Image, error) {
-	info, err := readImageFromClipboard()
-	if err != nil {
-		return nil, err
+// ReadClipboard reads an image from the clipboard as a core.Image.
+// Returns nil, nil if no image is available (not an error).
+func ReadClipboard() (*core.Image, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return readClipboardMacOS()
+	case "linux":
+		return readClipboardLinux()
+	default:
+		return nil, fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
 	}
-	if info == nil {
-		return nil, nil
-	}
-
-	data := info.ToProviderData()
-	return &data, nil
 }

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -26,76 +26,56 @@ var supportedTypes = map[string]string{
 	".gif":  "image/gif",
 }
 
-// ImageInfo holds information about a loaded image
-type ImageInfo struct {
-	Path      string
-	MediaType string
-	Data      []byte
-	Size      int
-	FileName  string
-}
-
-// Load loads and validates an image from the given path
-func Load(path string) (*ImageInfo, error) {
+// Load reads, validates, and base64-encodes an image from the given path.
+func Load(path string) (core.Image, error) {
 	// Resolve path
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("invalid path: %w", err)
+		return core.Image{}, fmt.Errorf("invalid path: %w", err)
 	}
 
 	// Check if file exists
 	info, err := os.Stat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("file not found: %s", path)
+			return core.Image{}, fmt.Errorf("file not found: %s", path)
 		}
-		return nil, fmt.Errorf("cannot access file: %w", err)
+		return core.Image{}, fmt.Errorf("cannot access file: %w", err)
 	}
 
 	// Check file size
 	if info.Size() > maxImageSize {
-		return nil, fmt.Errorf("image too large: %d bytes (max %d)", info.Size(), maxImageSize)
+		return core.Image{}, fmt.Errorf("image too large: %d bytes (max %d)", info.Size(), maxImageSize)
 	}
 
 	// Check extension
 	ext := strings.ToLower(filepath.Ext(absPath))
 	mediaType, ok := supportedTypes[ext]
 	if !ok {
-		return nil, fmt.Errorf("unsupported image format: %s", ext)
+		return core.Image{}, fmt.Errorf("unsupported image format: %s", ext)
 	}
 
 	// Read file
 	data, err := os.ReadFile(absPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return core.Image{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Detect actual content type to verify
 	detectedType := http.DetectContentType(data)
 	if !strings.HasPrefix(detectedType, "image/") {
-		return nil, fmt.Errorf("file is not a valid image")
+		return core.Image{}, fmt.Errorf("file is not a valid image")
 	}
 
-	return &ImageInfo{
-		Path:      absPath,
-		MediaType: mediaType,
-		Data:      data,
-		Size:      len(data),
-		FileName:  filepath.Base(absPath),
-	}, nil
+	return newImage(mediaType, filepath.Base(absPath), data), nil
 }
 
-// ToBase64 returns the image data as a base64 encoded string
-func (i *ImageInfo) ToBase64() string {
-	return base64.StdEncoding.EncodeToString(i.Data)
-}
-
-// ToProviderData converts ImageInfo to core.Image
-func (i *ImageInfo) ToProviderData() core.Image {
+// newImage builds a core.Image from raw bytes, base64-encoding the data.
+func newImage(mediaType, fileName string, data []byte) core.Image {
 	return core.Image{
-		MediaType: i.MediaType,
-		Data:      i.ToBase64(),
-		FileName:  i.FileName,
-		Size:      i.Size,
+		MediaType: mediaType,
+		Data:      base64.StdEncoding.EncodeToString(data),
+		FileName:  fileName,
+		Size:      len(data),
 	}
 }

--- a/tools/layercheck/main.go
+++ b/tools/layercheck/main.go
@@ -41,7 +41,7 @@ var layerOf = map[string]string{
 	"internal/cron":      "feature",
 	"internal/hook":      "feature",
 	"internal/identity":  "feature",
-	"internal/image":     "feature", // touches core.Image; pure infra extraction tracked in notes/tech-debt.md
+	"internal/image":     "feature", // image loader; produces core.Image, so it sits above core (not infrastructure)
 	"internal/inspector": "feature",
 	"internal/llm":       "feature",
 	"internal/mcp":       "feature",


### PR DESCRIPTION
Two commits:

- **refactor:** `image.ImageInfo` was a near-clone of `core.Image`, and both callers immediately converted to `core.Image` without using `ImageInfo`'s extra fields. `Load`/clipboard now return `core.Image` directly; `ImageInfo`/`ToProviderData`/`ToBase64` are deleted and the awkward `ReadImageToProviderData` is renamed to `ReadClipboard`. `image` still produces a core type, so it stays in the feature layer — the stale `layercheck` comment claiming a pending infra extraction is corrected. No behavior change.
- **feat:** add a Windows branch to the clipboard reader via PowerShell (`Clipboard.GetImage` under `-STA`, saved to a temp PNG), mirroring the macOS `osascript` and Linux `xclip`/`xsel` paths.

Build + tests green; cross-compiles for `windows/amd64`. The Windows clipboard path is not runtime-tested (developed on macOS).