### PR TITLE
feat(scrollback): commit thinking block-by-block while streaming

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -164,10 +164,12 @@ type AssistantParams struct {
 	// Streaming-commit offsets: how much of Content/Thinking is already in
 	// scrollback (see FlushStreamingBlocks). Only the remainder is rendered
 	// here. BulletEmitted swaps the "● " marker for a continuation gutter once
-	// the turn's first content block has been committed.
+	// the turn's first content block has been committed; ThinkingEmitted does the
+	// same for the "✦ " marker once the turn's first thinking block is committed.
 	ContentCommittedLen  int
 	ThinkingCommittedLen int
 	BulletEmitted        bool
+	ThinkingEmitted      bool
 }
 
 // InterruptedMarker is the literal suffix MarkLastInterrupted appends to an
@@ -192,10 +194,23 @@ func contentGutter(showBullet bool) string {
 	return continuationGutter
 }
 
+// thinkingGutter returns the 2-column lead for a reasoning block: the muted "✦"
+// marker for the turn's first thinking block, or a blank continuation gutter for
+// blocks committed after it, so progressively-committed reasoning aligns under
+// the single leading glyph.
+func thinkingGutter(showIcon bool) string {
+	if showIcon {
+		return ThinkingStyle.Render("✦ ")
+	}
+	return continuationGutter
+}
+
 // renderThinkingBlock renders reasoning text as the muted "✦" block shared by
 // the live view and the scrollback commit path. The glyph and text both stay
-// muted, matching the status-bar thinking indicator — no hue.
-func renderThinkingBlock(thinking string, width int) string {
+// muted, matching the status-bar thinking indicator — no hue. showIcon leads the
+// block with the "✦ " marker (the turn's first thinking) or a blank continuation
+// gutter for blocks committed after it.
+func renderThinkingBlock(thinking string, showIcon bool, width int) string {
 	wrapWidth := max(width-streamWrapReserve, minWrapWidth)
 	wrapped := lipgloss.NewStyle().Width(wrapWidth).Render(thinking)
 	var lines []string
@@ -204,8 +219,7 @@ func renderThinkingBlock(thinking string, width int) string {
 			lines = append(lines, ThinkingStyle.Render(line))
 		}
 	}
-	thinkingIcon := ThinkingStyle.Render("✦ ")
-	return lipgloss.JoinHorizontal(lipgloss.Top, thinkingIcon, strings.Join(lines, "\n"))
+	return lipgloss.JoinHorizontal(lipgloss.Top, thinkingGutter(showIcon), strings.Join(lines, "\n"))
 }
 
 // sliceFrom returns the portion of s past the first n bytes — the not-yet-
@@ -223,12 +237,15 @@ func sliceFrom(s string, n int) string {
 }
 
 // RenderCommittedThinkingBlock renders a completed reasoning block for commit to
