### PR TITLE
fix(llm): split cached prompt tokens from fresh input for OpenAI-compatible providers

### DIFF
--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -89,7 +89,19 @@ func StreamChatCompletions(ctx context.Context, cfg ChatStreamConfig) <-chan llm
 				}
 			}
 
-			state.UpdateUsage(int(chunk.Usage.PromptTokens), int(chunk.Usage.CompletionTokens))
+			// OpenAI-compatible APIs report prompt_tokens as the FULL prompt
+			// (cached tokens included) and expose the cached slice under
+			// prompt_tokens_details.cached_tokens. Split it so InputTokens holds
+			// only the fresh tokens and the cached portion lands in
+			// CacheReadInputTokens — the Anthropic convention the rest of the app
+			// assumes. Without the split, summing InputTokens across a turn's
+			// infer steps multi-counts the re-read cache (inflating the ↑ usage
+			// readout) and cost bills the cached prefix at the full input rate
+			// instead of the cache-read rate. TotalInputTokens stays the full
+			// prompt, so the ctx occupancy readout is unchanged.
+			cachedTokens := int(chunk.Usage.PromptTokensDetails.CachedTokens)
+			state.UpdateUsage(int(chunk.Usage.PromptTokens)-cachedTokens, int(chunk.Usage.CompletionTokens))
+			state.UpdateCacheUsage(0, cachedTokens)
 		}
 
 		if err := stream.Err(); err != nil {

--- a/internal/llm/openaicompat/stream_test.go
+++ b/internal/llm/openaicompat/stream_test.go
@@ -40,6 +40,24 @@ func (t *streamCaptureTransport) RoundTrip(req *http.Request) (*http.Response, e
 	}, nil
 }
 
+type cachedUsageTransport struct{}
+
+func (t *cachedUsageTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	streamBody := strings.Join([]string{
+		`data: {"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}`,
+		`data: {"id":"1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":20,"total_tokens":1020,"prompt_tokens_details":{"cached_tokens":900}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n\n")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(streamBody)),
+	}, nil
+}
+
 type authErrorTransport struct{}
 
 func (t *authErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -97,6 +115,47 @@ func TestStreamChatCompletionsRequestsAndReadsUsage(t *testing.T) {
 	}
 	if done.Usage.InputTokens != 11 || done.Usage.OutputTokens != 7 {
 		t.Fatalf("usage = in:%d out:%d, want in:11 out:7", done.Usage.InputTokens, done.Usage.OutputTokens)
+	}
+}
+
+func TestStreamChatCompletionsSplitsCachedPromptTokens(t *testing.T) {
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithHTTPClient(&http.Client{Transport: &cachedUsageTransport{}}),
+	)
+
+	ch := StreamChatCompletions(context.Background(), ChatStreamConfig{
+		Client:           client,
+		ProviderName:     "deepseek",
+		ConvertAssistant: DefaultAssistantMessage,
+		Options: llm.CompletionOptions{
+			Model:    "deepseek-v4-pro",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		},
+	})
+
+	var done *llm.CompletionResponse
+	for chunk := range ch {
+		if chunk.Type == llm.ChunkTypeDone {
+			done = chunk.Response
+		}
+	}
+
+	if done == nil {
+		t.Fatal("missing done chunk")
+	}
+	// prompt_tokens (1000) is the full prompt; the cached slice (900) moves to
+	// CacheRead so InputTokens holds only the fresh tokens (Anthropic
+	// convention). Their sum still equals the full prompt for the ctx readout.
+	if done.Usage.InputTokens != 100 {
+		t.Fatalf("InputTokens = %d, want 100 (1000 prompt - 900 cached)", done.Usage.InputTokens)
+	}
+	if done.Usage.CacheReadInputTokens != 900 {
+		t.Fatalf("CacheReadInputTokens = %d, want 900", done.Usage.CacheReadInputTokens)
+	}
+	if done.Usage.OutputTokens != 20 {
+		t.Fatalf("OutputTokens = %d, want 20", done.Usage.OutputTokens)
 	}
 }
 


### PR DESCRIPTION
OpenAI-compatible providers (DeepSeek et al.) report `prompt_tokens` as the full prompt, with the cached slice under `prompt_tokens_details.cached_tokens`. The adapter assigned the whole figure to `InputTokens` and left the cache fields empty, so summing `InputTokens` across a turn's infer steps multi-counted the re-read cache (inflating the per-turn `↑` usage readout) and cost billed the cached prefix at the full input rate instead of the cache-read rate.

Split the cached portion into `CacheReadInputTokens` so `InputTokens` holds only fresh tokens, matching the Anthropic convention the rest of the app assumes. `TotalInputTokens` (the `ctx` occupancy readout) is unchanged; providers that don't report cached tokens are unaffected.