### PR TITLE
refactor(messages): unify tool-result representation across layers

### DIFF
--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -259,24 +259,7 @@ func (m ConversationModel) ConvertToProviderFrom(startIdx int) []core.Message {
 		if msg.Role == core.RoleNotice {
 			continue
 		}
-
-		providerMsg := core.Message{
-			ID:                msg.ID,
-			Role:              msg.Role,
-			Content:           msg.Content,
-			DisplayContent:    msg.DisplayContent,
-			Images:            msg.Images,
-			ToolCalls:         msg.ToolCalls,
-			Thinking:          msg.Thinking,
-			ThinkingSignature: msg.ThinkingSignature,
-		}
-
-		if msg.ToolResult != nil {
-			tr := *msg.ToolResult
-			providerMsg.ToolResult = &tr
-		}
-
-		providerMsgs = append(providerMsgs, providerMsg)
+		providerMsgs = append(providerMsgs, msg.ToMessage())
 	}
 	return providerMsgs
 }

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -4,7 +4,6 @@ package conv
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -260,7 +259,6 @@ var (
 				Background(kit.CurrentTheme.Primary).
 				Bold(true)
 )
-var inlineImageTokenPattern = regexp.MustCompile(`\[Image #\d+\]`)
 
 // RenderUserMessage renders a user message with prompt and optional images.
 func RenderUserMessage(content, displayContent string, images []core.Image, mdRenderer *MDRenderer, width int) string {
@@ -270,7 +268,7 @@ func RenderUserMessage(content, displayContent string, images []core.Image, mdRe
 		displayContent = content
 	}
 
-	if len(images) > 0 && inlineImageTokenPattern.MatchString(displayContent) {
+	if len(images) > 0 && core.InlineImageTokenRe.MatchString(displayContent) {
 		sb.WriteString(lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			prompt,
@@ -298,7 +296,7 @@ func RenderUserMessage(content, displayContent string, images []core.Image, mdRe
 }
 
 func styleInlineImageTokens(content string) string {
-	return inlineImageTokenPattern.ReplaceAllStringFunc(content, func(token string) string {
+	return core.InlineImageTokenRe.ReplaceAllStringFunc(content, func(token string) string {
 		return PendingImageStyle.Render(token)
 	})
 }
@@ -506,7 +504,7 @@ func getToolExecutionDesc(toolName string) string {
 		return "Fetching web content..."
 	case "WebSearch":
 		return "Searching the web..."
-	case "AskUserQuestion":
+	case tool.ToolAskUserQuestion:
 		return "Preparing question..."
 	case tool.ToolSkill:
 		return "Loading skill..."

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -15,7 +15,7 @@ func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
 	m := &model{}
 	m.OnTurnBegin()
 
-	m.OnTokenUsage(&core.InferResponse{InputTokens: 1200, OutputTokens: 80})
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 1200, OutputTokens: 80}})
 	if m.env.InputTokens != 1200 || m.env.OutputTokens != 80 {
 		t.Fatalf("first token update = in:%d out:%d, want in:1200 out:80", m.env.InputTokens, m.env.OutputTokens)
 	}
@@ -23,7 +23,7 @@ func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
 		t.Fatalf("first turn totals = in:%d out:%d, want in:1200 out:80", m.env.TurnInputTokens, m.env.TurnOutputTokens)
 	}
 
-	m.OnTokenUsage(&core.InferResponse{InputTokens: 400, OutputTokens: 25})
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 400, OutputTokens: 25}})
 	if m.env.InputTokens != 400 || m.env.OutputTokens != 25 {
 		t.Fatalf("latest token update = in:%d out:%d, want in:400 out:25", m.env.InputTokens, m.env.OutputTokens)
 	}