-// native scrollback — the muted "✦" gutter plus the wrapped thinking text.
-func RenderCommittedThinkingBlock(thinking string, width int) string {
+// native scrollback — the muted gutter plus the wrapped thinking text. showIcon
+// leads with the "✦ " marker (the turn's first thinking block) or a blank
+// continuation gutter for blocks committed after it. Returns "" when the slice
+// renders empty (e.g. only blank lines).
+func RenderCommittedThinkingBlock(thinking string, showIcon bool, width int) string {
 	if strings.TrimSpace(thinking) == "" {
 		return ""
 	}
-	return renderThinkingBlock(thinking, width)
+	return renderThinkingBlock(thinking, showIcon, width)
 }
 
 // RenderCommittedContentBlock renders one or more completed markdown blocks of
@@ -274,7 +291,7 @@ func RenderAssistantMessage(params AssistantParams) string {
 	}
 
 	if params.Thinking != "" {
-		sb.WriteString(renderThinkingBlock(params.Thinking, params.Width) + "\n\n")
+		sb.WriteString(renderThinkingBlock(params.Thinking, !params.ThinkingEmitted, params.Width) + "\n\n")
 	}
 
 	content := formatAssistantContent(params)

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -8,6 +8,20 @@ import (
 	"github.com/genai-io/san/internal/llm"
 )
 
+// The turn's first committed thinking block leads with the "✦" marker;
+// progressively-committed blocks after it align under a blank continuation
+// gutter so the glyph appears once, not on every block.
+func TestRenderCommittedThinkingBlockGutter(t *testing.T) {
+	first := RenderCommittedThinkingBlock("first reasoning block", true, 80)
+	if !strings.Contains(first, "✦") {
+		t.Fatalf("first thinking block should lead with the ✦ marker, got %q", first)
+	}
+	cont := RenderCommittedThinkingBlock("continuation reasoning block", false, 80)
+	if strings.Contains(cont, "✦") {
+		t.Fatalf("continuation thinking block should not repeat the ✦ marker, got %q", cont)
+	}
+}
+
 func Test_extractIntField(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -185,6 +185,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		ContentCommittedLen:  msg.ContentCommittedLen,
 		ThinkingCommittedLen: msg.ThinkingCommittedLen,
 		BulletEmitted:        msg.BulletEmitted,
+		ThinkingEmitted:      msg.ThinkingEmitted,
 	})
 
 	if len(msg.ToolCalls) == 0 {

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -19,10 +19,11 @@ func (m *model) CommitMessages() []tea.Cmd {
 
 // FlushStreamingBlocks commits the in-flight assistant message's newly-completed
 // blocks to native scrollback, advancing its committed offsets so the live view
-// and the turn-end commit render only the remainder. Thinking commits as one
-// block the moment text starts (the reliable "reasoning done" signal); content
-// commits block-by-block as fenced code closes or blank lines land. Returns nil
-// when nothing new is committable.
+// and the turn-end commit render only the remainder. Both thinking and content
+// commit block-by-block as blank lines (or, for content, closing code fences)
+// land; once content starts — the reliable "reasoning done" signal — thinking's
+// trailing block is flushed too so nothing reasoning-side lingers in the live
+// view. Returns nil when nothing new is committable.
 func (m *model) FlushStreamingBlocks() []tea.Cmd {
 	idx := len(m.conv.Messages) - 1
 	if idx < 0 {
@@ -35,11 +36,20 @@ func (m *model) FlushStreamingBlocks() []tea.Cmd {
 
 	var blocks []string
 
-	if msg.ThinkingCommittedLen < len(msg.Thinking) && len(msg.Content) > 0 {
-		if block := conv.RenderCommittedThinkingBlock(msg.Thinking[msg.ThinkingCommittedLen:], m.env.Width); block != "" {
+	// Thinking commits paragraph-by-paragraph as blank lines land; once content
+	// starts, the trailing paragraph is flushed too (it has no terminating blank
+	// line of its own).
+	thinkingEnd := conv.CompletedBlockBoundary(msg.Thinking)
+	if len(msg.Content) > 0 {
+		thinkingEnd = len(msg.Thinking)
+	}
+	if thinkingEnd > msg.ThinkingCommittedLen {
+		block := conv.RenderCommittedThinkingBlock(msg.Thinking[msg.ThinkingCommittedLen:thinkingEnd], !msg.ThinkingEmitted, m.env.Width)
+		if block != "" {
 			blocks = append(blocks, block)
+			msg.ThinkingEmitted = true
 		}
-		msg.ThinkingCommittedLen = len(msg.Thinking)
+		msg.ThinkingCommittedLen = thinkingEnd
 	}
 
 	if boundary := conv.CompletedBlockBoundary(msg.Content); boundary > msg.ContentCommittedLen {

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/core"
+)
+
+func flushTestModel(msg core.ChatMessage) *model {
+	m := &model{env: env{Width: 80}, conv: conv.NewModel(80)}
+	m.conv.Messages = []core.ChatMessage{msg}
+	return m
+}
+
+// A completed thinking paragraph (terminated by a blank line) commits to
+// scrollback mid-stream, before any content arrives — reasoning no longer waits
+// for the whole block to finish.
+func TestFlushStreamingBlocksCommitsThinkingParagraph(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:     core.RoleAssistant,
+		Thinking: "first paragraph of reasoning\n\n",
+	})
+
+	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
+		t.Fatal("a completed thinking paragraph should commit")
+	}
+	msg := m.conv.Messages[0]
+	if msg.ThinkingCommittedLen != len(msg.Thinking) {
+		t.Fatalf("ThinkingCommittedLen = %d, want %d", msg.ThinkingCommittedLen, len(msg.Thinking))
+	}
+	if !msg.ThinkingEmitted {
+		t.Fatal("ThinkingEmitted should be set after the first thinking block commits")
+	}
+}
+
+// The still-streaming trailing paragraph (no terminating blank line) stays in
+// the live view until it completes — exactly like content's trailing block.
+func TestFlushStreamingBlocksHoldsIncompleteThinking(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:     core.RoleAssistant,
+		Thinking: "still streaming this paragraph",
+	})
+
+	if cmds := m.FlushStreamingBlocks(); cmds != nil {
+		t.Fatal("an incomplete thinking paragraph must stay in the live view")
+	}
+	if got := m.conv.Messages[0].ThinkingCommittedLen; got != 0 {
+		t.Fatalf("ThinkingCommittedLen = %d, want 0 (nothing committed)", got)
+	}
+}
+
+// When content starts — the reliable "reasoning done" signal — thinking's
+// trailing paragraph is flushed too, so nothing reasoning-side lingers.
+func TestFlushStreamingBlocksFlushesTrailingThinkingOnContent(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:     core.RoleAssistant,
+		Thinking: "reasoning with no trailing blank line",
+		Content:  "Here",
+	})
+
+	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
+		t.Fatal("content starting should flush the trailing thinking paragraph")
+	}
+	msg := m.conv.Messages[0]
+	if msg.ThinkingCommittedLen != len(msg.Thinking) {
+		t.Fatalf("thinking should be fully committed once content starts, got %d/%d",
+			msg.ThinkingCommittedLen, len(msg.Thinking))
+	}
+}

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -96,6 +96,7 @@ type ChatMessage struct {
 	ContentCommittedLen  int  // bytes of Content already flushed to scrollback
 	ThinkingCommittedLen int  // bytes of Thinking already flushed to scrollback
 	BulletEmitted        bool // the "● " content marker has already been emitted
+	ThinkingEmitted      bool // the "✦ " thinking marker has already been emitted
 }
 
 // ResetStreamCommit clears the streaming-commit progress so the message renders
@@ -105,6 +106,7 @@ func (m *ChatMessage) ResetStreamCommit() {
 	m.ContentCommittedLen = 0
 	m.ThinkingCommittedLen = 0
 	m.BulletEmitted = false
+	m.ThinkingEmitted = false
 }
 
 // ToMessage returns the wire/agent Message underlying this view-model, dropping


### PR DESCRIPTION
Reasoning was held whole in the live view and only committed to scrollback once content started. Now thinking commits paragraph-by-paragraph (at blank-line boundaries) as it streams, the same way content blocks already flush — so long reasoning no longer piles up in the live region.

- Commit completed thinking paragraphs mid-stream via `CompletedBlockBoundary`; content starting flushes the trailing paragraph.
- The `✦` marker leads the first thinking block; later blocks align under a continuation gutter (new `ThinkingEmitted`, mirroring `BulletEmitted`).