### PR TITLE
feat(llm): add Z.ai GLM Coding Plan provider endpoint [Symphony]

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Config lives in `~/.san/` (user) and `<project>/.san/` (project, overrides user)
 | **Moonshot** (Kimi) | `MOONSHOT_API_KEY` |
 | **Alibaba** (Qwen) | `DASHSCOPE_API_KEY` |
 | **MiniMax** | `MINIMAX_API_KEY` |
-| **Z.ai** (GLM) | `BIGMODEL_API_KEY` |
+| **Z.ai** (GLM / GLM Coding Plan) | `BIGMODEL_API_KEY` |
 | **SenseNova** | `SENSENOVA_API_KEY` |
 | **Mimo** | `MIMO_API_KEY` |
 | **Volcengine** (Ark) | `VOLCENGINE_API_KEY` |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -42,7 +42,7 @@ for Anthropic). Supported providers and the env var each one reads:
 | Alibaba | `DASHSCOPE_API_KEY` |
 | MiniMax | `MINIMAX_API_KEY` |
 | MiMo | `MIMO_API_KEY` |
-| Z.ai (GLM) | `BIGMODEL_API_KEY` |
+| Z.ai (GLM / GLM Coding Plan) | `BIGMODEL_API_KEY` |
 | DeepSeek | `DEEPSEEK_API_KEY` |
 | Ollama (local) | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`) |
 | SenseNova | `SENSENOVA_API_KEY` |

--- a/internal/llm/bigmodel/coding.go
+++ b/internal/llm/bigmodel/coding.go
@@ -1,0 +1,40 @@
+package bigmodel
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+// CodingMeta is the metadata for BigModel (Zhipu / Z.ai — GLM series) via Coding Plan.
+// Reuses BIGMODEL_API_KEY; the Coding Plan only differs from Direct API in the endpoint.
+var CodingMeta = llm.Meta{
+	Provider:    llm.BigModel,
+	AuthMethod:  llm.AuthCoding,
+	EnvVars:     []string{"BIGMODEL_API_KEY"},
+	DisplayName: "Coding Plan",
+}
+
+// NewCodingClient creates a new BigModel client using the Coding Plan endpoint.
+// Same key as Direct API; users just pick "Coding Plan" in the UI.
+func NewCodingClient(ctx context.Context) (llm.Provider, error) {
+	baseURL := secret.Resolve("BIGMODEL_CODING_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://open.bigmodel.cn/api/coding/paas/v4"
+	}
+
+	client := openai.NewClient(
+		option.WithAPIKey(secret.Resolve("BIGMODEL_API_KEY")),
+		option.WithBaseURL(baseURL),
+		option.WithMaxRetries(0),
+	)
+	return NewClient(client, "bigmodel:coding"), nil
+}
+
+func init() {
+	llm.Register(CodingMeta, NewCodingClient)
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -34,6 +34,7 @@ const (
 	AuthAPIKey  AuthMethod = "api_key"
 	AuthVertex  AuthMethod = "vertex"
 	AuthBedrock AuthMethod = "bedrock"
+	AuthCoding  AuthMethod = "coding"
 )
 
 // Meta contains static metadata about a provider auth method.


### PR DESCRIPTION
## Summary
Add Z.ai GLM Coding Plan provider endpoint

Register a new `bigmodel:coding` auth method that uses the dedicated Coding API endpoint (`https://open.bigmodel.cn/api/coding/paas/v4`) instead of the general API endpoint.

**Files changed:**
```
 internal/llm/bigmodel/coding.go    | 39 ++++++++++++++++++++++++++++++++++++++
 internal/llm/types.go              |  1 +
 internal/setting/client_options.go |  6 ++++++
 3 files changed, 46 insertions(+)
```

**Modified files:**
```
internal/llm/bigmodel/coding.go
internal/llm/types.go
internal/setting/client_options.go
```

## Commits
```
3278980 feat(llm): add Z.ai GLM Coding Plan provider endpoint
```

## CI Results (`go build ./cmd/san/`)
```
(passed)
```

---

Created by symphony agent (issue: local-0001)