### PR TITLE
feat(llm): add Agnes-AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ San is a terminal-native **unified runtime for specialized agents** — coding a
 
 ### Open architecture
 
-- **LLM providers** — Anthropic, OpenAI, Google, DeepSeek, Moonshot, Alibaba, MiniMax, Z.ai (GLM), SenseNova, Mimo, Volcengine (Ark), Ollama (local); swap via `/model`.
+- **LLM providers** — Anthropic, OpenAI, Google, DeepSeek, Moonshot, Alibaba, MiniMax, Z.ai (GLM), SenseNova, Mimo, Volcengine (Ark), Ollama (local), Agnes-AI; swap via `/model`.
 - **Search backends** — Exa, Tavily, Brave, Serper; swap via `/search`.
 - **Personas** — Markdown identities scoped to user or project; swap via `/identity` ([details](docs/concepts/harness-channels.md#identity-custom-personas)).
 - **Skills & extensions** — Claude Code skills, plugins, and MCP servers run unmodified; sandboxed subagents; lifecycle hooks (shell, LLM, agent, HTTP); auto-loaded project memory.
@@ -162,6 +162,7 @@ Config lives in `~/.san/` (user) and `<project>/.san/` (project, overrides user)
 | **Mimo** | `MIMO_API_KEY` |
 | **Volcengine** (Ark) | `VOLCENGINE_API_KEY` |
 | **Ollama** (local) | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`) |
+| **Agnes-AI** | `AGNESAI_API_KEY` |
 | **Exa** search | _none_ (default) |
 | **Tavily** search | `TAVILY_API_KEY` |
 | **Brave** search | `BRAVE_API_KEY` |

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/genai-io/san/internal/setting"
 
 	// Import providers for registration
+	_ "github.com/genai-io/san/internal/llm/agnesai"
 	_ "github.com/genai-io/san/internal/llm/alibaba"
 	_ "github.com/genai-io/san/internal/llm/anthropic"
 	_ "github.com/genai-io/san/internal/llm/bigmodel"

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,6 +46,7 @@ for Anthropic). Supported providers and the env var each one reads:
 | DeepSeek | `DEEPSEEK_API_KEY` |
 | Ollama (local) | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`) |
 | SenseNova | `SENSENOVA_API_KEY` |
+| Agnes-AI | `AGNESAI_API_KEY` |
 
 You can also set them in `.env` or `~/.san/providers.json`.
 

--- a/docs/packages/2-feature/llm.md
+++ b/docs/packages/2-feature/llm.md
@@ -7,7 +7,7 @@ layer: feature
 
 Provider registry, model store, and active-connection handle for every LLM backend
 (Anthropic, OpenAI, Google, Moonshot, Alibaba, MiniMax, Z.ai/GLM, DeepSeek,
-Ollama, SenseNova, Volcengine Ark, plus the generic openai-compat shim). Provider implementations live in
+Ollama, SenseNova, Volcengine Ark, Agnes-AI, plus the generic openai-compat shim). Provider implementations live in
 `internal/llm/<name>/` subpackages.
 
 ## Purpose
@@ -61,7 +61,7 @@ func ResetDefaultConn()       // test-only
   `~/.san/providers.json`; tracks current model.
 - `stream/` — provider-side helpers for SSE parsing.
 - Provider subpackages: `anthropic/`, `openai/`, `google/`, `moonshot/`,
-  `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `sensenova/`, `volcengine/`, `openaicompat/`.
+  `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `sensenova/`, `volcengine/`, `agnesai/`, `openaicompat/`.
 
 ## Lifecycle
 

--- a/internal/llm/agnesai/apikey.go
+++ b/internal/llm/agnesai/apikey.go
@@ -36,6 +36,6 @@ func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
 }
 
 func init() {
-	llm.RegisterProviderDisplay(llm.AgnesAI, llm.ProviderDisplay{Name: "Agnes-AI", Order: 120})
+	llm.RegisterProviderDisplay(llm.AgnesAI, llm.ProviderDisplay{Name: "Agnes-AI", Order: 130})
 	llm.Register(APIKeyMeta, NewAPIKeyClient)
 }

--- a/internal/llm/agnesai/apikey.go
+++ b/internal/llm/agnesai/apikey.go
@@ -1,0 +1,41 @@
+package agnesai
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+// APIKeyMeta is the metadata for Agnes-AI via API Key.
+var APIKeyMeta = llm.Meta{
+	Provider:    llm.AgnesAI,
+	AuthMethod:  llm.AuthAPIKey,
+	EnvVars:     []string{"AGNESAI_API_KEY"},
+	DisplayName: "Direct API",
+}
+
+// NewAPIKeyClient creates a new Agnes-AI client using API Key authentication.
+// Agnes-AI publishes an OpenAI-compatible endpoint, so we use the OpenAI SDK
+// with a custom base URL.
+func NewAPIKeyClient(ctx context.Context) (llm.Provider, error) {
+	baseURL := secret.Resolve("AGNESAI_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://apihub.agnes-ai.com/v1"
+	}
+
+	client := openai.NewClient(
+		option.WithAPIKey(secret.Resolve("AGNESAI_API_KEY")),
+		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
+	)
+	return NewClient(client, "agnesai:api_key"), nil
+}
+
+func init() {
+	llm.RegisterProviderDisplay(llm.AgnesAI, llm.ProviderDisplay{Name: "Agnes-AI", Order: 120})
+	llm.Register(APIKeyMeta, NewAPIKeyClient)
+}

