### PR TITLE
fix(status-bar): context-usage display fixes + cleanup

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -28,9 +28,6 @@ const (
 	// scrollback.
 	streamWrapReserve = 4
 
-	// autoCompactThreshold is the percentage of context usage that triggers auto-compact.
-	autoCompactThreshold = 95
-
 	// agentContentIndent is the extra indent for agent prompt/response content
 	// beyond toolResultExpandedStyle's PaddingLeft(4). Total indent = 4 + 4 = 8 chars.
 	agentContentIndent = "    "
@@ -199,32 +196,6 @@ func toolResultIcon(isError bool) string {
 		return "✗"
 	}
 	return "⎿"
-}
-
-// RenderTokenWarning returns a warning line when context usage is high.
-// Displayed above the input separator to alert the user.
-func RenderTokenWarning(inputTokens, inputLimit int, compactSuppressed bool) string {
-	if inputLimit == 0 || inputTokens == 0 || compactSuppressed {
-		return ""
-	}
-
-	percent := float64(inputTokens) / float64(inputLimit) * 100
-	if percent < 80 {
-		return ""
-	}
-
-	untilCompact := max(int(autoCompactThreshold-percent), 0)
-
-	if percent >= autoCompactThreshold {
-		style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
-		return "  " + style.Render(fmt.Sprintf("⚠ Context nearly full (%d%% used) — auto-compact imminent", int(percent)))
-	}
-	if percent >= 85 {
-		style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
-		return "  " + style.Render(fmt.Sprintf("⚡ %d%% until auto-compact", untilCompact))
-	}
-	style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	return "  " + style.Render(fmt.Sprintf("⚡ %d%% until auto-compact", untilCompact))
 }
 
 var (

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -37,7 +37,6 @@ const (
 type OperationModeParams struct {
 	Mode             setting.OperationMode
 	InputTokens      int
-	OutputTokens     int
 	InputLimit       int
 	ModelName        string
 	StatusMessage    string
@@ -527,7 +526,6 @@ type ToolCallsParams struct {
 	ToolCallsExpanded bool
 	ResultMap         map[string]ToolResultData
 	ParallelMode      bool
-	ParallelResults   map[int]bool
 	TaskProgress      map[int][]string
 	PendingCalls      []core.ToolCall
 	CurrentIdx        int
@@ -594,7 +592,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				}
 			}
 		} else {
-			icon := toolCallIcon(tc, params.PendingCalls, params.CurrentIdx, params.ParallelMode, params.ParallelResults, params.SpinnerView)
+			icon := toolCallIcon(tc, params.PendingCalls, params.CurrentIdx, params.ParallelMode, params.SpinnerView)
 			if _, hasResult := params.ResultMap[tc.ID]; hasResult {
 				icon = "●"
 			}
@@ -615,7 +613,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 			if params.ParallelMode {
 				limit = maxParallelAgentToolLines
 			}
-			sb.WriteString(renderAgentProgressInline(tc, params.PendingCalls, params.ParallelResults, params.TaskProgress, params.ToolCallsExpanded, limit, AgentStats{
+			sb.WriteString(renderAgentProgressInline(tc, params.PendingCalls, params.TaskProgress, params.ToolCallsExpanded, limit, AgentStats{
 				Model:        params.ModelName,
 				InputTokens:  params.InputTokens,
 				OutputTokens: params.OutputTokens,
@@ -626,7 +624,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 	return sb.String()
 }
 
-func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int, parallelMode bool, parallelResults map[int]bool, spinnerView string) string {
+func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int, parallelMode bool, spinnerView string) string {
 	idx := -1
 	for i, pending := range pendingCalls {
 		if pending.ID == tc.ID {
@@ -638,14 +636,9 @@ func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int
 		return "●"
 	}
 
-	if parallelMode {
-		if _, done := parallelResults[idx]; !done {
-			return spinnerView
-		}
-		return "●"
-	}
-
-	if idx == currentIdx {
+	// In parallel mode every in-flight call spins; sequentially, only the
+	// current call does.
+	if parallelMode || idx == currentIdx {
 		return spinnerView
 	}
 

--- a/internal/app/conv/progress.go
+++ b/internal/app/conv/progress.go
@@ -176,7 +176,7 @@ func renderAgentProgress(progress []string) string {
 	return sb.String()
 }
 
-func renderAgentProgressInline(tc core.ToolCall, pendingCalls []core.ToolCall, parallelResults map[int]bool, taskProgress map[int][]string, expanded bool, limit int, stats AgentStats) string {
+func renderAgentProgressInline(tc core.ToolCall, pendingCalls []core.ToolCall, taskProgress map[int][]string, expanded bool, limit int, stats AgentStats) string {
 	idx := -1
 	for i, pending := range pendingCalls {
 		if pending.ID == tc.ID {
@@ -186,13 +186,6 @@ func renderAgentProgressInline(tc core.ToolCall, pendingCalls []core.ToolCall, p
 	}
 	if idx == -1 {
 		return ""
-	}
-
-	// Check if completed in parallel results (not yet committed to messages)
-	if parallelResults != nil {
-		if _, done := parallelResults[idx]; done {
-			return ""
-		}
 	}
 
 	progress := taskProgress[idx]
@@ -336,10 +329,6 @@ func isAgentToolLine(line string) bool {
 type PendingToolSpinnerParams struct {
 	// InteractivePromptActive indicates if an interactive prompt is currently active.
 	InteractivePromptActive bool
-	// ParallelMode indicates parallel tool execution.
-	ParallelMode bool
-	// HasParallelTaskTools indicates if any parallel tools are Task tools.
-	HasParallelTaskTools bool
 	// BuildingTool is the tool name being built during streaming.
 	BuildingTool string
 	// PendingCalls are the pending tool calls.
@@ -367,11 +356,6 @@ func RenderPendingToolSpinner(params PendingToolSpinnerParams) string {
 		return ""
 	}
 
-	// Parallel mode with Task tools: progress rendered inline by RenderToolCalls
-	if params.ParallelMode && params.HasParallelTaskTools {
-		return ""
-	}
-
 	// Determine which tool is active
 	var toolName string
 	if params.BuildingTool != "" {
@@ -389,7 +373,7 @@ func RenderPendingToolSpinner(params PendingToolSpinnerParams) string {
 		}
 		var sb strings.Builder
 		// Show Agent label so it remains visible after the assistant message scrolls off.
-		if !params.SuppressAgentLabel && params.PendingCalls != nil && params.CurrentIdx < len(params.PendingCalls) {
+		if params.PendingCalls != nil && params.CurrentIdx < len(params.PendingCalls) {
 			tc := params.PendingCalls[params.CurrentIdx]
 			label := formatAgentLabel(tc.Input)
 			sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink), agentColorForInput(tc.Input, params.AgentColors)) + "\n")

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -64,7 +64,7 @@ func RenderToolResult(result toolresult.ToolResult, width int) string {
 	switch result.Metadata.Title {
 	case "Read":
 		if len(result.Lines) > 0 {
-			sb.WriteString(renderLines(result.Lines, true))
+			sb.WriteString(renderLines(result.Lines))
 		} else if result.Output != "" {
 			sb.WriteString(result.Output)
 		}
@@ -203,7 +203,7 @@ func capBoxWidth(width int) int {
 	return maxWidth
 }
 
-func renderLines(lines []toolresult.ContentLine, showLineNo bool) string {
+func renderLines(lines []toolresult.ContentLine) string {
 	if len(lines) == 0 {
 		return ""
 	}
@@ -227,14 +227,13 @@ func renderLines(lines []toolresult.ContentLine, showLineNo bool) string {
 			sb.WriteString(truncatedStyle.Render(line.Text))
 			sb.WriteString("\n")
 		default:
-			if showLineNo && line.LineNo > 0 {
+			if line.LineNo > 0 {
 				lineNoStr := fmt.Sprintf("%*d", lineNoWidth, line.LineNo)
 				sb.WriteString(lineNumberStyle.Render(lineNoStr))
-				sb.WriteString(lineNumberStyle.Render("│"))
-			} else if showLineNo {
+			} else {
 				sb.WriteString(strings.Repeat(" ", lineNoWidth))
-				sb.WriteString(lineNumberStyle.Render("│"))
 			}
+			sb.WriteString(lineNumberStyle.Render("│"))
 
 			var content string
 			switch line.Type {

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -39,7 +39,7 @@ type env struct {
 	// new turn and then accumulated after each infer in that turn.
 	TurnInputTokens  int
 	TurnOutputTokens int
-	turnUsageActive bool
+	turnUsageActive  bool
 	// ConversationCost is the session-cumulative spend shown in the status
 	// bar. It survives ResetContextDisplay (per-compaction) so compaction
 	// doesn't erase prior spend; only ResetTokens (/clear, /new) zeroes it.

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -28,6 +28,9 @@ type env struct {
 	// InputTokens / OutputTokens track the latest infer call only.
 	// They back the bottom-right context display, so they reflect the most
 	// recent prompt/output size rather than a turn or session aggregate.
+	// InputTokens is the FULL prompt size (fresh + cached tokens) so the
+	// context readout matches window occupancy even when prompt caching is
+	// active — see InferResponse.TotalInputTokens.
 	InputTokens  int
 	OutputTokens int
 	// TurnInputTokens / TurnOutputTokens track the current agent turn.

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -36,7 +36,10 @@ type env struct {
 	// new turn and then accumulated after each infer in that turn.
 	TurnInputTokens  int
 	TurnOutputTokens int
-	turnUsageActive  bool
+	turnUsageActive bool
+	// ConversationCost is the session-cumulative spend shown in the status
+	// bar. It survives ResetContextDisplay (per-compaction) so compaction
+	// doesn't erase prior spend; only ResetTokens (/clear, /new) zeroes it.
 	ConversationCost llm.Money
 	ThinkingEffort   string
 	// Compressions counts auto + manual compacts this session. Survives
@@ -238,14 +241,23 @@ func (m *env) SessionMode() string {
 	}
 }
 
+// ResetContextDisplay zeroes the bottom-right context-window readout (latest
+// input/output tokens). Called per-compaction: the live context shrinks to the
+// summary, so the bar/label restart from empty until the next infer. The
+// cumulative ConversationCost is deliberately NOT reset here — compaction does
+// not refund spend, so the session cost must survive it (see ResetTokens for
+// the full reset on /clear, /new).
 func (m *env) ResetContextDisplay() {
 	m.InputTokens = 0
 	m.OutputTokens = 0
-	m.ConversationCost = llm.Money{}
 }
 
+// ResetTokens clears all token/cost accounting for a fresh session (/clear,
+// /new). Unlike ResetContextDisplay this also zeroes the session-cumulative
+// ConversationCost and the compaction counter.
 func (m *env) ResetTokens() {
 	m.ResetContextDisplay()
+	m.ConversationCost = llm.Money{}
 	m.TurnInputTokens = 0
 	m.TurnOutputTokens = 0
 	m.turnUsageActive = false

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -1,6 +1,10 @@
 package app
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/llm"
+)
 
 func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
 	e := &env{Compressions: 3, InputTokens: 100, OutputTokens: 50}
@@ -13,6 +17,18 @@ func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
 	}
 }
 
+// ResetContextDisplay runs on every (auto-)compaction; the session-cumulative
+// cost must survive it, otherwise a long session's displayed spend resets to
+// zero each time the context is compacted.
+func TestResetContextDisplay_PreservesConversationCost(t *testing.T) {
+	cost := llm.Money{Amount: 1.25, Currency: llm.CurrencyUSD}
+	e := &env{InputTokens: 100, OutputTokens: 50, ConversationCost: cost}
+	e.ResetContextDisplay()
+	if e.ConversationCost != cost {
+		t.Errorf("ConversationCost = %v, want %v (must survive ResetContextDisplay)", e.ConversationCost, cost)
+	}
+}
+
 func TestResetTokens_ZeroesCompressions(t *testing.T) {
 	e := &env{Compressions: 5, TurnInputTokens: 80, TurnOutputTokens: 40}
 	e.ResetTokens()
@@ -21,6 +37,14 @@ func TestResetTokens_ZeroesCompressions(t *testing.T) {
 	}
 	if e.TurnInputTokens != 0 || e.TurnOutputTokens != 0 {
 		t.Errorf("turn tokens not zeroed: %d/%d", e.TurnInputTokens, e.TurnOutputTokens)
+	}
+}
+
+func TestResetTokens_ZeroesConversationCost(t *testing.T) {
+	e := &env{ConversationCost: llm.Money{Amount: 2.50, Currency: llm.CurrencyUSD}}
+	e.ResetTokens()
+	if !e.ConversationCost.IsZero() {
+		t.Errorf("ConversationCost = %v, want zero after ResetTokens", e.ConversationCost)
 	}
 }
 

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -3,7 +3,6 @@ package kit
 import (
 	"fmt"
 
-	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 )
 
@@ -23,24 +22,6 @@ func FormatTokenCount(count int) string {
 	default:
 		return fmt.Sprintf("%d", count)
 	}
-}
-
-// ShouldAutoCompact returns true when context usage is high enough to trigger
-// automatic compaction.
-func ShouldAutoCompact(p llm.Provider, messageCount, inputTokens int, store *llm.Store, currentModel *llm.CurrentModelInfo) bool {
-	if p == nil || messageCount < 3 {
-		return false
-	}
-	return core.NeedsCompaction(inputTokens, GetEffectiveInputLimit(store, currentModel))
-}
-
-// GetContextUsagePercent returns what percentage of the context window is used.
-func GetContextUsagePercent(inputTokens int, store *llm.Store, currentModel *llm.CurrentModelInfo) float64 {
-	inputLimit := GetEffectiveInputLimit(store, currentModel)
-	if inputLimit == 0 || inputTokens == 0 {
-		return 0
-	}
-	return float64(inputTokens) / float64(inputLimit) * 100
 }
 
 // GetMaxTokens returns the effective output limit, falling back to defaultMaxTokens.

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -38,9 +38,14 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 	}
 
 	// Bottom-right context usage reflects the latest prompt/output, not a
-	// lifetime sum across the whole session.
-	m.env.InputTokens = resp.InputTokens
+	// lifetime sum across the whole session. Use the full prompt size
+	// (incl. the cached system prompt) so the ctx readout matches real
+	// context-window occupancy rather than just the uncached delta.
+	m.env.InputTokens = resp.TotalInputTokens()
 	m.env.OutputTokens = resp.OutputTokens
+	// Turn totals accumulate per infer step. Keep the raw (uncached) input
+	// here: each step re-reads the same cached prompt, so summing the cached
+	// portion across steps would multi-count it.
 	m.env.TurnInputTokens += resp.InputTokens
 	m.env.TurnOutputTokens += resp.OutputTokens
 

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -32,6 +32,28 @@ func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
 	}
 }
 
+// The ctx readout must count the cached system prompt (reported separately by
+// Anthropic) so it reflects real window occupancy; the per-turn totals stay raw
+// so the cached prompt isn't re-counted on every infer step.
+func TestOnTokenUsageCountsCachedPromptInContext(t *testing.T) {
+	m := &model{}
+	m.OnTurnBegin()
+
+	m.OnTokenUsage(&core.InferResponse{
+		InputTokens:              500,
+		OutputTokens:             80,
+		CacheReadInputTokens:     140000,
+		CacheCreationInputTokens: 1000,
+	})
+
+	if want := 141500; m.env.InputTokens != want {
+		t.Fatalf("context InputTokens = %d, want %d (fresh + cache read + cache creation)", m.env.InputTokens, want)
+	}
+	if m.env.TurnInputTokens != 500 {
+		t.Fatalf("TurnInputTokens = %d, want 500 (raw, excludes cached prompt)", m.env.TurnInputTokens)
+	}
+}
+
 func TestResumeCommandForSessionRequiresPersistedTranscript(t *testing.T) {
 	transcriptPath := filepath.Join(t.TempDir(), "session.jsonl")
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -242,7 +242,6 @@ func (m model) renderModeStatus() string {
 	return conv.RenderModeStatus(conv.OperationModeParams{
 		Mode:             m.env.OperationMode,
 		InputTokens:      m.env.InputTokens,
-		OutputTokens:     m.env.OutputTokens,
 		InputLimit:       kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),
 		ModelName:        modelName,
 		StatusMessage:    m.userInput.Provider.StatusMessage,

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -35,6 +35,15 @@ type InferResponse struct {
 	CacheReadInputTokens     int
 }
 
+// TotalInputTokens is the full prompt size the model processed: fresh input
+// plus the cached portion (e.g. Anthropic reports the cache-marked system
+// prompt under CacheRead/CacheCreation, not InputTokens). This is the figure
+// that reflects context-window occupancy; InputTokens alone undercounts it
+// whenever prompt caching is active.
+func (r InferResponse) TotalInputTokens() int {
+	return r.InputTokens + r.CacheCreationInputTokens + r.CacheReadInputTokens
+}
+
 // Chunk is one piece of a streaming LLM response.
 type Chunk struct {
 	Text     string // incremental text


### PR DESCRIPTION
Audit of the status-bar displays (model, ctx label/bar, compressions badge, cost) and their update paths. Two correctness fixes plus cleanup.

- **Cost reset on compaction (bug):** `ResetContextDisplay` runs on every (auto-)compaction and was also zeroing `ConversationCost`, so the status-bar cost dropped to $0 each compaction and only ever reflected spend since the last one. Per-compaction now resets only the input/output token readout; the cumulative-cost reset moves to `ResetTokens` (/clear, /new).
- **Cached system prompt missing from context usage (bug):** the ctx readout used `resp.InputTokens`, which on Anthropic excludes the cache-marked system prompt (reported under CacheRead/CacheCreation), so the bar/label undercounted window occupancy while prompt caching was active. Added `InferResponse.TotalInputTokens` (fresh + cache read + cache creation) and feed it to the context display. Per-turn ↑ totals stay raw so the cached prompt isn't re-counted on each infer step; cost accounting is unchanged (still uses the per-category breakdown).
- **Dead code (cleanup):** removed `RenderTokenWarning` (superseded by the inline "compact at 95%" hint), `ShouldAutoCompact`, `GetContextUsagePercent`, and unused render params/constants — the agent compacts via `core.NeedsCompaction` directly.

Regression tests added for both fixes.