### PR TITLE
docs: document make ci in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,11 @@ GOCACHE=/private/tmp/san-go-build-cache go test \
   ./internal/session/... ./tests/integration/session/... ./tests/integration/cli/...
 ```
 
+Before opening a PR, run `make ci` as the full local gate for CI-style
+checks. It runs the same Makefile checks as CI, including format
+checking (`make format-check`), build verification, linting, and
+coverage via `make cover`.
+
 Transcript storage layout, recording rules, and the event model are
 documented in [`docs/packages/session.md`](docs/packages/session.md).
 


### PR DESCRIPTION
## Summary
- Document make ci as the full local PR gate in CONTRIBUTING.md.
- Note that it maps to CI-style checks including format checking, build verification, linting, and coverage via make cover.

## Validation
- make format-check (failed: make is not installed or available in the Windows PATH)
- make ci (not run: local environment is missing make and go; WSL is present but has no installed Linux distribution)
- git diff --check (passed)