### PR TITLE
feat(subagent): route subagent model overrides across providers

### DIFF
--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -50,7 +50,7 @@ Be terse. No code suggestions — that is the parent agent's job.
 | `allowed-tools` | no | Restrict the subagent's tool set. Default = same as parent. |
 | `permission-mode` | no | One of `default`, `acceptEdits`, `bypassPermissions`, `plan`. Default = parent. |
 | `isolation` | no | `none` (default) or `worktree` — see below. |
-| `model` | no | Pin a specific model for this subagent; otherwise inherits parent's model. |
+| `model` | no | Pin a model for this subagent; otherwise inherits the parent's. An alias (`opus`/`sonnet`/`haiku`) or bare id uses the parent's provider; `vendor/model` (e.g. `deepseek/deepseek-v4`) routes to another **connected** provider. |
 
 ## Permission Mode
 

--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -52,6 +52,34 @@ Be terse. No code suggestions — that is the parent agent's job.
 | `isolation` | no | `none` (default) or `worktree` — see below. |
 | `model` | no | Pin a model for this subagent; otherwise inherits the parent's. An alias (`opus`/`sonnet`/`haiku`) or bare id uses the parent's provider; `vendor/model` (e.g. `deepseek/deepseek-v4`) routes to another **connected** provider. |
 