--- a/internal/llm/agnesai/catalog.go
+++ b/internal/llm/agnesai/catalog.go
@@ -1,0 +1,19 @@
+package agnesai
+
+import "strings"
+
+// staticInputLimit returns the known context window for an Agnes-AI model ID.
+// Used as a fallback when the /v1/models endpoint omits context_length.
+//
+//	agnes-2.0-flash: 256K tokens (per Agnes-AI's agnes-20-flash256 docs)
+//	agnes-1.5-flash: 128K tokens (conservative default; not separately documented)
+func staticInputLimit(modelID string) int {
+	m := strings.ToLower(strings.TrimSpace(modelID))
+	switch {
+	case strings.HasPrefix(m, "agnes-2.0"):
+		return 256_000
+	case strings.HasPrefix(m, "agnes-1.5"):
+		return 128_000
+	}
+	return 0
+}

--- a/internal/llm/agnesai/client.go
+++ b/internal/llm/agnesai/client.go
@@ -1,0 +1,84 @@
+// Package agnesai implements the Provider interface for Agnes-AI
+// (https://agnes-ai.com). Agnes-AI exposes an OpenAI-compatible endpoint,
+// so we reuse the openai-go SDK with a custom base URL and the shared
+// openaicompat helpers.
+package agnesai
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/openaicompat"
+)
+
+// Client implements the Provider interface for Agnes-AI using the OpenAI SDK.
+type Client struct {
+	client openai.Client
+	name   string
+}
+
+// NewClient creates a new Agnes-AI client with the given OpenAI SDK client.
+func NewClient(client openai.Client, name string) *Client {
+	return &Client{
+		client: client,
+		name:   name,
+	}
+}
+
+// Name returns the provider name.
+func (c *Client) Name() string { return c.name }
+
+// Stream sends a completion request and returns a channel of streaming chunks.
+func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	return openaicompat.StreamChatCompletions(ctx, openaicompat.ChatStreamConfig{
+		Client:           c.client,
+		ProviderName:     c.name,
+		Options:          opts,
+		ConvertAssistant: openaicompat.DefaultAssistantMessage,
+	})
+}
+
+// ListModels returns the available models for Agnes-AI using the /models API.
+// The list is fully dynamic — no hardcoded catalog or fallback. If the API
+// errors, the error propagates so users see the real failure rather than a
+// stale offline list.
+func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	page, err := c.client.Models.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	models := make([]llm.ModelInfo, 0, len(page.Data))
+	for _, m := range page.Data {
+		id := m.ID
+		info := llm.ModelInfo{ID: id, Name: id, DisplayName: id}
+		if raw := m.RawJSON(); raw != "" {
+			var extra struct {
+				ContextLength int `json:"context_length"`
+			}
+			if err := json.Unmarshal([]byte(raw), &extra); err == nil && extra.ContextLength > 0 {
+				info.InputTokenLimit = extra.ContextLength
+			}
+		}
+		if info.InputTokenLimit == 0 {
+			info.InputTokenLimit = staticInputLimit(id)
+		}
+		models = append(models, info)
+	}
+
+	if len(models) == 0 {
+		return nil, fmt.Errorf("agnes-ai returned no models")
+	}
+
+	slices.SortFunc(models, func(a, b llm.ModelInfo) int { return cmp.Compare(a.ID, b.ID) })
+	return models, nil
+}
+
+// Ensure Client implements Provider.
+var _ llm.Provider = (*Client)(nil)

--- a/internal/llm/agnesai/client.go
+++ b/internal/llm/agnesai/client.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/openai/openai-go/v3"
 
@@ -44,10 +45,12 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 	})
 }
 
