### PR TITLE
chore: bump version to 1.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.20.5] - 2026-06-16
+
+### Fixed
+- Split cached prompt tokens from fresh input for OpenAI-compatible providers, so per-turn input usage no longer multi-counts the re-read cache and cost applies the cache-read rate ([@yanmxa](https://github.com/yanmxa) in [#234](https://github.com/genai-io/san/pull/234))
+
 ## [v1.20.4] - 2026-06-16
 
 ### Fixed

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.4"
+var version = "1.20.5"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {


### PR DESCRIPTION
Patch release bundling the OpenAI-compatible cache-token accounting fix from #234.

- Bump code version to 1.20.5
- Add CHANGELOG section for v1.20.5