+## Cross-Provider Models
+
+The `model:` field lets each subagent run on the model that fits its role —
+using only frontmatter, with no router or extra config. A `vendor/model` value
+routes the agent to another **connected** provider:
+
+| Agent | `model:` | Why |
+|---|---|---|
+| `planner` | `anthropic/claude-opus-4-7` | strongest reasoning for decomposition |
+| `coder` | `deepseek/deepseek-v4` | cheap, fast bulk implementation |
+| `reviewer` | `anthropic/claude-sonnet-4-6` | independent review on a *different* model |
+
+`model:` accepts:
+
+- `inherit` (or empty) — the parent conversation's model.
+- an alias (`opus` / `sonnet` / `haiku`) or a bare id — served by the parent's
+  provider.
+- `vendor/model` (e.g. `deepseek/deepseek-v4`) — routed to another **connected**
+  provider.
+
+The `vendor` names the model family, not the serving platform: auth comes from
+how you connected that vendor, so Claude-on-Vertex is still `anthropic/…`. A
+role whose vendor isn't connected fails with a clear "provider not connected"
+error instead of silently falling back to the parent's model.
+
+No policy engine is needed: the foreground agent picks which agent to spawn from
+each `description` / `when-to-use`, so choosing the agent chooses the model.
+
 ## Permission Mode
 
 Subagents have no UI, so permission prompts cannot be shown. The mode

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -395,6 +395,7 @@ func (m *model) ReconfigureAgentTool() {
 	m.ensureMemoryContextLoaded()
 
 	executor := subagent.NewExecutor(m.env.LLMProvider, m.env.CWD, m.env.GetModelID(), m.services.Hook)
+	executor.SetResolver(llm.NewProviderPool(m.services.LLM.Store()))
 	if m.services.Session.GetStore() != nil && m.services.Session.ID() != "" {
 		executor.SetSessionStore(m.services.Session.GetStore(), m.services.Session.ID())
 	}

--- a/internal/app/run_agent.go
+++ b/internal/app/run_agent.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/tool"
@@ -65,6 +66,7 @@ func RunAgent(opts AgentRunOptions) error {
 	// same permission gate (deny_tools / bypass-immune / allow_tools / mode)
 	// as TUI-spawned subagents.
 	executor := subagent.NewExecutor(provider, cwd, modelID, nil)
+	executor.SetResolver(llm.NewProviderPool(llm.Default().Store()))
 	executor.SetContext(setting.IsGitRepo(cwd))
 
 	fmt.Printf("Agent: %s\n", opts.Type)

--- a/internal/llm/provider_pool.go
+++ b/internal/llm/provider_pool.go
@@ -1,0 +1,53 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// ProviderPool hands out a live Provider for a connected vendor, opening each
+// vendor's connection once and reusing it. A session that routes work across
+// vendors — say a planner on Anthropic and a coder on DeepSeek — shares one
+// pool so every subagent on the same vendor talks through the same client.
+type ProviderPool struct {
+	store *Store
+	mu    sync.Mutex
+	byKey map[string]Provider // makeProviderKey(vendor, authMethod)
+}
+
+// NewProviderPool returns a pool backed by the given connection store.
+func NewProviderPool(store *Store) *ProviderPool {
+	return &ProviderPool{store: store, byKey: make(map[string]Provider)}
+}
+
+// Resolve returns the provider for a connected vendor (e.g. "deepseek").
+//
+// The auth method comes from how the user connected that vendor, so a model
+// family served via Vertex or Bedrock resolves like a direct API key — the
+// "vendor/model" routing form names the vendor, never the serving platform.
+// Resolution fails when the vendor is not connected; it never falls back to a
+// different vendor.
+func (p *ProviderPool) Resolve(ctx context.Context, vendor Name) (Provider, error) {
+	if p == nil || p.store == nil {
+		return nil, fmt.Errorf("provider pool is not configured")
+	}
+
+	conn, ok := p.store.GetConnection(vendor)
+	if !ok {
+		return nil, fmt.Errorf("provider %q is not connected", vendor)
+	}
+	key := makeProviderKey(vendor, conn.AuthMethod)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.byKey[key]; ok {
+		return existing, nil
+	}
+	provider, err := GetProvider(ctx, vendor, conn.AuthMethod)
+	if err != nil {
+		return nil, err
+	}
+	p.byKey[key] = provider
+	return provider, nil
+}

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -200,6 +200,22 @@ func (r *Registry) ProvidersByOrder() []Name {
 	return result
 }
 
+// IsProvider reports whether name is a registered provider vendor. It is the
+// source of truth for telling a "vendor/model" routing ref apart from a bare
+// model id that merely contains a slash.
+func IsProvider(name Name) bool {
+	return globalRegistry.IsProvider(name)
+}
+
+// IsProvider reports whether name is a registered provider vendor.
+func (r *Registry) IsProvider(name Name) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, ok := r.providerDisplay[name]
+	return ok
+}
+
 // ProviderDisplayName returns the provider-level display name for a provider.
 func ProviderDisplayName(p Name) string {
 	return globalRegistry.ProviderDisplayName(p)

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -22,9 +22,18 @@ import (
 	"go.uber.org/zap"
 )
 
+// ProviderResolver turns a vendor name into a live provider so a subagent can
+// run on a different vendor than its parent. The app wires an *llm.ProviderCache;
+// a nil resolver disables cross-provider routing, in which case an explicit
+// "vendor/model" override errors instead of silently using the parent provider.
+type ProviderResolver interface {
+	Resolve(ctx context.Context, provider llm.Name) (llm.Provider, error)
+}
+
 // Executor runs agent LLM loops
 type Executor struct {
 	provider        llm.Provider
+	resolver        ProviderResolver // resolves "vendor/model" overrides; nil = same-provider only
 	cwd             string
 	parentModelID   string // Parent conversation's model ID (used when inheriting)
 	hooks           hook.Handler
@@ -44,6 +53,7 @@ type SubagentSessionStore interface {
 
 type runConfig struct {
 	config      *AgentConfig
+	provider    llm.Provider // provider this run talks to (parent's, or a routed vendor)
 	modelID     string
 	maxSteps    int
 	displayName string
@@ -67,6 +77,14 @@ func NewExecutor(llmProvider llm.Provider, cwd string, parentModelID string, hoo
 // instructions) is intentionally not propagated — see collectSubagentReminders.
 func (e *Executor) SetContext(isGit bool) {
 	e.isGit = isGit
+}
+
+// SetResolver enables cross-provider routing: a subagent whose model is an
+// explicit "vendor/model" override resolves through this resolver instead of
+// reusing the parent's provider. Without it such overrides error rather than
+// silently fall back to the parent.
+func (e *Executor) SetResolver(r ProviderResolver) {
+	e.resolver = r
 }
 
 // SetCapabilities provides skills and agents prompt sections so subagents
@@ -99,7 +117,7 @@ func (e *Executor) GetParentModelID() string {
 // Run executes an agent request and returns the result.
 // For background agents, this should be called in a goroutine.
 func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentResult, error) {
-	run, err := e.prepareRun(req)
+	run, err := e.prepareRun(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +129,7 @@ func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentRe
 
 	result, err := e.executePreparedRun(ctx, run)
 	if err != nil && shouldRetryWithParentModel(err, run.cfg.modelID, e.parentModelID) {
+		run.cfg.provider = e.provider
 		run.cfg.modelID = e.parentModelID
 		result, err = e.executePreparedRun(ctx, run)
 	}
@@ -197,7 +216,7 @@ func (e *Executor) prepareWorkspace(req tool.AgentExecRequest) (string, func(), 
 	return result.Path, cleanup, nil
 }
 
-func (e *Executor) prepareRunConfig(req tool.AgentExecRequest) (*runConfig, error) {
+func (e *Executor) prepareRunConfig(ctx context.Context, req tool.AgentExecRequest) (*runConfig, error) {
 	config, ok := defaultRegistry.Get(req.Agent)
 	if !ok {
 		return nil, fmt.Errorf("unknown agent type: %s", req.Agent)
@@ -215,9 +234,15 @@ func (e *Executor) prepareRunConfig(req tool.AgentExecRequest) (*runConfig, erro
 		maxSteps = defaultMaxSteps
 	}
 
+	provider, modelID, err := e.resolveModel(ctx, req.Model, config.Model)
+	if err != nil {
+		return nil, err
+	}
+
 	return &runConfig{
 		config:      config,
-		modelID:     e.resolveModelID(req.Model, config.Model),
+		provider:    provider,
+		modelID:     modelID,
 		maxSteps:    maxSteps,
 		displayName: displayName,
 		brief:       e.buildBrief(config, permMode),
@@ -256,7 +281,7 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	_, agentDirectoryGetter := e.capabilityPrompts(rc.config)
 
 	sys := system.Build(core.ScopeSubagent,
-		system.WithProvider(e.provider.Name()),
+		system.WithProvider(rc.provider.Name()),
 		system.WithGitGuidelines(e.isGit),
 		system.WithSubagentIdentity(rc.brief),
 		system.WithEnvironment(system.Environment{
@@ -300,7 +325,7 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	coreTools = tool.WithPermission(coreTools, permFn)
 
 	ag = core.NewAgent(core.Config{
-		LLM:       llm.NewClient(e.provider, rc.modelID, 0),
+		LLM:       llm.NewClient(rc.provider, rc.modelID, 0),
 		System:    sys,
 		Tools:     coreTools,
 		AgentType: rc.config.Name,
@@ -376,18 +401,47 @@ func (e *Executor) fireSubagentStop(req tool.AgentExecRequest, agentHookID, agen
 	})
 }
 
-// resolveModelID determines the model to use based on priority:
-// 1. Explicit request override
-// 2. Agent configuration
-// 3. Parent conversation model
-func (e *Executor) resolveModelID(requestModel string, configModel string) string {
-	if requestModel != "" {
-		return resolveModelAlias(requestModel)
+// resolveModel picks the provider and model id for a run, by priority:
+// 1. Explicit request override (req.Model)
+// 2. Agent configuration (config.Model)
+// 3. Parent conversation model ("inherit" or empty)
+//
+// An explicit "vendor/model" override routes to that vendor through the
+// resolver, erroring if the vendor is not connected. Every other form — an
+// alias, a bare model id, or "inherit" — stays on the parent's provider,
+// preserving prior behavior.
+func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel string) (llm.Provider, string, error) {
+	ref := requestModel
+	if ref == "" {
+		ref = configModel
 	}
-	if configModel != "" && configModel != "inherit" {
-		return resolveModelAlias(configModel)
+	if ref == "" || ref == "inherit" {
+		return e.provider, e.parentModelID, nil
 	}
-	return e.parentModelID
+	if vendor, modelID, ok := parseVendorModel(ref); ok {
+		if e.resolver == nil {
+			return nil, "", fmt.Errorf("model %q routes to provider %q, but cross-provider routing is unavailable", ref, vendor)
+		}
+		p, err := e.resolver.Resolve(ctx, vendor)
+		if err != nil {
+			return nil, "", fmt.Errorf("model %q: %w", ref, err)
+		}
+		return p, modelID, nil
+	}
+	return e.provider, resolveModelAlias(ref), nil
+}
+
+// parseVendorModel reads the explicit "vendor/model" form (e.g.
+// "deepseek/deepseek-v4"), the only way to route a subagent to another vendor.
+// Any ref containing a slash is treated as vendor-qualified — San model ids
+// never contain one — so a misspelled or unconnected vendor surfaces as a clear
+// resolver error rather than silently running on the parent provider.
+func parseVendorModel(ref string) (vendor llm.Name, model string, ok bool) {
+	slash := strings.IndexByte(ref, '/')
+	if slash <= 0 || slash >= len(ref)-1 {
+		return "", "", false
+	}
+	return llm.Name(ref[:slash]), ref[slash+1:], true
 }
 
 func shouldRetryWithParentModel(err error, modelID, parentModelID string) bool {

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ProviderResolver turns a vendor name into a live provider so a subagent can
-// run on a different vendor than its parent. The app wires an *llm.ProviderCache;
+// run on a different vendor than its parent. The app wires an *llm.ProviderPool;
 // a nil resolver disables cross-provider routing, in which case an explicit
 // "vendor/model" override errors instead of silently using the parent provider.
 type ProviderResolver interface {
@@ -433,15 +433,17 @@ func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel s
 
 // parseVendorModel reads the explicit "vendor/model" form (e.g.
 // "deepseek/deepseek-v4"), the only way to route a subagent to another vendor.
-// Any ref containing a slash is treated as vendor-qualified — San model ids
-// never contain one — so a misspelled or unconnected vendor surfaces as a clear
-// resolver error rather than silently running on the parent provider.
+// A ref is vendor-qualified only when the part before the first slash is a
+// registered provider name; a bare model id that merely contains a slash (e.g.
+// mimo's "xiaomi/mimo-v2-flash") is not, so it stays on the parent provider
+// instead of erroring. A known but unconnected vendor still surfaces as a clear
+// resolver error.
 func parseVendorModel(ref string) (vendor llm.Name, model string, ok bool) {
-	slash := strings.IndexByte(ref, '/')
-	if slash <= 0 || slash >= len(ref)-1 {
+	v, m, found := strings.Cut(ref, "/")
+	if !found || v == "" || m == "" || !llm.IsProvider(llm.Name(v)) {
 		return "", "", false
 	}
-	return llm.Name(ref[:slash]), ref[slash+1:], true
+	return llm.Name(v), m, true
 }
 
 func shouldRetryWithParentModel(err error, modelID, parentModelID string) bool {

--- a/internal/subagent/executor_run.go
+++ b/internal/subagent/executor_run.go
@@ -48,7 +48,7 @@ func (r *preparedRun) recordUsage(resp *core.InferResponse) {
 	}
 }
 
-func (e *Executor) prepareRun(req tool.AgentExecRequest) (*preparedRun, error) {
+func (e *Executor) prepareRun(ctx context.Context, req tool.AgentExecRequest) (*preparedRun, error) {
 	if err := e.validateRequest(req); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (e *Executor) prepareRun(req tool.AgentExecRequest) (*preparedRun, error) {
 		return nil, err
 	}
 
-	cfg, err := e.prepareRunConfig(req)
+	cfg, err := e.prepareRunConfig(ctx, req)
 	if err != nil {
 		cleanupWorkspace()
 		return nil, err

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -159,10 +159,10 @@ func TestParseVendorModel(t *testing.T) {
 		{"deepseek/deepseek-v4", llm.DeepSeek, "deepseek-v4", true},
 		{"anthropic/claude-opus-4-20250514", llm.Anthropic, "claude-opus-4-20250514", true},
 		{"acme/some-model", "acme", "some-model", true}, // any slash parses; the pool rejects unknown vendors
-		{"opus", "", "", false},                         // alias, not a qualified ref
-		{"claude-opus-4-20250514", "", "", false},       // bare model id, no slash
-		{"deepseek/", "", "", false},                    // empty model
-		{"/deepseek-v4", "", "", false},                 // empty vendor
+		{"opus", "", "", false},                   // alias, not a qualified ref
+		{"claude-opus-4-20250514", "", "", false}, // bare model id, no slash
+		{"deepseek/", "", "", false},              // empty model
+		{"/deepseek-v4", "", "", false},           // empty vendor
 	}
 	for _, tt := range tests {
 		vendor, model, ok := parseVendorModel(tt.ref)

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/genai-io/san/internal/tool"
 )
 
+// parseVendorModel gates "vendor/model" routing on registered providers, so the
+// tests that exercise routing register the vendors they reference. (The app
+// wires these via blank imports in cmd/san/main.go.)
+func init() {
+	llm.RegisterProviderDisplay(llm.DeepSeek, llm.ProviderDisplay{Name: "DeepSeek"})
+	llm.RegisterProviderDisplay(llm.Anthropic, llm.ProviderDisplay{Name: "Anthropic"})
+}
+
 type stubSubagentSessionStore struct {
 	saveParentID string
 	saveTitle    string
@@ -158,7 +166,8 @@ func TestParseVendorModel(t *testing.T) {
 	}{
 		{"deepseek/deepseek-v4", llm.DeepSeek, "deepseek-v4", true},
 		{"anthropic/claude-opus-4-20250514", llm.Anthropic, "claude-opus-4-20250514", true},
-		{"acme/some-model", "acme", "some-model", true}, // any slash parses; the pool rejects unknown vendors
+		{"acme/some-model", "", "", false},        // unknown vendor -> treated as a bare model id
+		{"xiaomi/mimo-v2-flash", "", "", false},   // mimo ships slash ids; "xiaomi" is not a vendor name
 		{"opus", "", "", false},                   // alias, not a qualified ref
 		{"claude-opus-4-20250514", "", "", false}, // bare model id, no slash
 		{"deepseek/", "", "", false},              // empty model

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/tool"
 )
@@ -44,7 +45,7 @@ func (s *stubSubagentSessionStore) LoadSubagentMessages(agentID string) ([]core.
 func TestPrepareRunConfigRespectsOverrides(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
 
-	rc, err := executor.prepareRunConfig(tool.AgentExecRequest{
+	rc, err := executor.prepareRunConfig(context.Background(), tool.AgentExecRequest{
 		Agent:    "general-purpose",
 		Name:     "Scout",
 		Model:    "override-model",
@@ -75,7 +76,7 @@ func TestPrepareRunConfigRespectsOverrides(t *testing.T) {
 func TestPrepareRunConfigDoesNotLowerBuiltinMaxSteps(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
 
-	rc, err := executor.prepareRunConfig(tool.AgentExecRequest{
+	rc, err := executor.prepareRunConfig(context.Background(), tool.AgentExecRequest{
 		Agent:    "general-purpose",
 		MaxSteps: 20,
 	})
@@ -88,17 +89,87 @@ func TestPrepareRunConfigDoesNotLowerBuiltinMaxSteps(t *testing.T) {
 	}
 }
 
-func TestResolveModelIDUsesConfigBeforeParent(t *testing.T) {
+func TestResolveModelUsesConfigBeforeParent(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
+	ctx := context.Background()
 
-	if got := executor.resolveModelID("", "sonnet"); got != "claude-sonnet-4-20250514" {
+	if _, got, _ := executor.resolveModel(ctx, "", "sonnet"); got != "claude-sonnet-4-20250514" {
 		t.Fatalf("config model = %q, want sonnet alias", got)
 	}
-	if got := executor.resolveModelID("", "inherit"); got != "parent-model" {
+	if _, got, _ := executor.resolveModel(ctx, "", "inherit"); got != "parent-model" {
 		t.Fatalf("inherit model = %q, want parent", got)
 	}
-	if got := executor.resolveModelID("override-model", "sonnet"); got != "override-model" {
+	if _, got, _ := executor.resolveModel(ctx, "override-model", "sonnet"); got != "override-model" {
 		t.Fatalf("request override = %q, want override", got)
+	}
+}
+
+// stubResolver records the vendor it was asked to resolve.
+type stubResolver struct {
+	provider llm.Provider
+	vendor   llm.Name
+	err      error
+}
+
+func (s *stubResolver) Resolve(_ context.Context, p llm.Name) (llm.Provider, error) {
+	s.vendor = p
+	return s.provider, s.err
+}
+
+func TestResolveModelRoutesQualifiedRefToResolver(t *testing.T) {
+	stub := &stubResolver{}
+	executor := &Executor{parentModelID: "parent-model", resolver: stub}
+
+	_, modelID, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", "")
+	if err != nil {
+		t.Fatalf("resolveModel() error: %v", err)
+	}
+	if stub.vendor != llm.DeepSeek {
+		t.Fatalf("resolver vendor = %q, want %q", stub.vendor, llm.DeepSeek)
+	}
+	if modelID != "deepseek-v4" {
+		t.Fatalf("modelID = %q, want deepseek-v4", modelID)
+	}
+}
+
+func TestResolveModelQualifiedRefWithoutResolverErrors(t *testing.T) {
+	executor := &Executor{parentModelID: "parent-model"} // no resolver wired
+
+	if _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
+		t.Fatal("expected an error when an explicit vendor/model ref has no resolver")
+	}
+}
+
+func TestResolveModelPropagatesResolverError(t *testing.T) {
+	stub := &stubResolver{err: errors.New("provider \"deepseek\" is not connected")}
+	executor := &Executor{parentModelID: "parent-model", resolver: stub}
+
+	if _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
+		t.Fatal("expected the resolver error to propagate")
+	}
+}
+
+func TestParseVendorModel(t *testing.T) {
+	tests := []struct {
+		ref    string
+		vendor llm.Name
+		model  string
+		ok     bool
+	}{
+		{"deepseek/deepseek-v4", llm.DeepSeek, "deepseek-v4", true},
+		{"anthropic/claude-opus-4-20250514", llm.Anthropic, "claude-opus-4-20250514", true},
+		{"acme/some-model", "acme", "some-model", true}, // any slash parses; the pool rejects unknown vendors
+		{"opus", "", "", false},                         // alias, not a qualified ref
+		{"claude-opus-4-20250514", "", "", false},       // bare model id, no slash
+		{"deepseek/", "", "", false},                    // empty model
+		{"/deepseek-v4", "", "", false},                 // empty vendor
+	}
+	for _, tt := range tests {
+		vendor, model, ok := parseVendorModel(tt.ref)
+		if ok != tt.ok || vendor != tt.vendor || model != tt.model {
+			t.Fatalf("parseVendorModel(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.ref, vendor, model, ok, tt.vendor, tt.model, tt.ok)
+		}
 	}
 }
 

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -288,7 +288,13 @@ type AgentConfig struct {
 	Description string `yaml:"description" json:"description"`
 	Color       string `yaml:"color,omitempty" json:"color,omitempty"`
 	WhenToUse   string `yaml:"when-to-use,omitempty" json:"when_to_use,omitempty"`
-	Model       string `yaml:"model" json:"model"`
+	// Model selects the model for this agent. Accepted forms:
+	//   - "inherit" or empty — use the parent conversation's model
+	//   - an alias ("opus", "sonnet", "haiku") or a bare model id served by the
+	//     parent's provider
+	//   - "vendor/model" (e.g. "deepseek/deepseek-v4") to route to another
+	//     connected provider; the named vendor must be connected
+	Model string `yaml:"model" json:"model"`
 
 	// PermissionMode is the default policy when no allow/deny rule matches.
 	PermissionMode PermissionMode `yaml:"mode" json:"mode"`


### PR DESCRIPTION
A subagent's `model:` (and the `Agent` tool's `model`) now accepts an explicit `vendor/model` form (e.g. `deepseek/deepseek-v4`) that resolves to that vendor's *connected* provider, instead of silently falling back to the parent model.

- **Fixes a silent degradation**: the executor built every child client from the single parent provider instance, so a cross-provider override hit `model_not_found` and fell back to the parent — per-agent model only worked within one vendor.
- `llm.ProviderPool` lazily builds and caches one provider per connected vendor. `vendor/model` names the **vendor only**; the serving platform/auth comes from how that vendor is connected, so Claude-on-Vertex stays the Anthropic provider (not Google).
- An unknown or unconnected vendor errors instead of degrading. Aliases (`opus`/`sonnet`/`haiku`), bare ids, and `inherit` keep using the parent's provider unchanged.

This lets each subagent run on the provider that best fits its role with **no new config** — just `model:` in its frontmatter. The writing-a-subagent guide includes a cross-provider example.