-// ListModels returns the available models for Agnes-AI using the /models API.
-// The list is fully dynamic — no hardcoded catalog or fallback. If the API
-// errors, the error propagates so users see the real failure rather than a
-// stale offline list.
+// ListModels returns the available chat-capable models for Agnes-AI using
+// the /models API. Non-chat modalities (image, video) live on separate
+// endpoints and are filtered out so they can't be selected for chat.
+// The list is otherwise fully dynamic — no hardcoded catalog or fallback.
+// If the API errors, the error propagates so users see the real failure
+// rather than a stale offline list.
 func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	page, err := c.client.Models.List(ctx)
 	if err != nil {
@@ -57,6 +60,9 @@ func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	models := make([]llm.ModelInfo, 0, len(page.Data))
 	for _, m := range page.Data {
 		id := m.ID
+		if !isChatModel(id) {
+			continue
+		}
 		info := llm.ModelInfo{ID: id, Name: id, DisplayName: id}
 		if raw := m.RawJSON(); raw != "" {
 			var extra struct {
@@ -78,6 +84,16 @@ func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 
 	slices.SortFunc(models, func(a, b llm.ModelInfo) int { return cmp.Compare(a.ID, b.ID) })
 	return models, nil
+}
+
+// isChatModel reports whether the given model ID is a chat-completions
+// model. Agnes-AI's /v1/models endpoint returns every modality in one
+// list (agnes-*-flash text, agnes-image-*, agnes-video-*); only the text
+// models work with /v1/chat/completions, so the others must be filtered
+// out before being surfaced in the model picker.
+func isChatModel(modelID string) bool {
+	m := strings.ToLower(modelID)
+	return !strings.HasPrefix(m, "agnes-image") && !strings.HasPrefix(m, "agnes-video")
 }
 
 // Ensure Client implements Provider.

--- a/internal/llm/agnesai/client_test.go
+++ b/internal/llm/agnesai/client_test.go
@@ -76,6 +76,63 @@ func TestAgnesAIListModelsReturnsAPIResults(t *testing.T) {
 	}
 }
 
+func TestAgnesAIListModelsFiltersOutNonChatModalities(t *testing.T) {
+	// Agnes-AI's /v1/models endpoint returns text, image, and video models
+	// in one list. Image/video models can't be used with /v1/chat/completions
+	// so they must be filtered out before reaching the model picker.
+	transport := &modelsTransport{
+		body: `{
+			"object": "list",
+			"data": [
+				{"id": "agnes-1.5-flash", "object": "model"},
+				{"id": "agnes-2.0-flash", "object": "model"},
+				{"id": "agnes-image-2.0-flash", "object": "model"},
+				{"id": "agnes-image-2.1-flash", "object": "model"},
+				{"id": "agnes-video-v2.0", "object": "model"}
+			]
+		}`,
+	}
+	c := newTestClient(transport)
+
+	models, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	want := []string{"agnes-1.5-flash", "agnes-2.0-flash"}
+	if len(ids) != len(want) {
+		t.Fatalf("expected %d chat models %v, got %d: %v", len(want), want, len(ids), ids)
+	}
+	for i, id := range ids {
+		if id != want[i] {
+			t.Errorf("models[%d] = %q, want %q", i, id, want[i])
+		}
+	}
+}
+
+func TestIsChatModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"agnes-1.5-flash", true},
+		{"agnes-2.0-flash", true},
+		{"AGNES-IMAGE-2.0-FLASH", false}, // case-insensitive
+		{"agnes-image-2.0-flash", false},
+		{"agnes-image-2.1-flash", false},
+		{"agnes-video-v2.0", false},
+		{"agnes-video-v3.0", false},
+	}
+	for _, c := range cases {
+		if got := isChatModel(c.model); got != c.want {
+			t.Errorf("isChatModel(%q) = %v, want %v", c.model, got, c.want)
+		}
+	}
+}
+
 func TestAgnesAIListModelsFallsBackToStaticLimit(t *testing.T) {
 	// If the API omits context_length, the static fallback in catalog.go
 	// should kick in so the status bar can still render.

--- a/internal/llm/agnesai/client_test.go
+++ b/internal/llm/agnesai/client_test.go
@@ -1,0 +1,139 @@
+package agnesai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type modelsTransport struct {
+	body string
+}
+
+func (t *modelsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Request:    req,
+	}, nil
+}
+
+type modelsErrorTransport struct{}
+
+func (t *modelsErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Status:     "401 Unauthorized",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"message":"Invalid Authentication","type":"invalid_authentication_error"}`)),
+		Request:    req,
+	}, nil
+}
+
+func newTestClient(transport http.RoundTripper) *Client {
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL("https://apihub.agnes-ai.com/v1"),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	return NewClient(client, "agnesai:test")
+}
+
+func TestAgnesAIListModelsReturnsAPIResults(t *testing.T) {
+	transport := &modelsTransport{
+		body: `{
+			"object": "list",
+			"data": [
+				{"id": "agnes-2.0-flash", "object": "model", "context_length": 262144},
+				{"id": "agnes-1.5-flash", "object": "model", "context_length": 131072}
+			]
+		}`,
+	}
+	c := newTestClient(transport)
+
+	models, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "agnes-1.5-flash" {
+		t.Fatalf("expected first model agnes-1.5-flash (sorted), got %s", models[0].ID)
+	}
+	if models[1].ID != "agnes-2.0-flash" {
+		t.Fatalf("expected second model agnes-2.0-flash, got %s", models[1].ID)
+	}
+	if models[1].InputTokenLimit != 262144 {
+		t.Fatalf("expected agnes-2.0-flash input limit 262144, got %d", models[1].InputTokenLimit)
+	}
+}
+
+func TestAgnesAIListModelsFallsBackToStaticLimit(t *testing.T) {
+	// If the API omits context_length, the static fallback in catalog.go
+	// should kick in so the status bar can still render.
+	transport := &modelsTransport{
+		body: `{
+			"object": "list",
+			"data": [
+				{"id": "agnes-1.5-flash", "object": "model"},
+				{"id": "agnes-2.0-flash", "object": "model"}
+			]
+		}`,
+	}
+	c := newTestClient(transport)
+
+	models, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	byID := map[string]int{}
+	for _, m := range models {
+		byID[m.ID] = m.InputTokenLimit
+	}
+	if byID["agnes-1.5-flash"] != 128_000 {
+		t.Errorf("agnes-1.5-flash limit = %d, want 128000 (static fallback)", byID["agnes-1.5-flash"])
+	}
+	if byID["agnes-2.0-flash"] != 256_000 {
+		t.Errorf("agnes-2.0-flash limit = %d, want 256000 (static fallback)", byID["agnes-2.0-flash"])
+	}
+}
+
+func TestAgnesAIListModelsReturnsErrorOnAPIFailure(t *testing.T) {
+	c := newTestClient(&modelsErrorTransport{})
+
+	models, err := c.ListModels(context.Background())
+	if err == nil {
+		t.Fatal("expected ListModels to fail")
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected no fallback models, got %d", len(models))
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+}
+
+func TestStaticInputLimit(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"agnes-2.0-flash", 256_000},
+		{"agnes-1.5-flash", 128_000},
+		{"AGNES-2.0-FLASH", 256_000}, // case-insensitive
+		{"unknown-model", 0},
+	}
+	for _, c := range cases {
+		if got := staticInputLimit(c.model); got != c.want {
+			t.Errorf("staticInputLimit(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -12,6 +12,7 @@ import (
 type Name string
 
 const (
+	AgnesAI    Name = "agnesai"
 	Anthropic  Name = "anthropic"
 	OpenAI     Name = "openai"
 	Google     Name = "google"

--- a/internal/setting/client_options.go
+++ b/internal/setting/client_options.go
@@ -11,6 +11,8 @@ func DefaultModel(providerName string, authMethod string) string {
 		return "claude-sonnet-4-5@20250929"
 	}
 	switch providerName {
+	case "agnesai":
+		return "agnes-2.0-flash"
 	case "anthropic":
 		return "claude-sonnet-4-20250514"
 	case "openai":


### PR DESCRIPTION
## Summary

Register [Agnes-AI](https://agnes-ai.com) as a built-in LLM provider using its OpenAI-compatible endpoint at `https://apihub.agnes-ai.com/v1`.

