### PR TITLE
feat(status-bar): make context bar opt-in and clean up rendering

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -45,7 +45,8 @@ type OperationModeParams struct {
 	ModelName        string
 	StatusMessage    string
 	ConversationCost llm.Money
-	Compressions     int // NEW — session compact count, drives the badge
+	Compressions     int  // session compact count, drives the "compacted ×N" badge
+	ShowContextBar   bool // render the visual [██████░░░░] 71% bar (opt-in)
 	Width            int
 	ThinkingEffort   string
 	ShowThinking     bool
@@ -72,13 +73,7 @@ func RenderModeStatus(params OperationModeParams) string {
 
 	left := strings.Join(leftParts, "  ")
 
-	right := renderModelWithTokens(
-		params.ModelName, params.StatusMessage,
-		params.InputTokens, params.InputLimit,
-		params.ConversationCost,
-		params.Compressions,
-		params.Width,
-	)
+	right := renderStatusCluster(params)
 	if right == "" || params.Width <= 0 {
 		return left
 	}
@@ -87,83 +82,56 @@ func RenderModeStatus(params OperationModeParams) string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
-// renderModelWithTokens composes the right-side cluster of the status
-// bar: model name, context label, bar, optional compressions badge,
-// optional cost. The actual rendering lives in status_bar.go; this
-// function preserves the existing call shape from RenderModeStatus.
-func renderModelWithTokens(
-	modelName, statusMessage string,
-	inputTokens, inputLimit int,
-	conversationCost llm.Money,
-	compressions int,
-	width int,
-) string {
-	if modelName == "" {
+// renderStatusCluster composes the status line's right-hand cluster, in
+// display order: model name, optional transient status message, the numeric
+// "ctx X/Y" label, the optional visual context bar, the optional compressions
+// badge, and the optional cost. Each piece is a statusSegment with a drop
+// priority; fitStatusSegments drops the least important first when the
+// terminal is too narrow to hold them all.
+func renderStatusCluster(p OperationModeParams) string {
+	if p.ModelName == "" {
 		return ""
 	}
 	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	sep := muted.Render(" · ")
 
-	// Always render the label + bar — RenderContext{Label,Bar} emit a
-	// dim placeholder ("ctx X/--" / "[----------] --") when the limit
-	// is unknown, so the gap stays visible instead of silently hiding.
-	labelText := RenderContextLabel(inputTokens, inputLimit)
-	barText := RenderContextBar(inputTokens, inputLimit)
-	if inputLimit > 0 {
-		if hint := compactStatusHint(float64(inputTokens) / float64(inputLimit) * 100); hint != "" {
-			barText += sep + muted.Render(hint)
-		}
-	}
-	badgeText := RenderCompressionsBadge(compressions)
-	costText := ""
-	if !conversationCost.IsZero() {
-		costText = muted.Render(kit.FormatMoney(conversationCost))
-	}
-
+	// Priority 1 = most important (dropped last). The model name always
+	// renders; everything else drops before it under width pressure.
 	segments := []statusSegment{
-		{render: func() string { return muted.Render(modelName) }, width: lipgloss.Width(modelName), priority: 1},
+		{text: muted.Render(p.ModelName), priority: 1},
 	}
-	if statusMessage != "" {
-		segments = append(segments, statusSegment{
-			render:   func() string { return muted.Render(statusMessage) },
-			width:    lipgloss.Width(statusMessage),
-			priority: 2,
-		})
-	}
-	if labelText != "" {
-		segments = append(segments, statusSegment{
-			render:   func() string { return labelText },
-			width:    lipgloss.Width(labelText),
-			priority: 3,
-		})
-		segments = append(segments, statusSegment{
-			render:   func() string { return barText },
-			width:    lipgloss.Width(barText),
-			priority: 4,
-		})
-	}
-	if badgeText != "" {
-		segments = append(segments, statusSegment{
-			render:   func() string { return badgeText },
-			width:    lipgloss.Width(badgeText),
-			priority: 5,
-		})
-	}
-	if costText != "" {
-		segments = append(segments, statusSegment{
-			render:   func() string { return costText },
-			width:    lipgloss.Width(costText),
-			priority: 6,
-		})
+	if p.StatusMessage != "" {
+		segments = append(segments, statusSegment{text: muted.Render(p.StatusMessage), priority: 2})
 	}
 
-	// AllocateStatusSegments joins survivors with segmentSep (a sentinel);
-	// split on it and rejoin with the visual separator to match the
-	// existing aesthetic. The sentinel guarantees segments containing the
-	// visual separator substring stay intact.
-	allocated := AllocateStatusSegments(segments, width)
-	parts := strings.Split(allocated, segmentSep)
-	return strings.Join(parts, sep)
+	// The numeric label always renders — it falls back to "ctx X/--" when the
+	// limit is unknown, so the slot stays visible instead of silently hiding.
+	segments = append(segments, statusSegment{
+		text:     RenderContextLabel(p.InputTokens, p.InputLimit),
+		priority: 3,
+	})
+
+	// The visual bar is opt-in (off by default). When shown it also carries
+	// the auto-compact hint as a near-full warning.
+	if p.ShowContextBar {
+		bar := RenderContextBar(p.InputTokens, p.InputLimit)
+		if p.InputLimit > 0 {
+			if hint := compactStatusHint(float64(p.InputTokens) / float64(p.InputLimit) * 100); hint != "" {
+				bar += sep + muted.Render(hint)
+			}
+		}
+		segments = append(segments, statusSegment{text: bar, priority: 4})
+	}
+
+	if badge := RenderCompressionsBadge(p.Compressions); badge != "" {
+		segments = append(segments, statusSegment{text: badge, priority: 5})
+	}
+	if !p.ConversationCost.IsZero() {
+		segments = append(segments, statusSegment{text: muted.Render(kit.FormatMoney(p.ConversationCost)), priority: 6})
+	}
+
+	survivors := fitStatusSegments(segments, p.Width, lipgloss.Width(sep))
+	return strings.Join(survivors, sep)
 }
 
 func RenderTurnUsageSummary(inputTokens, outputTokens, width int) string {

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -95,6 +95,7 @@ func TestRenderModeStatusShowsTokenUsageWithModel(t *testing.T) {
 		InputTokens:      142000,
 		InputLimit:       200000,
 		ConversationCost: llm.Money{Amount: 0.04, Currency: llm.CurrencyUSD},
+		ShowContextBar:   true,
 		Width:            120,
 	})
 	visible := stripANSI(rendered)
@@ -104,22 +105,42 @@ func TestRenderModeStatusShowsTokenUsageWithModel(t *testing.T) {
 	if !strings.Contains(visible, "[") || !strings.Contains(visible, "] 71%") {
 		t.Fatalf("RenderModeStatus() = %q, want bar with percent", visible)
 	}
+	// The numeric label rides alongside the bar.
+	if !strings.Contains(visible, "ctx 142.0k/200.0k") {
+		t.Fatalf("RenderModeStatus() = %q, want numeric ctx label", visible)
+	}
 	// Cost segment must still render.
 	if !strings.Contains(visible, "$0.04") {
 		t.Fatalf("RenderModeStatus() = %q, want cost segment", visible)
 	}
-	// Old per-call percent format must NOT appear anymore.
-	if strings.Contains(visible, "(71%)") {
-		t.Fatalf("RenderModeStatus() = %q, should not contain old (NN%%) format", visible)
+}
+
+// TestRenderModeStatusHidesBarByDefault confirms the visual bar is opt-in:
+// with ShowContextBar unset the [██░░] bar and its percent are gone, but the
+// numeric "ctx X/Y" label still shows.
+func TestRenderModeStatusHidesBarByDefault(t *testing.T) {
+	rendered := RenderModeStatus(OperationModeParams{
+		ModelName:   "claude-sonnet-4-6",
+		InputTokens: 142000,
+		InputLimit:  200000,
+		Width:       120,
+	})
+	visible := stripANSI(rendered)
+	if !strings.Contains(visible, "ctx 142.0k/200.0k") {
+		t.Fatalf("numeric ctx label should still show when bar is off; got %q", visible)
+	}
+	if strings.Contains(visible, "█") || strings.Contains(visible, "71%") {
+		t.Fatalf("visual bar should be hidden by default; got %q", visible)
 	}
 }
 
-func TestRenderModeStatusKeepsContextDisplayOnRightOnly(t *testing.T) {
+func TestRenderModeStatusShowsBarWhenEnabled(t *testing.T) {
 	rendered := RenderModeStatus(OperationModeParams{
-		ModelName:   "claude-sonnet-4-6",
-		InputTokens: 190000,
-		InputLimit:  200000,
-		Width:       120,
+		ModelName:      "claude-sonnet-4-6",
+		InputTokens:    190000,
+		InputLimit:     200000,
+		ShowContextBar: true,
+		Width:          120,
 	})
 	visible := stripANSI(rendered)
 	if !strings.Contains(visible, "claude-sonnet-4-6") {
@@ -143,8 +164,8 @@ func TestRenderModeStatusShowsCompressionsBadgeWhenNonZero(t *testing.T) {
 		Width:        120,
 	})
 	visible := stripANSI(rendered)
-	if !strings.Contains(visible, "🗜️ 3") {
-		t.Fatalf("want '🗜️ 3' badge in %q", visible)
+	if !strings.Contains(visible, "compacted ×3") {
+		t.Fatalf("want 'compacted ×3' badge in %q", visible)
 	}
 }
 
@@ -157,7 +178,7 @@ func TestRenderModeStatusHidesBadgeWhenZero(t *testing.T) {
 		Width:        120,
 	})
 	visible := stripANSI(rendered)
-	if strings.Contains(visible, "🗜️") {
+	if strings.Contains(visible, "compacted") {
 		t.Fatalf("badge should be hidden when zero; got %q", visible)
 	}
 }
@@ -167,10 +188,11 @@ func TestRenderModeStatusShowsPlaceholderWhenLimitUnknown(t *testing.T) {
 	// a placeholder so the gap stays visible and actionable, instead of
 	// silently hiding the entire context segment.
 	rendered := RenderModeStatus(OperationModeParams{
-		ModelName:   "some-model",
-		InputTokens: 5000,
-		InputLimit:  0,
-		Width:       120,
+		ModelName:      "some-model",
+		InputTokens:    5000,
+		InputLimit:     0,
+		ShowContextBar: true,
+		Width:          120,
 	})
 	visible := stripANSI(rendered)
 	if !strings.Contains(visible, "[----------]") {

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -6,6 +6,7 @@ package conv
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -126,84 +127,63 @@ func compressionBadgeStyle(n int) lipgloss.Style {
 	}
 }
 
-// RenderCompressionsBadge returns the "🗜️ N" badge or "" when n ≤ 0.
-// Color escalates per compressionBadgeStyle.
+// RenderCompressionsBadge returns the "compacted ×N" badge or "" when n ≤ 0.
+// Plain text (no emoji) keeps the status line aligned across terminals; color
+// escalates with the count per compressionBadgeStyle.
 func RenderCompressionsBadge(n int) string {
 	if n <= 0 {
 		return ""
 	}
-	return compressionBadgeStyle(n).Render(fmt.Sprintf("🗜️ %d", n))
+	return compressionBadgeStyle(n).Render(fmt.Sprintf("compacted ×%d", n))
 }
 
-// segmentSep is the internal join separator. Uses the ASCII Unit
-// Separator (\x1f) so it can never collide with rendered segment text
-// (lipgloss emits ANSI escapes with \x1b; user strings don't contain
-// control characters). Callers split on it to swap in their own visual
-// separator.
-const segmentSep = "\x1f"
-
-// statusSegment is a unit the allocator can keep or drop atomically.
-// Lower priority drops first when width is constrained (PRD §8.3).
+// statusSegment is one keep-or-drop unit of the status line's right cluster.
+// Under width pressure whole segments are dropped, never truncated mid-text.
 type statusSegment struct {
-	render   func() string // lazy — only invoked if the segment survives
-	width    int           // precomputed visible width (excluding separators)
-	priority int           // 1 = highest (drops last); larger = drops first
+	text     string // already-rendered (styled) text
+	priority int    // 1 = most important (dropped last); larger drops first
 }
 
-// AllocateStatusSegments walks segments in priority order, keeping each
-// segment that fits in the remaining budget plus its leading separator.
-// Segments are never truncated mid-render. Returns survivors joined with
-// segmentSep, in the original caller-supplied order. Callers split on
-// segmentSep to rejoin with their preferred visual separator.
-func AllocateStatusSegments(segments []statusSegment, availableWidth int) string {
-	if availableWidth <= 0 || len(segments) == 0 {
-		return ""
-	}
-	// Sort by priority ascending (1 first). Stable so equal-priority
-	// segments keep their original order.
-	order := make([]int, len(segments))
-	for i := range order {
-		order[i] = i
-	}
-	// Insertion sort — n is tiny (≤6 segments in practice).
-	for i := 1; i < len(order); i++ {
-		j := i
-		for j > 0 && segments[order[j-1]].priority > segments[order[j]].priority {
-			order[j-1], order[j] = order[j], order[j-1]
-			j--
-		}
+// fitStatusSegments returns the segments that fit within maxWidth when joined
+// by a separator of sepWidth visible columns, preserving their caller-supplied
+// order. Under width pressure it drops the highest-priority-number segments
+// first; survivors keep the original order so the layout still reads naturally.
+func fitStatusSegments(segments []statusSegment, maxWidth, sepWidth int) []string {
+	if maxWidth <= 0 || len(segments) == 0 {
+		return nil
 	}
 
-	type kept struct {
-		idx    int
-		render string
+	// Decide keep/drop in priority order (most important first) without
+	// disturbing the original order the survivors are emitted in.
+	byPriority := make([]int, len(segments))
+	for i := range byPriority {
+		byPriority[i] = i
 	}
-	var survivors []kept
-	budget := availableWidth
-	for _, idx := range order {
-		s := segments[idx]
-		need := s.width
-		if len(survivors) > 0 {
-			need += len(segmentSep)
+	sort.SliceStable(byPriority, func(a, b int) bool {
+		return segments[byPriority[a]].priority < segments[byPriority[b]].priority
+	})
+
+	keep := make([]bool, len(segments))
+	remaining := maxWidth
+	kept := 0
+	for _, i := range byPriority {
+		need := lipgloss.Width(segments[i].text)
+		if kept > 0 {
+			need += sepWidth // every segment after the first costs a separator
 		}
-		if need > budget {
+		if need > remaining {
 			continue
 		}
-		survivors = append(survivors, kept{idx: idx, render: s.render()})
-		budget -= need
+		keep[i] = true
+		remaining -= need
+		kept++
 	}
 
-	// Re-emit in the original (caller-supplied) order so the layout reads
-	// naturally regardless of priority.
-	byIdx := make(map[int]int, len(survivors))
-	for i, k := range survivors {
-		byIdx[k.idx] = i
-	}
-	out := make([]string, 0, len(survivors))
-	for origIdx := range segments {
-		if i, ok := byIdx[origIdx]; ok {
-			out = append(out, survivors[i].render)
+	out := make([]string, 0, kept)
+	for i, seg := range segments {
+		if keep[i] {
+			out = append(out, seg.text)
 		}
 	}
-	return strings.Join(out, segmentSep)
+	return out
 }

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -108,12 +108,12 @@ func TestRenderCompressionsBadge(t *testing.T) {
 		visible string // empty means badge should not render
 	}{
 		{"zero-hidden", 0, ""},
-		{"one", 1, "🗜️ 1"},
-		{"four-dim", 4, "🗜️ 4"},
-		{"five-warn", 5, "🗜️ 5"},
-		{"nine-warn", 9, "🗜️ 9"},
-		{"ten-error", 10, "🗜️ 10"},
-		{"twenty-error", 20, "🗜️ 20"},
+		{"one", 1, "compacted ×1"},
+		{"four-dim", 4, "compacted ×4"},
+		{"five-warn", 5, "compacted ×5"},
+		{"nine-warn", 9, "compacted ×9"},
+		{"ten-error", 10, "compacted ×10"},
+		{"twenty-error", 20, "compacted ×20"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -132,59 +132,75 @@ func TestRenderCompressionsBadge(t *testing.T) {
 	}
 }
 
-func TestAllocateStatusSegments_DropsInPriorityOrder(t *testing.T) {
+func TestFitStatusSegments_DropsInPriorityOrder(t *testing.T) {
 	// Priorities: 1=highest (drops last), 4=lowest (drops first).
 	segments := []statusSegment{
-		{render: func() string { return "[bar] 71%" }, width: 11, priority: 1},
-		{render: func() string { return "ctx 142K/200K" }, width: 14, priority: 2},
-		{render: func() string { return "🗜️ 2" }, width: 5, priority: 3},
-		{render: func() string { return "$0.04" }, width: 5, priority: 4},
+		{text: "[bar] 71%", priority: 1},
+		{text: "ctx 142K/200K", priority: 2},
+		{text: "compacted ×2", priority: 3},
+		{text: "$0.04", priority: 4},
 	}
 
-	// Wide: everything fits with separators.
-	got := AllocateStatusSegments(segments, 100)
-	for _, s := range segments {
-		if !strings.Contains(got, stripANSI(s.render())) {
-			t.Errorf("wide: segment %q dropped from %q", stripANSI(s.render()), got)
+	// Wide: everything fits, in original order.
+	got := fitStatusSegments(segments, 100, 3)
+	if len(got) != len(segments) {
+		t.Fatalf("wide: kept %d segments, want %d (%q)", len(got), len(segments), got)
+	}
+	for i, seg := range segments {
+		if got[i] != seg.text {
+			t.Errorf("wide: position %d = %q, want %q", i, got[i], seg.text)
 		}
 	}
 
 	// Narrow (~30 cols): lowest-priority segments drop first.
-	got = AllocateStatusSegments(segments, 30)
-	if !strings.Contains(got, "[bar] 71%") {
-		t.Errorf("priority-1 segment should survive at width 30; got %q", got)
+	got = fitStatusSegments(segments, 30, 3)
+	joined := strings.Join(got, " · ")
+	if !strings.Contains(joined, "[bar] 71%") {
+		t.Errorf("priority-1 segment should survive at width 30; got %q", joined)
 	}
-	if strings.Contains(got, "$0.04") {
-		t.Errorf("priority-4 (cost) should drop first at width 30; got %q", got)
+	if strings.Contains(joined, "$0.04") {
+		t.Errorf("priority-4 (cost) should drop first at width 30; got %q", joined)
 	}
 }
 
-func TestAllocateStatusSegments_NeverTruncatesMidSegment(t *testing.T) {
-	segments := []statusSegment{
-		{render: func() string { return "exactly12ch" }, width: 11, priority: 1},
-	}
-	// Just enough room.
-	got := AllocateStatusSegments(segments, 11)
-	if !strings.Contains(got, "exactly12ch") {
+func TestFitStatusSegments_NeverTruncatesMidSegment(t *testing.T) {
+	segments := []statusSegment{{text: "exactly12ch", priority: 1}}
+
+	// Just enough room (segment is 11 cols wide).
+	if got := fitStatusSegments(segments, 11, 3); len(got) != 1 || got[0] != "exactly12ch" {
 		t.Errorf("segment should fit at width=its own width; got %q", got)
 	}
-	// One col too narrow.
-	got = AllocateStatusSegments(segments, 10)
-	if strings.Contains(got, "exactly12") {
+	// One col too narrow: drop the whole segment, never truncate.
+	if got := fitStatusSegments(segments, 10, 3); len(got) != 0 {
 		t.Errorf("segment must drop, not truncate, when it doesn't fit; got %q", got)
 	}
 }
 
-func TestAllocateStatusSegments_PreservesSegmentContainingSpaces(t *testing.T) {
-	// Regression: the internal separator is a sentinel (\x1f) that
-	// cannot appear in rendered text, so segments containing arbitrary
-	// substrings (including spaces) survive intact.
+func TestFitStatusSegments_PreservesOriginalOrder(t *testing.T) {
+	// Survivors keep their caller-supplied order even though the highest
+	// priority (dropped last) is the second segment.
 	segments := []statusSegment{
-		{render: func() string { return "ab  cd" }, width: 6, priority: 1},
-		{render: func() string { return "ef" }, width: 2, priority: 2},
+		{text: "first", priority: 2},
+		{text: "second", priority: 1},
 	}
-	got := AllocateStatusSegments(segments, 100)
-	if !strings.Contains(got, "ab  cd") || !strings.Contains(got, "ef") {
-		t.Errorf("segments with inner spaces corrupted: %q", got)
+	got := fitStatusSegments(segments, 100, 3)
+	if len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Errorf("survivors should keep original order; got %q", got)
+	}
+}
+
+func TestFitStatusSegments_AccountsForSeparatorWidth(t *testing.T) {
+	// Two 5-col segments need 5 + sepWidth + 5 columns together. With a
+	// 3-col separator that's 13; one column short drops the lower-priority
+	// (higher-number) second segment.
+	segments := []statusSegment{
+		{text: "aaaaa", priority: 1},
+		{text: "bbbbb", priority: 2},
+	}
+	if got := fitStatusSegments(segments, 13, 3); len(got) != 2 {
+		t.Errorf("both should fit at width 13 (5+3+5); got %q", got)
+	}
+	if got := fitStatusSegments(segments, 12, 3); len(got) != 1 || got[0] != "aaaaa" {
+		t.Errorf("separator should push the second segment out at width 12; got %q", got)
 	}
 }

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -43,6 +43,11 @@ type env struct {
 	// ResetContextDisplay (called per-compact); zeroed only by ResetTokens
 	// (called on /reset, /new).
 	Compressions int
+	// ShowContextBar mirrors the persisted appearance setting (off by
+	// default): when true the status line renders the visual [██████░░░░] 71%
+	// bar. Cached here so the hot render path never snapshots settings.
+	// Set at startup and whenever the /config Appearance panel saves.
+	ShowContextBar bool
 
 	// ── Permission (mutable — changes per mode cycle) ───────────
 	OperationMode      setting.OperationMode

--- a/internal/app/input/config_appearance.go
+++ b/internal/app/input/config_appearance.go
@@ -1,7 +1,13 @@
-// /config Appearance panel: a radio list that switches the color theme
-// (light / dark / auto). Selecting a row applies the theme live to the
-// running TUI and persists it to the user-level settings file. Theme is a
-// personal preference, so — unlike Self-Learning — it has no project scope.
+// /config Appearance panel: two radio groups the user navigates as one
+// flat list.
+//
+//   - COLOR THEME — light / dark / auto. Applied live and persisted to the
+//     user-level settings file.
+//   - CONTEXT BAR — on / off. Toggles the visual context-usage bar
+//     ([██████░░░░] 71%) in the status line. Off by default.
+//
+// Both are personal preferences, so — unlike Self-Learning — they have no
+// project scope; selecting a row persists to the user settings file.
 package input
 
 import (
@@ -22,25 +28,59 @@ type ThemeSavedMsg struct {
 	Theme string
 }
 
-type themeChoice struct {
-	label, value, desc string
+// ContextBarSavedMsg is emitted after the appearance panel persists the
+// context-bar on/off choice so the app can update its live display flag,
+// refresh its settings handle, and show a confirmation. The value is already
+// written to disk by the time this fires.
+type ContextBarSavedMsg struct {
+	On bool
 }
 
-// appearanceThemeChoices mirrors the first-run selector (kit.RunThemeSelector)
-// so the in-app switcher and the first-run prompt offer the same options.
-var appearanceThemeChoices = []themeChoice{
-	{"Dark", "dark", "Dark background terminal"},
-	{"Light", "light", "Light background terminal"},
-	{"Auto", "auto", "Match terminal appearance automatically"},
+// appearanceKind tags which setting a row applies when selected.
+type appearanceKind int
+
+const (
+	kindTheme appearanceKind = iota
+	kindContextBar
+)
+
+// appearanceOption is one selectable row. section heads the group it belongs
+// to (printed once, above the group's first row). Exactly one value field is
+// meaningful, selected by kind: theme for kindTheme, barOn for kindContextBar.
+type appearanceOption struct {
+	section string
+	kind    appearanceKind
+	label   string
+	desc    string
+	theme   string // kindTheme: the theme value to apply
+	barOn   bool   // kindContextBar: the on/off value to apply
+}
+
+// appearanceOptions is the full, section-ordered row list. The theme group
+// comes first so the cursor can park on the current theme at Enter (and so
+// indexOfTheme returns the same indices the first-run selector uses).
+func appearanceOptions() []appearanceOption {
+	return []appearanceOption{
+		{section: "COLOR THEME", kind: kindTheme, label: "Dark", desc: "Dark background terminal", theme: "dark"},
+		{section: "COLOR THEME", kind: kindTheme, label: "Light", desc: "Light background terminal", theme: "light"},
+		{section: "COLOR THEME", kind: kindTheme, label: "Auto", desc: "Match terminal appearance automatically", theme: "auto"},
+		{section: "CONTEXT BAR", kind: kindContextBar, label: "On", desc: "Show the visual context-usage bar", barOn: true},
+		{section: "CONTEXT BAR", kind: kindContextBar, label: "Off", desc: "Hide the bar (numeric ctx X/Y still shows)", barOn: false},
+	}
 }
 
 type appearancePanel struct {
 	settings *setting.Settings
 
-	// baseline is the theme persisted on disk, marked "● current" in the
-	// list; cursor is the row the user is hovering. Dirty when they differ.
-	baseline string
-	cursor   int
+	options []appearanceOption
+	cursor  int // hovered row in options
+
+	// Baselines are the values persisted on disk, marked "● current" in their
+	// group. A group is "dirty" while the cursor hovers a row that diverges
+	// from its baseline.
+	themeBaseline string
+	barBaseline   bool
+
 	// saveErr holds the last failed persist so Render can surface it inline
 	// instead of silently swallowing it. Cleared on navigation / re-entry.
 	saveErr error
@@ -53,20 +93,25 @@ func newAppearancePanel(settings *setting.Settings) *appearancePanel {
 func (p *appearancePanel) Title() string { return "appearance" }
 
 func (p *appearancePanel) Enter() {
-	p.baseline = "auto"
+	p.options = appearanceOptions()
+	p.themeBaseline = "auto"
+	p.barBaseline = false
 	if p.settings != nil {
-		if data := p.settings.Snapshot(); data != nil && data.Theme != "" {
-			p.baseline = data.Theme
+		if data := p.settings.Snapshot(); data != nil {
+			if data.Theme != "" {
+				p.themeBaseline = data.Theme
+			}
+			p.barBaseline = data.ShowContextBar()
 		}
 	}
-	p.cursor = indexOfTheme(p.baseline)
+	p.cursor = indexOfTheme(p.themeBaseline)
 	p.saveErr = nil
 }
 
-// Dirty reports whether the hovered row diverges from the saved theme, so
-// the shell pins the "● unsaved" indicator.
+// Dirty reports whether the hovered row diverges from its group's saved
+// value, so the shell pins the "● unsaved" indicator.
 func (p *appearancePanel) Dirty() bool {
-	return appearanceThemeChoices[p.cursor].value != p.baseline
+	return !p.isCurrent(p.options[p.cursor])
 }
 
 func (p *appearancePanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
@@ -77,26 +122,44 @@ func (p *appearancePanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		p.saveErr = nil
 	case "down", "j":
-		if p.cursor < len(appearanceThemeChoices)-1 {
+		if p.cursor < len(p.options)-1 {
 			p.cursor++
 		}
 		p.saveErr = nil
 	case "enter", " ":
-		value := appearanceThemeChoices[p.cursor].value
+		return p.apply(p.options[p.cursor])
+	}
+	return nil, false
+}
+
+// apply persists (and, for the theme, live-applies) the hovered option,
+// advances that group's baseline, and returns the confirmation command.
+// On failure it sets saveErr, keeps the popup open (done=false), and leaves
+// the baseline untouched.
+func (p *appearancePanel) apply(opt appearanceOption) (tea.Cmd, bool) {
+	switch opt.kind {
+	case kindTheme:
 		// Apply live so the switch is visible immediately. InitTheme only
 		// flips lipgloss's cached background flag (no terminal I/O), so it is
 		// safe to call mid-program.
-		kit.InitTheme(value)
-		if err := setting.SaveTheme(value); err != nil {
+		kit.InitTheme(opt.theme)
+		if err := setting.SaveTheme(opt.theme); err != nil {
 			// Keep the on-screen theme in sync with what's actually persisted:
 			// revert the live apply and surface the error instead of leaving
 			// the UI showing a theme that won't survive a restart.
-			kit.InitTheme(p.baseline)
+			kit.InitTheme(p.themeBaseline)
 			p.saveErr = err
 			return nil, false
 		}
-		p.baseline = value
-		return func() tea.Msg { return ThemeSavedMsg{Theme: value} }, true
+		p.themeBaseline = opt.theme
+		return func() tea.Msg { return ThemeSavedMsg{Theme: opt.theme} }, true
+	case kindContextBar:
+		if err := setting.SaveContextBar(opt.barOn); err != nil {
+			p.saveErr = err
+			return nil, false
+		}
+		p.barBaseline = opt.barOn
+		return func() tea.Msg { return ContextBarSavedMsg{On: opt.barOn} }, true
 	}
 	return nil, false
 }
@@ -107,44 +170,71 @@ func (p *appearancePanel) HintLine() string {
 
 func (p *appearancePanel) Render(width int) string {
 	var b strings.Builder
-	b.WriteString(appearanceSectionStyle.Render("COLOR THEME"))
-	b.WriteString(" ")
-	ruleLen := max(width-len("COLOR THEME")-1, 1)
-	b.WriteString(appearanceRuleStyle.Render(strings.Repeat("─", ruleLen)))
-	b.WriteString("\n\n")
 
-	for i, opt := range appearanceThemeChoices {
-		caret := "  "
-		label := appearanceLabelStyle.Render(opt.label)
-		if i == p.cursor {
-			caret = appearanceCursorStyle.Render("▸ ")
-			label = appearanceCursorStyle.Render(opt.label)
+	prevSection := ""
+	for i, opt := range p.options {
+		if opt.section != prevSection {
+			if prevSection != "" {
+				b.WriteString("\n")
+			}
+			b.WriteString(renderAppearanceSection(opt.section, width))
+			b.WriteString("\n\n")
+			prevSection = opt.section
 		}
-
-		radio := appearanceRadioOffStyle.Render("○")
-		current := ""
-		if opt.value == p.baseline {
-			radio = appearanceRadioOnStyle.Render("●")
-			current = "  " + appearanceCurrentStyle.Render("current")
-		}
-
-		// Pad labels to a common column so the descriptions line up.
-		labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
-		b.WriteString(caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current)
+		b.WriteString(p.renderOption(i, opt))
 		b.WriteString("\n")
 	}
 
 	if p.saveErr != nil {
 		b.WriteString("\n")
-		b.WriteString(appearanceErrorStyle.Render("⚠ couldn't save theme: " + p.saveErr.Error()))
+		b.WriteString(appearanceErrorStyle.Render("⚠ couldn't save: " + p.saveErr.Error()))
 		b.WriteString("\n")
 	}
 	return b.String()
 }
 
+// renderAppearanceSection renders a section heading followed by a rule that
+// fills the remaining width.
+func renderAppearanceSection(title string, width int) string {
+	ruleLen := max(width-len(title)-1, 1)
+	return appearanceSectionStyle.Render(title) + " " + appearanceRuleStyle.Render(strings.Repeat("─", ruleLen))
+}
+
+func (p *appearancePanel) renderOption(i int, opt appearanceOption) string {
+	caret := "  "
+	label := appearanceLabelStyle.Render(opt.label)
+	if i == p.cursor {
+		caret = appearanceCursorStyle.Render("▸ ")
+		label = appearanceCursorStyle.Render(opt.label)
+	}
+
+	radio := appearanceRadioOffStyle.Render("○")
+	current := ""
+	if p.isCurrent(opt) {
+		radio = appearanceRadioOnStyle.Render("●")
+		current = "  " + appearanceCurrentStyle.Render("current")
+	}
+
+	// Pad labels to a common column so the descriptions line up.
+	labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
+	return caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current
+}
+
+// isCurrent reports whether opt matches the persisted value for its group.
+func (p *appearancePanel) isCurrent(opt appearanceOption) bool {
+	switch opt.kind {
+	case kindContextBar:
+		return opt.barOn == p.barBaseline
+	default:
+		return opt.theme == p.themeBaseline
+	}
+}
+
+// indexOfTheme returns the row index of the given theme value, or 0 (the
+// first row) when it is unknown / unset.
 func indexOfTheme(value string) int {
-	for i, opt := range appearanceThemeChoices {
-		if opt.value == value {
+	for i, opt := range appearanceOptions() {
+		if opt.kind == kindTheme && opt.theme == value {
 			return i
 		}
 	}

--- a/internal/app/input/config_appearance_test.go
+++ b/internal/app/input/config_appearance_test.go
@@ -60,8 +60,8 @@ func TestAppearancePanelEnterSavesAndEmits(t *testing.T) {
 	if !done {
 		t.Fatalf("enter should dismiss the popup (done=true)")
 	}
-	if p.baseline != "dark" {
-		t.Fatalf("baseline = %q, want %q", p.baseline, "dark")
+	if p.themeBaseline != "dark" {
+		t.Fatalf("themeBaseline = %q, want %q", p.themeBaseline, "dark")
 	}
 	if p.saveErr != nil {
 		t.Fatalf("unexpected saveErr: %v", p.saveErr)
@@ -116,11 +116,54 @@ func TestAppearancePanelEnterSaveFailureSurfacesError(t *testing.T) {
 	if p.saveErr == nil {
 		t.Fatalf("a failed save should set saveErr")
 	}
-	if p.baseline != "auto" {
-		t.Fatalf("baseline should be untouched on failure, got %q", p.baseline)
+	if p.themeBaseline != "auto" {
+		t.Fatalf("themeBaseline should be untouched on failure, got %q", p.themeBaseline)
 	}
-	if out := p.Render(80); !strings.Contains(out, "couldn't save theme") {
+	if out := p.Render(80); !strings.Contains(out, "couldn't save") {
 		t.Fatalf("Render should surface the save error, got:\n%s", out)
+	}
+}
+
+// TestAppearancePanelContextBarSavesAndEmits confirms selecting the "On"
+// context-bar row persists contextBar=true to the user settings file,
+// advances the bar baseline, and emits a ContextBarSavedMsg.
+func TestAppearancePanelContextBarSavesAndEmits(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	p := newAppearancePanel(nil)
+	p.Enter() // cursor parks on the current theme (index 2, "auto")
+	if p.barBaseline {
+		t.Fatalf("context bar should default off")
+	}
+
+	// Walk down to the "On" context-bar row (index 3) and select it.
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown}) // auto → On
+	cmd, done := p.HandleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Fatalf("enter should dismiss the popup (done=true)")
+	}
+	if !p.barBaseline {
+		t.Fatalf("barBaseline should be true after enabling")
+	}
+	msg, ok := cmd().(ContextBarSavedMsg)
+	if !ok || !msg.On {
+		t.Fatalf("expected ContextBarSavedMsg{On:true}, got %#v", cmd())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".san", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings file not written: %v", err)
+	}
+	var data struct {
+		ContextBar *bool `json:"contextBar"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("settings file not valid JSON: %v\n%s", err, raw)
+	}
+	if data.ContextBar == nil || !*data.ContextBar {
+		t.Fatalf("persisted contextBar = %v, want true\n%s", data.ContextBar, raw)
 	}
 }
 

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -46,6 +46,7 @@ func newBaseModel() model {
 	environment := newEnv(svc.LLM, appCwd, svc.Setting.IsGitRepo(appCwd))
 	if settings := svc.Setting.Snapshot(); settings != nil {
 		environment.ApplyDefaultPermissionMode(settings.Permissions.DefaultMode, appCwd, svc.Setting.AllowBypass())
+		environment.ShowContextBar = settings.ShowContextBar()
 	}
 	return model{
 		userInput: input.New(appCwd, defaultWidth, commandSuggestionMatcher(svc.Command), input.SelectorDeps{

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -149,6 +149,19 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.conv.AddNotice("Theme set to " + msg.Theme)
 		return m, nil
+	case input.ContextBarSavedMsg:
+		// Update the live display flag so the status line reflects the choice
+		// immediately, then refresh the in-memory handle for re-opens.
+		m.env.ShowContextBar = msg.On
+		if err := m.services.Setting.Reload(m.env.CWD); err != nil {
+			log.Logger().Warn("reload settings after context-bar save failed", zap.Error(err))
+		}
+		if msg.On {
+			m.conv.AddNotice("Context bar on")
+		} else {
+			m.conv.AddNotice("Context bar off")
+		}
+		return m, nil
 	case input.SkillCycleMsg:
 		// Why re-emit on toggle: the skills directory rides in
 		// <system-reminder>, which is only refreshed at SessionStart and

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -248,6 +248,7 @@ func (m model) renderModeStatus() string {
 		StatusMessage:    m.userInput.Provider.StatusMessage,
 		ConversationCost: m.env.ConversationCost,
 		Compressions:     m.env.Compressions,
+		ShowContextBar:   m.env.ShowContextBar,
 		Width:            m.env.Width,
 		ThinkingEffort:   thinkingEffort,
 		ShowThinking:     showThinking,

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -433,6 +433,20 @@ func SaveTheme(t string) error {
 	return nil
 }
 
+// SaveContextBar persists the context-usage bar on/off choice to
+// ~/.san/settings.json. The value is written as an explicit pointer so an
+// "off" choice overrides any inherited "on" instead of being dropped as a
+// zero value (see Data.ContextBar).
+func SaveContextBar(on bool) error {
+	if err := NewLoader().SaveToUser(&Data{ContextBar: &on}); err != nil {
+		return err
+	}
+	loadedSettingsMu.Lock()
+	loadedSettings = nil
+	loadedSettingsMu.Unlock()
+	return nil
+}
+
 // SavePersonaAt persists the chosen persona name at the given scope: the
 // project file (.san/settings.json under cwd) when userLevel is false, or the
 // user file (~/.san/settings.json) when true. An empty name clears the field.

--- a/internal/setting/merger.go
+++ b/internal/setting/merger.go
@@ -22,6 +22,7 @@ func mergeSettings(base, overlay *Data) *Data {
 	result.DisabledTools = mergeMaps(base.DisabledTools, overlay.DisabledTools)
 	result.SearchProvider = coalesce(overlay.SearchProvider, base.SearchProvider)
 	result.AllowBypass = coalesceBool(overlay.AllowBypass, base.AllowBypass)
+	result.ContextBar = coalesceBool(overlay.ContextBar, base.ContextBar)
 	result.Persona = coalesce(overlay.Persona, base.Persona)
 	result.SelfLearn = mergeSelfLearn(base.SelfLearn, overlay.SelfLearn)
 

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -32,6 +32,11 @@ type Data struct {
 	Theme          string             `json:"theme,omitempty"`
 	SearchProvider string             `json:"searchProvider,omitempty"`
 	AllowBypass    *bool              `json:"allowBypass,omitempty"`
+	// ContextBar toggles the visual context-usage bar ([██████░░░░] 71%) in
+	// the status line. Pointer so an explicit "off" persists distinctly from
+	// "unset"; nil (unset) means off — the bar is opt-in. The numeric
+	// "ctx X/Y" label is unaffected and always shows.
+	ContextBar *bool `json:"contextBar,omitempty"`
 	// Persona selects an active persona directory under ~/.san/personas/<name>/
 	// or .san/personas/<name>/. Empty = no persona override. The persona's own
 	// settings.json is applied as the highest config overlay (see
@@ -161,6 +166,12 @@ func (s SelfLearnSettings) Validate() error {
 		)
 	}
 	return nil
+}
+
+// ShowContextBar reports whether the visual context-usage bar is enabled.
+// Nil (unset) resolves to off — the bar is opt-in.
+func (s *Data) ShowContextBar() bool {
+	return s != nil && s.ContextBar != nil && *s.ContextBar
 }
 
 // PermissionSettings defines permission rules for tool execution.
@@ -412,6 +423,10 @@ func (s *Data) Clone() *Data {
 	if s.AllowBypass != nil {
 		v := *s.AllowBypass
 		dst.AllowBypass = &v
+	}
+	if s.ContextBar != nil {
+		v := *s.ContextBar
+		dst.ContextBar = &v
 	}
 	for k, v := range s.Env {
 		dst.Env[k] = v


### PR DESCRIPTION
Make the visual context-usage bar (`[██████░░░░] 71%`) opt-in — configurable under `/config › Appearance`, **off by default**. The numeric `ctx X/Y` label still always shows.

- New **CONTEXT BAR** on/off group in the Appearance panel, persisted as `contextBar` in user settings (a `*bool` so an explicit "off" overrides an inherited "on"); applied live via `ContextBarSavedMsg`.
- Cleaned up the status-line right-cluster renderer: dropped the `\x1f` sentinel split/rejoin in favor of returning survivors as a `[]string` joined directly, and fixed the segment allocator to budget the real 3-col separator width (it previously under-counted, so a tight line could overflow).
- Replaced the `🗜️` compaction badge with plain `compacted ×N` so the status line stays aligned across terminals.