@@ -39,12 +39,12 @@ func TestOnTokenUsageCountsCachedPromptInContext(t *testing.T) {
 	m := &model{}
 	m.OnTurnBegin()
 
-	m.OnTokenUsage(&core.InferResponse{
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
 		InputTokens:              500,
 		OutputTokens:             80,
 		CacheReadInputTokens:     140000,
 		CacheCreationInputTokens: 1000,
-	})
+	}})
 
 	if want := 141500; m.env.InputTokens != want {
 		t.Fatalf("context InputTokens = %d, want %d (fresh + cache read + cache creation)", m.env.InputTokens, want)
@@ -74,7 +74,7 @@ func TestOnTokenUsageClearsCompactedStatusOnNextInfer(t *testing.T) {
 	m := &model{}
 	m.userInput.Provider.StatusMessage = "compacted"
 
-	m.OnTokenUsage(&core.InferResponse{InputTokens: 400, OutputTokens: 25})
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 400, OutputTokens: 25}})
 
 	if m.userInput.Provider.StatusMessage != "" {
 		t.Fatalf("StatusMessage = %q, want compacted badge cleared on next infer", m.userInput.Provider.StatusMessage)

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -803,8 +803,10 @@ func (a *agent) snapshot() []Message {
 }
 
 func (a *agent) appendResult(tc ToolCall, content string, isError bool) {
+	// A tool result rides on a RoleUser message — its content lives on
+	// ToolResult.Content, not on Message.Content. See the Role doc.
 	a.append(Message{
-		Role: RoleTool, Content: content,
+		Role:       RoleUser,
 		ToolResult: &ToolResult{ToolCallID: tc.ID, ToolName: tc.Name, Content: content, IsError: isError},
 	})
 }

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -22,17 +22,26 @@ type InferRequest struct {
 	Tools    []ToolSchema // available tools
 }
 
+// Usage is the token accounting for one LLM call. Field names use the project's
+// domain vocabulary; the json tags preserve each provider's wire format (e.g.
+// Anthropic's cache_creation_input_tokens). It lives in core, the foundation
+// layer, so both core.InferResponse and the llm provider response share one
+// definition (llm.Usage aliases this).
+type Usage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+}
+
 // InferResponse is the final aggregated response from one LLM call.
 type InferResponse struct {
-	Content                  string     // text output
-	Thinking                 string     // chain-of-thought (extended thinking)
-	ThinkingSignature        string     // signature for replaying thinking blocks
-	ToolCalls                []ToolCall // tool execution requests
-	StopReason               StopReason
-	InputTokens              int
-	OutputTokens             int
-	CacheCreationInputTokens int
-	CacheReadInputTokens     int
+	Content           string     // text output
+	Thinking          string     // chain-of-thought (extended thinking)
+	ThinkingSignature string     // signature for replaying thinking blocks
+	ToolCalls         []ToolCall // tool execution requests
+	StopReason        StopReason
+	Usage
 }
 
 // TotalInputTokens is the full prompt size the model processed: fresh input

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -21,12 +21,16 @@ func NewMessageID() string {
 }
 
 // Role identifies who produced a message in the conversation.
+//
+// A tool result is a RoleUser message carrying a non-nil ToolResult — that is
+// the wire shape every provider expects (tool_result blocks ride inside a
+// user turn), so it is also how we hold them in history. Distinguish a
+// tool-result turn from a user-typed turn by ToolResult != nil, never by Role.
 type Role string
 
 const (
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
-	RoleTool      Role = "tool_result" // a tool-result turn; "tool_result" is its wire value
 	RoleNotice    Role = "notice"
 )
 
@@ -101,6 +105,46 @@ func (m *ChatMessage) ResetStreamCommit() {
 	m.ContentCommittedLen = 0
 	m.ThinkingCommittedLen = 0
 	m.BulletEmitted = false
+}
+
+// ToMessage returns the wire/agent Message underlying this view-model, dropping
+// the transient display state. The ToolResult is deep-copied so a provider can
+// consume the result without aliasing conv's copy. This is the single Chat →
+// Message field mapping — every converter (provider, transcript) routes through
+// it so a new field can never be forgotten in one path.
+func (c ChatMessage) ToMessage() Message {
+	msg := Message{
+		ID:                c.ID,
+		Role:              c.Role,
+		Content:           c.Content,
+		DisplayContent:    c.DisplayContent,
+		Images:            c.Images,
+		Thinking:          c.Thinking,
+		ThinkingSignature: c.ThinkingSignature,
+		ToolCalls:         c.ToolCalls,
+	}
+	if c.ToolResult != nil {
+		tr := *c.ToolResult
+		msg.ToolResult = &tr
+	}
+	return msg
+}
+
+// ToChat wraps a wire/agent Message as a fresh view-model with no display state
+// set (expand toggles collapsed, streaming offsets zero). The single Message →
+// Chat field mapping, mirroring ToMessage.
+func (m Message) ToChat() ChatMessage {
+	return ChatMessage{
+		ID:                m.ID,
+		Role:              m.Role,
+		Content:           m.Content,
+		DisplayContent:    m.DisplayContent,
+		Images:            m.Images,
+		Thinking:          m.Thinking,
+		ThinkingSignature: m.ThinkingSignature,
+		ToolCalls:         m.ToolCalls,
+		ToolResult:        m.ToolResult,
+	}
 }
 
 // Image represents an image attachment.
