### PR TITLE
fix(provider): enable Ctrl+V paste to API key input

### DIFF
--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -16,6 +16,21 @@ import (
 	"github.com/genai-io/san/internal/secret"
 )
 
+// HandlePaste inserts bracketed-paste content into the API key input when it's active.
+func (s *ProviderSelector) HandlePaste(content string) tea.Cmd {
+	if !s.apiKeyActive {
+		return nil
+	}
+	content = strings.NewReplacer("\r", "", "\n", "").Replace(content)
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	s.apiKeyInput.SetValue(content)
+	s.apiKeyInput.CursorEnd()
+	return nil
+}
+
 func (s *ProviderSelector) handleAPIKeyInput(key tea.KeyMsg) tea.Cmd {
 	switch key.String() {
 	case "enter":


### PR DESCRIPTION
## Summary
- Fix Ctrl+V paste not working in the provider API key input field
- The `ProviderSelector` was missing the `pasteHandler` interface, causing bracketed-paste events to be silently dropped by the paste routing logic in `update.go`
- Added `HandlePaste` method to `ProviderSelector` that inserts pasted content into the API key text input when active

## Test plan
- [x] Code compiles successfully
- [ ] Manually verify Ctrl+V paste works in the provider API key input

🤖 Generated with [Claude Code](https://claude.com/claude-code)