### PR TITLE
fix: text-only image gate, selector keymap, model-switch banner, resumed-session leak

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -282,7 +282,7 @@ func handleProviderModelSelected(deps OverlayDeps, state *ProviderState, msg Pro
 	})
 	ctx := context.Background()
 	providerRefreshConnection(deps, state, ctx, llm.Name(msg.ProviderName), msg.AuthMethod)
-	return deps.PrintWelcome(msg.ModelID)
+	return tea.Batch(deps.CommitMessages()...)
 }
 
 func providerRefreshConnection(deps OverlayDeps, state *ProviderState, ctx context.Context, providerName llm.Name, authMethod llm.AuthMethod) {

--- a/internal/app/input/on_provider_nav.go
+++ b/internal/app/input/on_provider_nav.go
@@ -114,17 +114,16 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 		return s.handleConfirmRemove(key)
 	}
 
+	// Navigation is arrow-driven and works regardless of the search query:
+	// ↑/↓ (and ctrl+p/ctrl+n) move the list, ←/→ (and tab/shift+tab) switch
+	// tabs. Switching tabs clears the query (switchTab).
 	switch key.String() {
-	case "tab":
-		if s.searchQuery == "" {
-			s.NextTab()
-		}
+	case "tab", "right":
+		s.NextTab()
 		return nil
 
 	case "shift+tab":
-		if s.searchQuery == "" {
-			s.PrevTab()
-		}
+		s.PrevTab()
 		return nil
 
 	case "up", "ctrl+p":
@@ -138,14 +137,8 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 	case "enter":
 		return s.Select()
 
-	case "right":
-		if s.searchQuery == "" {
-			s.NextTab()
-		}
-		return nil
-
 	case "left":
-		if s.searchQuery == "" && !s.GoBack() {
+		if !s.GoBack() {
 			s.PrevTab()
 		}
 		return nil
@@ -178,28 +171,11 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 		return s.handleCredentialRemove()
 
 	default:
-		// Typed text capture. Vim navigation takes priority while the model
-		// search is empty (mirrors every other selector); otherwise the
-		// printable rune is search input. l/h switch tabs since this is tabbed.
+		// Typed text capture: every printable rune is search input. Navigation
+		// is arrows + ctrl+p/ctrl+n; tabs are tab/shift+tab and left/right — no
+		// bare-letter vim keys — so a query can start with any character
+		// (e.g. "kimi", "haiku", "llama").
 		if text := key.Key().Text; text != "" {
-			if s.searchQuery == "" {
-				switch key.String() {
-				case "j":
-					s.MoveDown()
-					return nil
-				case "k":
-					s.MoveUp()
-					return nil
-				case "l":
-					s.NextTab()
-					return nil
-				case "h":
-					if !s.GoBack() {
-						s.PrevTab()
-					}
-					return nil
-				}
-			}
 			s.appendModelSearch(text)
 			return nil
 		}

--- a/internal/app/input/runtime.go
+++ b/internal/app/input/runtime.go
@@ -18,7 +18,6 @@ type OverlayDeps struct {
 
 	SwitchProvider          func(llm.Provider)
 	SetCurrentModel         func(*llm.CurrentModelInfo)
-	PrintWelcome            func(modelID string) tea.Cmd
 	ClearCachedInstructions func()
 	RefreshMemoryContext    func(cwd, reason string)
 	FireFileChanged         func(path, tool string)

--- a/internal/app/kit/listnav.go
+++ b/internal/app/kit/listnav.go
@@ -95,19 +95,10 @@ func (n *ListNav) HandleKey(key tea.KeyMsg) (searchChanged, consumed bool) {
 		}
 		return false, true
 	default:
-		// Typed text capture. Vim-style navigation takes priority when the
-		// search is empty; otherwise the printable character is search input.
+		// Typed text capture: every printable rune is search input. Navigation
+		// is arrows + ctrl+p/ctrl+n only — no bare-letter vim keys — so a query
+		// can start with any character (e.g. "kimi").
 		if text := key.Key().Text; text != "" {
-			if n.Search == "" {
-				switch key.String() {
-				case "j":
-					n.MoveDown()
-					return false, true
-				case "k":
-					n.MoveUp()
-					return false, true
-				}
-			}
 			n.Search += text
 			return true, true
 		}

--- a/internal/app/kit/listnav_test.go
+++ b/internal/app/kit/listnav_test.go
@@ -110,22 +110,19 @@ func TestListNav_HandleKey_Navigation(t *testing.T) {
 	}
 }
 
-func TestListNav_HandleKey_VimKeysWhenSearchEmpty(t *testing.T) {
+func TestListNav_HandleKey_LettersAlwaysSearch(t *testing.T) {
 	n := ListNav{MaxVisible: 5, Total: 10}
 
-	// j navigates when search is empty
-	changed, consumed := n.HandleKey(tea.KeyPressMsg{Code: 'j', Text: "j"})
-	if changed || !consumed || n.Selected != 1 {
-		t.Fatalf("j: changed=%v consumed=%v sel=%d", changed, consumed, n.Selected)
-	}
-	if n.Search != "" {
-		t.Fatalf("j should not modify search, got %q", n.Search)
+	// j/k are search input even when the search is empty — there is no
+	// bare-letter vim navigation, so a query can start with any letter.
+	changed, consumed := n.HandleKey(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if !changed || !consumed || n.Search != "k" || n.Selected != 0 {
+		t.Fatalf("k: changed=%v consumed=%v search=%q sel=%d", changed, consumed, n.Search, n.Selected)
 	}
 
-	// k navigates when search is empty
-	changed, consumed = n.HandleKey(tea.KeyPressMsg{Code: 'k', Text: "k"})
-	if changed || !consumed || n.Selected != 0 {
-		t.Fatalf("k: changed=%v consumed=%v sel=%d", changed, consumed, n.Selected)
+	changed, consumed = n.HandleKey(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if !changed || !consumed || n.Search != "kj" || n.Selected != 0 {
+		t.Fatalf("j: changed=%v consumed=%v search=%q sel=%d", changed, consumed, n.Search, n.Selected)
 	}
 }
 

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -7,7 +7,6 @@ package app
 
 import (
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/kit"
@@ -42,28 +41,9 @@ func (m *model) overlayDeps() input.OverlayDeps {
 			llm.Default().SetCurrentModel(info)
 			m.env.LoadThinkingEffortFromStore()
 		},
-		PrintWelcome: func(modelID string) tea.Cmd {
-			modelName := modelID
-			if name := m.services.LLM.Store().CachedModelDisplayName(modelID); name != "" {
-				modelName = name
-			}
-			dim := lipgloss.NewStyle().Foreground(welcomeDim)
-			line := brandMark()
-			if proj := projectName(m.env.CWD); proj != "" {
-				line += dim.Render("  ·  ") + dim.Render(proj)
-			}
-			if modelName != "" {
-				line += dim.Render("  ·  ") + dim.Render(modelName)
-			}
-			// Overwrite the original welcome line in-place using ANSI cursor
-			// codes. The original printWelcome output is:
-			//   \n  (leading newline from renderWelcome)
-			//   <content>  (the styled welcome line)
-			//   \n  (trailing newline from fmt.Println)
-			// Move up 2 lines to the content line, clear it, rewrite, then
-			// position the cursor on the blank line below for the TUI.
-			return tea.Println("\033[2A\033[2K\r" + line + "\n")
-		},
+		// No welcome reprint on model switch: the live status line already
+		// shows the current model, and the startup brand line is a one-time
+		// splash (re-emitting it duplicated the banner / leaked blank lines).
 		ClearCachedInstructions: m.env.ClearCachedInstructions,
 		RefreshMemoryContext:    m.refreshMemoryContext,
 		FireFileChanged:         m.fireFileChanged,

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -57,6 +57,9 @@ func (m *model) drainTurnQueues() (tea.Cmd, bool) {
 	// producing one TurnEvent per queued message.
 	if item, ok := m.userInput.Queue.Dequeue(); ok {
 		log.QueueLog("drainTurnQueues: dequeued %q remaining=%d", truncate(item.Content, 60), m.userInput.Queue.Len())
+		if m.imagesBlockedForModel(item.Images) {
+			return tea.Batch(m.CommitMessages()...), true
+		}
 		m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: item.Content, Images: item.Images})
 		m.services.Agent.Send(item.Content, item.Images)
 		return nil, true

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -120,12 +120,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the Providers tab) clears the store's CurrentModel and updates
 		// llm.Default — but the per-turn env fields would stay stale until
 		// the next explicit model selection without this refresh.
-		prevModel := m.env.CurrentModel
 		m.env.CurrentModel = m.services.LLM.CurrentModel()
 		m.env.LLMProvider = m.services.LLM.Provider()
-		if prevModel != nil && m.env.CurrentModel == nil {
-			return m, m.overlayDeps().PrintWelcome(m.env.GetModelDisplayName())
-		}
 		return m, nil
 	case input.ToolToggleMsg:
 	case input.ConfigSavedMsg:

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
 )
 
@@ -85,6 +86,11 @@ func (m *model) dispatchSubmission(raw string) tea.Cmd {
 	if !ok {
 		return tea.Batch(m.CommitMessages()...)
 	}
+	// Hold the turn (keeping the input) if it carries images the active model
+	// can't accept, rather than letting the provider reject the request.
+	if m.imagesBlockedForModel(msg.Images) {
+		return tea.Batch(m.CommitMessages()...)
+	}
 	m.conv.Append(msg)
 	m.userInput.Reset()
 	return m.SubmitToAgent(msg.Content, msg.Images)
@@ -118,6 +124,18 @@ func (m *model) buildUserMessage(raw string) (core.ChatMessage, bool) {
 		DisplayContent: displayContent,
 		Images:         allImages,
 	}, true
+}
+
+// imagesBlockedForModel reports whether a turn carrying images must be held back
+// because the active model is text-only. It adds a user-facing notice when it
+// blocks; callers must not send the turn and should preserve the input so the
+// user can remove the image or switch to a vision-capable model.
+func (m *model) imagesBlockedForModel(images []core.Image) bool {
+	if len(images) == 0 || llm.SupportsImages(m.env.LLMProvider, m.env.GetModelID()) {
+		return false
+	}
+	m.conv.AddNotice("The current model doesn't support images — remove the image or switch to a vision-capable model.")
+	return true
 }
 
 // drainInputQueueAfterCancel pops one queued item (if any) and runs it

--- a/internal/llm/capability_test.go
+++ b/internal/llm/capability_test.go
@@ -1,0 +1,28 @@
+package llm
+
+import (
+	"context"
+	"testing"
+)
+
+// plainProvider implements Provider without declaring image support, so the
+// helper must default it to true.
+type plainProvider struct{}
+
+func (plainProvider) Stream(context.Context, CompletionOptions) <-chan StreamChunk { return nil }
+func (plainProvider) ListModels(context.Context) ([]ModelInfo, error)              { return nil, nil }
+func (plainProvider) Name() string                                                 { return "plain" }
+
+// textOnlyProvider opts out of image input via ImageSupportProvider.
+type textOnlyProvider struct{ plainProvider }
+
+func (textOnlyProvider) SupportsImages(string) bool { return false }
+
+func TestSupportsImages(t *testing.T) {
+	if !SupportsImages(plainProvider{}, "m") {
+		t.Error("a provider that doesn't implement ImageSupportProvider should default to supported")
+	}
+	if SupportsImages(textOnlyProvider{}, "m") {
+		t.Error("a provider that opts out should report no image support")
+	}
+}

--- a/internal/llm/deepseek/client.go
+++ b/internal/llm/deepseek/client.go
@@ -107,6 +107,11 @@ func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	return models, nil
 }
 
+// SupportsImages reports that DeepSeek models are text-only: the Chat
+// Completions API rejects image_url content parts.
+func (c *Client) SupportsImages(_ string) bool { return false }
+
 // Ensure Client implements Provider
 var _ llm.Provider = (*Client)(nil)
 var _ llm.ThinkingEffortProvider = (*Client)(nil)
+var _ llm.ImageSupportProvider = (*Client)(nil)

--- a/internal/llm/deepseek/client_test.go
+++ b/internal/llm/deepseek/client_test.go
@@ -98,6 +98,13 @@ func TestDeepSeekStreamSendsRequest(t *testing.T) {
 	}
 }
 
+func TestDeepSeekIsTextOnly(t *testing.T) {
+	c := NewClient(openai.Client{}, "deepseek:test")
+	if c.SupportsImages("deepseek-v4-pro") {
+		t.Error("DeepSeek is text-only; SupportsImages should be false")
+	}
+}
+
 func TestDeepSeekEstimateCost(t *testing.T) {
 	cost, ok := EstimateCost("deepseek-v4-flash", llm.Usage{
 		InputTokens:  1000000,

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -62,6 +62,23 @@ type ThinkingEffortProvider interface {
 	DefaultThinkingEffort(model string) string
 }
 
+// ImageSupportProvider is implemented by providers that declare whether a model
+// accepts image input. Providers that don't implement it are assumed to support
+// images (the common case); a text-only provider opts out by returning false.
+type ImageSupportProvider interface {
+	SupportsImages(model string) bool
+}
+
+// SupportsImages reports whether the provider's model accepts image input. It
+// defaults to true so vision-capable providers need no change; text-only
+// providers (e.g. DeepSeek) opt out via ImageSupportProvider.
+func SupportsImages(p Provider, model string) bool {
+	if ip, ok := p.(ImageSupportProvider); ok {
+		return ip.SupportsImages(model)
+	}
+	return true
+}
+
 func ThinkingEfforts(p Provider, model string) []string {
 	ep, ok := p.(ThinkingEffortProvider)
 	if !ok {

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -244,7 +244,13 @@ func extractUserContent(blocks []ContentBlock, msg *core.Message) {
 		switch block.Type {
 		case "text":
 			content.WriteString(block.Text)
-			display.WriteString(block.Text)
+			// <system-reminder> blocks are harness-injected context the model
+			// sees but the user must not: keep them in Content, exclude them
+			// from the displayed text (otherwise a resumed session re-renders
+			// the whole reminder block to the user).
+			if !strings.HasPrefix(block.Source, SourceReminder) {
+				display.WriteString(block.Text)
+			}
 		case "image":
 			if block.ImageSource != nil {
 				msg.Images = append(msg.Images, core.Image{MediaType: block.ImageSource.MediaType, Data: block.ImageSource.Data})
@@ -264,7 +270,10 @@ func extractUserContent(blocks []ContentBlock, msg *core.Message) {
 
 	if msg.ToolResult == nil {
 		msg.Content = content.String()
-		msg.DisplayContent = display.String()
+		// Trim the trailing blank line left where a reminder was appended
+		// (AttachToContent joins with "\n\n"), so the displayed text matches
+		// what the user originally typed.
+		msg.DisplayContent = strings.TrimRight(display.String(), "\n")
 	}
 }
 

--- a/internal/session/message_convert_test.go
+++ b/internal/session/message_convert_test.go
@@ -48,6 +48,27 @@ func Test_userContentToBlocks_splitsByProvenance(t *testing.T) {
 	}
 }
 
+// On resume, a reminder block must stay in Content (the model needs it) but be
+// excluded from DisplayContent (the user must not see the harness scaffolding).
+func Test_extractUserContent_stripsReminderFromDisplay(t *testing.T) {
+	blocks := []ContentBlock{
+		{Type: "text", Text: "hi\n\n"},
+		{Type: "text", Text: "<system-reminder source=\"memory-auto\">\nmem\n</system-reminder>", Source: SourceReminder + ":memory-auto"},
+	}
+	var msg core.Message
+	extractUserContent(blocks, &msg)
+
+	if !strings.Contains(msg.Content, "system-reminder") {
+		t.Fatalf("Content should keep the reminder for the model, got %q", msg.Content)
+	}
+	if strings.Contains(msg.DisplayContent, "system-reminder") {
+		t.Fatalf("DisplayContent must not include the reminder, got %q", msg.DisplayContent)
+	}
+	if msg.DisplayContent != "hi" {
+		t.Fatalf("DisplayContent = %q, want %q", msg.DisplayContent, "hi")
+	}
+}
+
 // Plain user content with no reminders produces exactly one user-text block.
 func Test_userContentToBlocks_plainTextOneBlock(t *testing.T) {
 	blocks := userContentToBlocks("just a question", "", nil)


### PR DESCRIPTION
Four independent fixes (one commit each):

- **Text-only models + images.** Sending an image to a text-only model (e.g. DeepSeek) returned a raw `400 unknown variant image_url`. Add an optional `llm.ImageSupportProvider` capability (defaults to *supported*, so vision providers are unchanged; DeepSeek opts out) and gate the submit/queue-drain paths — a turn carrying images for an unsupported model is held with a notice instead of being sent.
- **List-selector search swallowed h/j/k/l.** Bare-letter vim navigation ate the first character of a query, so `kimi`/`haiku`/`llama` couldn't be searched. Every printable rune now filters; navigation is arrows + ctrl+p/ctrl+n (list) and tab/shift+tab + ←/→ (tabs), no longer gated on an empty query.
- **Model switch reprinted the brand banner.** The in-place `\033[2A\033[2K` cursor hack leaked a blank line and duplicated the banner in a live viewport. Removed; the status line already shows the current model.
- **Resumed sessions leaked `<system-reminder>`.** On resume, display text was rebuilt from all blocks including harness-injected reminders. Reminder blocks now stay in `Content` (for the model) but are excluded from displayed text.

Independent of the open image PR #221 (no shared files). Build, vet, layercheck, and touched-package tests all green; new regression tests for the capability gate, the listnav keymap, and the resume display path.