@@ -289,16 +333,6 @@ func buildConversationText(msgs []Message, stripReminders bool) string {
 	return sb.String()
 }
 
-// LastAssistantContent returns the most recent non-empty assistant content from provider messages.
-func LastAssistantContent(msgs []Message) string {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == RoleAssistant && msgs[i].Content != "" {
-			return msgs[i].Content
-		}
-	}
-	return ""
-}
-
 // LastAssistantChatContent returns the most recent non-empty assistant content from chat messages.
 func LastAssistantChatContent(msgs []ChatMessage) string {
 	for i := len(msgs) - 1; i >= 0; i-- {
@@ -334,12 +368,16 @@ type ContentPart struct {
 	Image *Image
 }
 
-var inlineImageTokenRe = regexp.MustCompile(`\[Image #(\d+)\]`)
+// InlineImageTokenRe matches the "[Image #N]" placeholder tokens that stand in
+// for image attachments in a message's DisplayContent. It is the single
+// definition of that wire token format, shared by the display and persistence
+// layers so they parse it identically.
+var InlineImageTokenRe = regexp.MustCompile(`\[Image #(\d+)\]`)
 
 // InterleavedContentParts parses [Image #N] tokens from display content and returns
 // interleaved text and image parts.
 func InterleavedContentParts(msg Message) []ContentPart {
-	if len(msg.Images) == 0 || msg.DisplayContent == "" || !inlineImageTokenRe.MatchString(msg.DisplayContent) {
+	if len(msg.Images) == 0 || msg.DisplayContent == "" || !InlineImageTokenRe.MatchString(msg.DisplayContent) {
 		return nil
 	}
 
@@ -347,7 +385,7 @@ func InterleavedContentParts(msg Message) []ContentPart {
 
 	var parts []ContentPart
 	last := 0
-	matches := inlineImageTokenRe.FindAllStringSubmatchIndex(msg.DisplayContent, -1)
+	matches := InlineImageTokenRe.FindAllStringSubmatchIndex(msg.DisplayContent, -1)
 	if len(matches) > 0 {
 		parts = make([]ContentPart, 0, len(matches)*2+1)
 	}
@@ -384,7 +422,7 @@ func InterleavedContentParts(msg Message) []ContentPart {
 // from token ID to sequential index (0-based). imageCount caps the number of entries.
 func BuildImageIDMap(displayContent string, imageCount int) map[int]int {
 	m := make(map[int]int, imageCount)
-	matches := inlineImageTokenRe.FindAllStringSubmatch(displayContent, -1)
+	matches := InlineImageTokenRe.FindAllStringSubmatch(displayContent, -1)
 	idx := 0
 	for _, match := range matches {
 		id, err := strconv.Atoi(match[1])

--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -8,7 +8,7 @@ import "context"
 // The agent loop handles interception (via hooks) and result recording (via Message).
 //
 // Execute returns plain text. The agent loop wraps it into a ToolResult and
-// appends it to the conversation as a Message with Role=RoleTool.
+// appends it to the conversation as a RoleUser Message carrying that ToolResult.
 type Tool interface {
 	Name() string
 	Description() string

--- a/internal/llm/anthropic/client_test.go
+++ b/internal/llm/anthropic/client_test.go
@@ -200,7 +200,7 @@ func TestSanitizeToolResults_AllPaired(t *testing.T) {
 		{Role: core.RoleAssistant, Content: "let me check", ToolCalls: []core.ToolCall{
 			{ID: "tc_1", Name: "Read"},
 		}},
-		{Role: core.RoleTool, ToolResult: &core.ToolResult{ToolCallID: "tc_1", Content: "file content"}},
+		{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "tc_1", Content: "file content"}},
 		{Role: core.RoleAssistant, Content: "done"},
 	}
 

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -327,18 +327,26 @@ func outputLimitFromProvider(p Provider, model string) int {
 	return 0
 }
 
-// toProviderMessages converts core messages for provider consumption.
-// Key semantic change: RoleTool messages become RoleUser with ToolResult.
+// toProviderMessages converts core messages for provider consumption, keeping
+// only the fields a provider needs. A tool result is a RoleUser message with a
+// non-nil ToolResult; user-typed text is a RoleUser message without one.
 func toProviderMessages(msgs []core.Message) []core.Message {
 	out := make([]core.Message, 0, len(msgs))
 	for _, m := range msgs {
 		switch m.Role {
 		case core.RoleUser:
-			out = append(out, core.Message{
-				Role:    core.RoleUser,
-				Content: m.Content,
-				Images:  m.Images,
-			})
+			if m.ToolResult != nil {
+				out = append(out, core.Message{
+					Role:       core.RoleUser,
+					ToolResult: m.ToolResult,
+				})
+			} else {
+				out = append(out, core.Message{
+					Role:    core.RoleUser,
+					Content: m.Content,
+					Images:  m.Images,
+				})
+			}
 		case core.RoleAssistant:
 			out = append(out, core.Message{
 				Role:              core.RoleAssistant,
@@ -347,13 +355,6 @@ func toProviderMessages(msgs []core.Message) []core.Message {
 				ThinkingSignature: m.ThinkingSignature,
 				ToolCalls:         m.ToolCalls,
 			})
-		case core.RoleTool:
-			if m.ToolResult != nil {
-				out = append(out, core.Message{
-					Role:       core.RoleUser,
-					ToolResult: m.ToolResult,
-				})
-			}
 		}
 	}
 	return out
@@ -365,14 +366,11 @@ func toInferResponse(r *CompletionResponse) *core.InferResponse {
 		return nil
 	}
 	return &core.InferResponse{
-		Content:                  r.Content,
-		Thinking:                 r.Thinking,
-		ThinkingSignature:        r.ThinkingSignature,
-		ToolCalls:                r.ToolCalls,
-		StopReason:               core.StopReason(r.StopReason),
-		InputTokens:              r.Usage.InputTokens,
-		OutputTokens:             r.Usage.OutputTokens,
-		CacheCreationInputTokens: r.Usage.CacheCreationInputTokens,
-		CacheReadInputTokens:     r.Usage.CacheReadInputTokens,
+		Content:           r.Content,
+		Thinking:          r.Thinking,
+		ThinkingSignature: r.ThinkingSignature,
+		ToolCalls:         r.ToolCalls,
+		StopReason:        core.StopReason(r.StopReason),
+		Usage:             r.Usage,
 	}
 }

--- a/internal/llm/openaicompat/convert_test.go
+++ b/internal/llm/openaicompat/convert_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/genai-io/san/internal/core"
 )
 
-func TestConvertMessagesConvertsRoleToolResultToToolMessage(t *testing.T) {
+func TestConvertMessagesConvertsToolResultToToolMessage(t *testing.T) {
 	msgs := []core.Message{
 		{
 			Role: core.RoleAssistant,
@@ -21,7 +21,7 @@ func TestConvertMessagesConvertsRoleToolResultToToolMessage(t *testing.T) {
 			}},
 		},
 		{
-			Role: core.RoleTool,
+			Role: core.RoleUser,
 			ToolResult: &core.ToolResult{
 				ToolCallID: "call_1",
 				ToolName:   "Read",

--- a/internal/llm/sanitize_test.go
+++ b/internal/llm/sanitize_test.go
@@ -39,7 +39,7 @@ func TestSanitizeToolMessagesKeepsOnlyImmediatelyAnsweredToolCalls(t *testing.T)
 			},
 		},
 		{
-			Role:       core.RoleTool,
+			Role:       core.RoleUser,
 			ToolResult: &core.ToolResult{ToolCallID: "call_1", ToolName: "Read", Content: "ok"},
 		},
 		{Role: core.RoleUser, Content: "next"},

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -196,15 +196,9 @@ func (r CompletionResponse) LogToolCallSummary(escaper func(string) string) stri
 	return sb.String()
 }
 
-// Usage contains token usage information. Field names use the project's domain
-// vocabulary (InputTokens/CacheCreationInputTokens/…); the json tags preserve each
-// provider's wire format (e.g. Anthropic's cache_creation_input_tokens).
-type Usage struct {
-	InputTokens              int `json:"input_tokens"`
-	OutputTokens             int `json:"output_tokens"`
-	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
-	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
-}
+// Usage is an alias for core.Usage — token accounting is defined once in the
+// foundation layer so the provider response and core.InferResponse share it.
+type Usage = core.Usage
 
 // --- Streaming Types ---
 

--- a/internal/selflearn/fork.go
+++ b/internal/selflearn/fork.go
@@ -73,10 +73,9 @@ func RunReview(ctx context.Context, fc ForkConfig, kinds ReviewKind, snapshot []
 		OnEvent:   fc.OnEvent,
 	})
 
-	// Trim trailing user/tool messages so the review prompt isn't the second
-	// consecutive user-role turn on the wire — most providers reject that as
-	// a role-order violation. RoleTool is included because tool_result is
-	// encoded as a user-role message by every provider we target.
+	// Trim trailing user-role messages (user-typed turns and tool results, both
+	// RoleUser) so the review prompt isn't the second consecutive user-role turn
+	// on the wire — most providers reject that as a role-order violation.
 	ag.SetMessages(trimTrailingPendingMessages(snapshot))
 	ag.Append(ctx, core.UserMessage(prompt, nil))
 	res, err := ag.ThinkAct(ctx)
@@ -89,16 +88,14 @@ func RunReview(ctx context.Context, fc ForkConfig, kinds ReviewKind, snapshot []
 	return res.Content, nil
 }
 
-// trimTrailingPendingMessages drops trailing messages that the provider
-// would render as user-role on the wire (RoleUser and RoleTool — provider
-// adapters encode tool_result as a user-role message). The fork's review
+// trimTrailingPendingMessages drops trailing user-role messages — both
+// user-typed turns and tool results are RoleUser on the wire. The fork's review
 // prompt is then safe to append as the next user turn. Does not mutate the
 // caller's slice (it's shared with the main agent).
 func trimTrailingPendingMessages(msgs []core.Message) []core.Message {
 	end := len(msgs)
 	for end > 0 {
-		role := msgs[end-1].Role
-		if role != core.RoleUser && role != core.RoleTool {
+		if msgs[end-1].Role != core.RoleUser {
 			break
 		}
 		end--

--- a/internal/selflearn/fork_test.go
+++ b/internal/selflearn/fork_test.go
@@ -42,12 +42,12 @@ func (s *scriptedLLM) Infer(_ context.Context, req core.InferRequest) (<-chan co
 
 // TestTrimTrailingPendingMessages guards against the "messages must
 // alternate" provider rejection: when the snapshot ends with a tool_result
-// (RoleTool) or any trailing user turn, the fork's own UserMessage(prompt)
-// would put two consecutive user-role messages on the wire.
+// (a RoleUser message with a ToolResult) or any trailing user turn, the fork's
+// own UserMessage(prompt) would put two consecutive user-role messages on the wire.
 func TestTrimTrailingPendingMessages(t *testing.T) {
 	asst := core.Message{Role: core.RoleAssistant, Content: "ok"}
 	usr := core.Message{Role: core.RoleUser, Content: "ask"}
-	toolResult := core.Message{Role: core.RoleTool, Content: "tool result"}
+	toolResult := core.Message{Role: core.RoleUser, ToolResult: &core.ToolResult{Content: "tool result"}}
 
 	// Snapshot ends with two trailing user messages → both dropped.
 	in := []core.Message{asst, usr, usr}

--- a/internal/session/convert.go
+++ b/internal/session/convert.go
@@ -4,97 +4,26 @@ import (
 	"github.com/genai-io/san/internal/core"
 )
 
+// ConvertToEntries turns the conversation view-model into transcript entries.
+// Notices are display-only and dropped; the rest convert to wire Messages and
+// share messagesToEntries with every other writer, so the stable IDs stamped at
+// conv.Append time survive (the append-only save path dedupes by them).
 func ConvertToEntries(messages []core.ChatMessage) []Entry {
-	entries := make([]Entry, 0, len(messages))
-	var prevUUID string
-
+	msgs := make([]core.Message, 0, len(messages))
 	for _, msg := range messages {
 		if msg.Role == core.RoleNotice {
 			continue
 		}
-
-		// Prefer the stable ID stamped at conv.Append time; fall back to a
-		// fresh one only for messages that arrive without an ID (legacy
-		// paths, tool results assembled inline, etc.). Stable IDs are
-		// required for the append-only save path's dedup to work.
-		uuid := msg.ID
-		if uuid == "" {
-			uuid = generateShortID()
-		}
-
-		var parentUuid *string
-		if prevUUID != "" {
-			s := prevUUID
-			parentUuid = &s
-		}
-
-		entry := Entry{
-			UUID:       uuid,
-			ParentUuid: parentUuid,
-			Version:    GetAppVersion(),
-		}
-
-		switch msg.Role {
-		case core.RoleUser:
-			entry.Type = EntryUser
-			if msg.ToolResult != nil {
-				entry.Message = &EntryMessage{
-					Role:    "user",
-					Content: toolResultToBlocks(msg.ToolResult),
-				}
-			} else {
-				entry.Message = &EntryMessage{
-					Role:    "user",
-					Content: userContentToBlocks(msg.Content, msg.DisplayContent, msg.Images),
-				}
-			}
-
-		case core.RoleAssistant:
-			entry.Type = EntryAssistant
-			entry.Message = &EntryMessage{
-				Role:    "assistant",
-				Content: assistantContentToBlocks(msg.Content, msg.Thinking, msg.ThinkingSignature, msg.ToolCalls),
-			}
-
-		case core.RoleTool:
-			entry.Type = EntryUser
-			if msg.ToolResult != nil {
-				entry.Message = &EntryMessage{
-					Role:    "user",
-					Content: toolResultToBlocks(msg.ToolResult),
-				}
-			}
-
-		default:
-			continue
-		}
-
-		entries = append(entries, entry)
-		prevUUID = uuid
+		msgs = append(msgs, msg.ToMessage())
 	}
-
-	return entries
+	return messagesToEntries(msgs)
 }
 
 func ConvertFromEntries(entries []Entry) []core.ChatMessage {
 	coreMsgs := EntriesToMessages(entries)
 	messages := make([]core.ChatMessage, 0, len(coreMsgs))
-
 	for _, m := range coreMsgs {
-		chatMsg := core.ChatMessage{
-			Role:              m.Role,
-			Content:           m.Content,
-			DisplayContent:    m.DisplayContent,
-			Images:            m.Images,
-			Thinking:          m.Thinking,
-			ThinkingSignature: m.ThinkingSignature,
-			ToolCalls:         m.ToolCalls,
-		}
-		if m.ToolResult != nil {
-			chatMsg.ToolResult = m.ToolResult
-		}
-		messages = append(messages, chatMsg)
+		messages = append(messages, m.ToChat())
 	}
-
 	return messages
 }

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -10,8 +9,6 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 )
-
-var inlineImageTokenPattern = regexp.MustCompile(`\[Image #(\d+)\]`)
 
 // systemReminderRe matches a complete <system-reminder>...</system-reminder>
 // block including tags. Reminders are appended verbatim by reminder.AttachToContent
@@ -68,7 +65,13 @@ func messagesToEntries(msgs []core.Message) []Entry {
 	var prevUUID string
 
 	for _, msg := range msgs {
-		uuid := generateShortID()
+		// Prefer the stable ID stamped upstream (conv.Append, agent.append) so
+		// the append-only save path can dedupe by it; fall back only for
+		// messages assembled without one.
+		uuid := msg.ID
+		if uuid == "" {
+			uuid = core.NewMessageID()
+		}
 
 		var parentUuid *string
 		if prevUUID != "" {
@@ -145,7 +148,7 @@ func EntriesToMessages(entries []Entry) []core.Message {
 }
 
 func userContentToBlocks(content, displayContent string, images []core.Image) []ContentBlock {
-	if len(images) > 0 && displayContent != "" && inlineImageTokenPattern.MatchString(displayContent) {
+	if len(images) > 0 && displayContent != "" && core.InlineImageTokenRe.MatchString(displayContent) {
 		return interleavedUserContentToBlocks(content, displayContent, images)
 	}
 
@@ -166,7 +169,7 @@ func interleavedUserContentToBlocks(content, displayContent string, images []cor
 
 	idToIdx := core.BuildImageIDMap(displayContent, len(images))
 
-	matches := inlineImageTokenPattern.FindAllStringSubmatchIndex(displayContent, -1)
+	matches := core.InlineImageTokenRe.FindAllStringSubmatchIndex(displayContent, -1)
 	for _, match := range matches {
 		start, end := match[0], match[1]
 		idStart, idEnd := match[2], match[3]
@@ -314,10 +317,4 @@ func extractUserText(entry Entry) (string, bool) {
 		return text, true
 	}
 	return "", false
-}
-
-func generateShortID() string {
-	var b [8]byte
-	_, _ = rand.Read(b[:])
-	return fmt.Sprintf("%x", b[:])
 }

--- a/internal/session/projection.go
+++ b/internal/session/projection.go
@@ -3,6 +3,7 @@ package session
 import (
 	"time"
 
+	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/session/transcript"
 )
 
@@ -16,7 +17,7 @@ func EntriesToNodes(entries []Entry, sessionID, defaultCwd string, createdAt tim
 			continue
 		}
 		if entry.UUID == "" {
-			entry.UUID = generateShortID()
+			entry.UUID = core.NewMessageID()
 		}
 		parentID := derefString(entry.ParentUuid)
 		if parentID == "" && prevID != "" {

--- a/internal/session/recorder.go
+++ b/internal/session/recorder.go
@@ -233,15 +233,11 @@ func (r *Recorder) onAppend(ev core.Event) {
 // through the same converters Store.Save uses, so the dedupe key (message
 // ID) maps to byte-identical content from either writer.
 //
-// RoleTool maps to "user" because that's the wire shape sent to the LLM
-// (Anthropic models tool results as a user message containing tool_result
-// blocks). Without this case the agent's tool-result message gets an ID
-// stamped and joins a.messages → its ID lands in inference.requested's
-// messageIDs, but no message.appended is ever written, so replay can't
-// resolve the ID and the integrity check flags it as missing.
+// A tool result is a RoleUser message with a non-nil ToolResult; it serializes
+// as a "user" turn carrying tool_result blocks, the wire shape the LLM expects.
 func messageToTranscript(msg core.Message) ([]transcript.ContentBlock, string) {
 	switch msg.Role {
-	case core.RoleUser, core.RoleTool:
+	case core.RoleUser:
 		if msg.ToolResult != nil {
 			return toolResultToBlocks(msg.ToolResult), "user"
 		}

--- a/internal/session/recorder_order_test.go
+++ b/internal/session/recorder_order_test.go
@@ -44,7 +44,7 @@ func TestRecorderWritesMessageBeforeInference(t *testing.T) {
 
 	// Assistant reply appends after PostInfer.
 	rec.OnAgentEvent(core.Event{Type: core.PostInfer, Source: "main", Data: &core.InferResponse{
-		StopReason: core.StopEndTurn, InputTokens: 10, OutputTokens: 5,
+		StopReason: core.StopEndTurn, Usage: core.Usage{InputTokens: 10, OutputTokens: 5},
 	}})
 	assistantMsg := core.Message{ID: "m2", Role: core.RoleAssistant, Content: "hi"}
 	rec.OnAgentEvent(core.Event{Type: core.OnAppend, Source: "main", Data: assistantMsg})

--- a/internal/session/recorder_test.go
+++ b/internal/session/recorder_test.go
@@ -38,7 +38,7 @@ func TestRecorderWritesRequestedAndRespondedPerTurn(t *testing.T) {
 		SystemDigest: "sha256:sys", ToolsDigest: "sha256:tools", MessageIDs: []string{"m1", "m2"},
 	}})
 	rec.OnAgentEvent(core.Event{Type: core.PostInfer, Source: "main", Data: &core.InferResponse{
-		StopReason: core.StopEndTurn, InputTokens: 42, OutputTokens: 8, CacheReadInputTokens: 10,
+		StopReason: core.StopEndTurn, Usage: core.Usage{InputTokens: 42, OutputTokens: 8, CacheReadInputTokens: 10},
 	}})
 
 	tx, err := fs.Load(context.Background(), "sess-1")

--- a/internal/tool/skill/skill.go
+++ b/internal/tool/skill/skill.go
@@ -215,7 +215,9 @@ func alreadyInlined(ctx context.Context, fullName string) bool {
 	tag := "<command-name>" + fullName + "</command-name>"
 	for i := len(msgs) - 1; i >= 0; i-- {
 		m := msgs[i]
-		if m.Role != core.RoleUser {
+		// Want the most recent user-typed turn; a tool result is also RoleUser
+		// (it carries a ToolResult), so skip those to avoid stopping on one.
+		if m.Role != core.RoleUser || m.ToolResult != nil {
 			continue
 		}
 		return strings.HasPrefix(strings.TrimSpace(m.Content), tag)

--- a/tests/integration/testutil/core_helpers.go
+++ b/tests/integration/testutil/core_helpers.go
@@ -56,12 +56,11 @@ func (f *FakeLLM) Infer(_ context.Context, _ core.InferRequest) (<-chan core.Chu
 		ch <- core.Chunk{
 			Done: true,
 			Response: &core.InferResponse{
-				Content:      resp.Content,
-				Thinking:     resp.Thinking,
-				ToolCalls:    legacyToCoreCalls(resp.ToolCalls),
-				StopReason:   core.StopReason(resp.StopReason),
-				InputTokens:  resp.Usage.InputTokens,
-				OutputTokens: resp.Usage.OutputTokens,
+				Content:    resp.Content,
+				Thinking:   resp.Thinking,
+				ToolCalls:  legacyToCoreCalls(resp.ToolCalls),
+				StopReason: core.StopReason(resp.StopReason),
+				Usage:      core.Usage{InputTokens: resp.Usage.InputTokens, OutputTokens: resp.Usage.OutputTokens},
 			},
 		}
 	}()


### PR DESCRIPTION
Tool results were modeled two ways — `RoleTool`+`ToolResult` in the agent core, `RoleUser`+`ToolResult` in conv and on the wire — so every consumer had to handle both, and two forgot. This collapses them to one representation (a tool result is a `RoleUser` message with a non-nil `ToolResult`, the wire shape the load path already produced) and dedupes the layer.

- Fixes two silent drops the dual representation caused: `messagesToEntries` omitted tool results from saved **subagent transcripts**, and `BuildConversationText` omitted them from the **compaction size estimate and summary**. Removing `RoleTool` lets the `RoleUser`+`ToolResult` branches those consumers already had cover both.
- `ChatMessage.ToMessage` / `Message.ToChat` are now the single field mappings; provider and transcript converters route through them, and `ConvertToEntries` delegates to `messagesToEntries` (one entry writer instead of two near-duplicates).
- `session.generateShortID` → `core.NewMessageID`; the three `[Image #N]` regexes → one `core.InlineImageTokenRe`; `Usage` sinks into `core` (`llm.Usage` aliases it) and `InferResponse` embeds it, dropping the per-field flatten.
- Drops the redundant `Content` copy on tool-result messages, deletes dead `LastAssistantContent`, uses the `tool.ToolAskUserQuestion` constant.

Net −57 lines. `go build`, `go vet`, and the full test suite pass.