### PR TITLE
fix(status): resolve context window by model ID across all caches

### DIFF
--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -33,22 +33,16 @@ func GetMaxTokens(store *llm.Store, currentModel *llm.CurrentModelInfo, defaultM
 }
 
 // GetModelTokenLimits returns the cached token limits for the current model.
+// It resolves the model by ID across every cached provider list (like
+// CachedModelDisplayName), not just the current provider's: an OpenAI-compatible
+// aggregator may serve a model with no advertised context window while the same
+// model's native provider knows the real one. Matching by ID lets the status
+// bar borrow that known window instead of falling back to "--".
 func GetModelTokenLimits(store *llm.Store, currentModel *llm.CurrentModelInfo) (inputLimit, outputLimit int) {
 	if store == nil || currentModel == nil {
 		return 0, 0
 	}
-
-	models, ok := store.GetCachedModels(currentModel.Provider, currentModel.AuthMethod)
-	if !ok {
-		return 0, 0
-	}
-
-	for _, model := range models {
-		if model.ID == currentModel.ModelID {
-			return model.InputTokenLimit, model.OutputTokenLimit
-		}
-	}
-	return 0, 0
+	return store.CachedModelLimits(currentModel.ModelID)
 }
 
 // getEffectiveTokenLimits returns custom limits if set, otherwise cached model limits.

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -310,6 +310,33 @@ func (s *Store) CachedModelDisplayName(id string) string {
 	return raw
 }
 
+// CachedModelLimits returns the token limits for a model ID found in any
+// cached provider list, ignoring TTL. Returns (0, 0) when no cached entry
+// reports a context window for the ID.
+//
+// The companion to CachedModelDisplayName, and for the same reason: the same
+// model can be cached under several provider/auth keys, and only some report a
+// context window. An OpenAI-compatible aggregator often echoes the raw model ID
+// with no context length (limit 0), while the model's native provider knows the
+// real window (e.g. DeepSeek V4 Pro at 1M). Resolving the limit from only the
+// current provider's cache would then render "--" even though another cache
+// knows the answer. So we scan all caches and prefer an entry with a real
+// (non-zero) input limit. Scans in place without allocating, since it feeds the
+// status bar on every render.
+func (s *Store) CachedModelLimits(id string) (inputLimit, outputLimit int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, cache := range s.data.Models {
+		for _, m := range cache.Models {
+			if m.ID == id && m.InputTokenLimit > 0 {
+				return m.InputTokenLimit, m.OutputTokenLimit
+			}
+		}
+	}
+	return 0, 0
+}
+
 // SetCurrentModel sets the current model with provider info
 func (s *Store) SetCurrentModel(modelID string, provider Name, authMethod AuthMethod) error {
 	s.mu.Lock()

--- a/internal/llm/store_test.go
+++ b/internal/llm/store_test.go
@@ -135,3 +135,43 @@ func TestStore_CachedModelDisplayNamePrefersRealNameAndIsStable(t *testing.T) {
 		t.Fatalf("CachedModelDisplayName(missing) = %q, want empty", got)
 	}
 }
+
+// A model can be cached under several provider keys where only some report a
+// context window: an aggregator echoes the ID with no limit, while the native
+// provider knows the real one. CachedModelLimits must prefer the known window
+// over the zero, deterministically, so the status bar never flickers to "--".
+func TestStore_CachedModelLimitsPrefersKnownWindow(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	store, err := NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	// alibaba echoes the model with no context window; deepseek knows the real one.
+	if err := store.CacheModels(Alibaba, AuthAPIKey, []ModelInfo{
+		{ID: "deepseek-v4-pro"},
+	}); err != nil {
+		t.Fatalf("CacheModels(alibaba) error = %v", err)
+	}
+	if err := store.CacheModels(DeepSeek, AuthAPIKey, []ModelInfo{
+		{ID: "deepseek-v4-pro", InputTokenLimit: 1_000_000, OutputTokenLimit: 384_000},
+	}); err != nil {
+		t.Fatalf("CacheModels(deepseek) error = %v", err)
+	}
+
+	// Call many times; with randomized map order an order-dependent
+	// implementation would return the zero limit on some iterations.
+	for i := range 100 {
+		in, out := store.CachedModelLimits("deepseek-v4-pro")
+		if in != 1_000_000 || out != 384_000 {
+			t.Fatalf("CachedModelLimits() = (%d, %d), want (1000000, 384000) on iteration %d", in, out, i)
+		}
+	}
+
+	// An uncached ID returns zero limits.
+	if in, out := store.CachedModelLimits("missing"); in != 0 || out != 0 {
+		t.Fatalf("CachedModelLimits(missing) = (%d, %d), want (0, 0)", in, out)
+	}
+}


### PR DESCRIPTION
The status bar `ctx X/Y` limit was resolved only from the current model's provider+auth cache, while the model **name** is resolved across all caches. A model served via an OpenAI-compatible aggregator that omits `context_length` caches a zero limit, so the bar showed `ctx X/--` even when another cache (e.g. the native DeepSeek catalog) knew the real window.

- Add `Store.CachedModelLimits`, the limit counterpart to `CachedModelDisplayName`: scan every cached provider list by model ID, prefer a non-zero input limit.
- `GetModelTokenLimits` now uses it, so name and limit resolution match. Ignoring TTL also stops an expired cache from dropping a known window to `--`.