- New package `internal/llm/agnesai` (apikey/client/catalog/tests) — follows the established `internal/llm/bigmodel` pattern: openai-go SDK with custom base URL, shared `openaicompat` helpers.
- `ListModels` hits `/v1/models` dynamically; static context-window fallback when the API omits `context_length` (256K for `agnes-2.0-flash` per its docs, 128K for `agnes-1.5-flash`).
- Default model: `agnes-2.0-flash`.
- Env vars: `AGNESAI_API_KEY` (required), `AGNESAI_BASE_URL` (optional override).
- Registration sites: `internal/llm/types.go` (Name constant), `cmd/san/main.go` (blank import), `internal/setting/client_options.go` (DefaultModel switch case).

## Out of scope (intentional)

- **No cost estimator** — Agnes-AI's pricing isn't documented publicly. Other providers (`ollama`, `alibaba`) also skip `RegisterCostEstimator`. Can be added later when pricing is published.
- **No thinking/reasoning or image-input support** — Agnes-AI's docs don't expose either toggle. If they add one, the optional `ThinkingEffortProvider` / `ImageSupportProvider` interfaces can be implemented without breaking the registry.

## Test plan

- [x] `gofmt -s -w` clean on changed paths
- [x] `go build ./...` succeeds
- [x] `go test ./internal/llm/agnesai/...` — 4 new tests pass (dynamic listing, static fallback, error propagation, catalog function)
- [x] `go test ./internal/llm/... ./internal/setting/...` — no regressions across 18 packages
- [x] `go vet` clean
- [x] Manual smoke test with `AGNESAI_API_KEY=sk-... san`, select "Agnes-AI" in provider picker, verify `agnes-2.0-flash` appears in model list and can run a completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)