### PR TITLE
ci: pin remaining GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,10 +26,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/pr-freshness.yml
+++ b/.github/workflows/pr-freshness.yml
@@ -44,7 +44,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       INPUT_PR: ${{ github.event.inputs.pr }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
           printf '%s\n' "$results" > "$RUNNER_TEMP/verdicts.json"
 
       - name: Comment & label PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           VERDICTS_FILE: ${{ runner.temp }}/verdicts.json
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           fetch-tags: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.8'
 
@@ -49,7 +49,7 @@ jobs:
           PY
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: |
             bin/san_*.tar.gz


### PR DESCRIPTION
## Summary

- Pin the remaining unpinned GitHub Actions references to commit SHAs.
- Keep version comments next to each SHA for readability and Dependabot context.
- Covers the pages, PR freshness, and release workflows.

Part of genai-io/san#88 ("Pin actions to SHAs").

## Validation

- `git diff --check` passed.
- Verified no remaining unpinned `uses: ...@(vN|main|master)` entries in `.github/workflows`.
- Resolved SHAs from the upstream action tags with `git ls-remote`.
