### PR TITLE
fix(scrollback): stop re-rendering committed history

### DIFF
--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -125,23 +125,6 @@ func (m *ConversationModel) DropStreamingAssistant() {
 	}
 }
 
-// ResetStreamCommit clears the streaming-commit offsets on the in-flight
-// trailing assistant message so it renders whole again. Called when the
-// terminal is cleared and rebuilt (resize reflow): the message's
-// progressively-flushed prefix is wiped from scrollback, so the live view must
-// show the full message and the next flush re-commit its blocks from the top.
-func (m *ConversationModel) ResetStreamCommit() {
-	n := len(m.Messages)
-	if n == 0 || n <= m.CommittedCount {
-		return
-	}
-	last := &m.Messages[n-1]
-	if last.Role != core.RoleAssistant {
-		return
-	}
-	last.ResetStreamCommit()
-}
-
 func (m *ConversationModel) RemoveEmptyLastAssistant() {
 	if len(m.Messages) > 0 {
 		last := m.Messages[len(m.Messages)-1]
@@ -168,8 +151,12 @@ func (m *ConversationModel) MarkLastInterrupted() {
 	}
 }
 
+// Toggling only touches the live (uncommitted) tail: committed messages are
+// already in the terminal's native scrollback and can't be re-rendered in
+// place, so they stay frozen as last drawn.
+
 func (m *ConversationModel) ToggleMostRecentExpandable() {
-	for i := len(m.Messages) - 1; i >= 0; i-- {
+	for i := len(m.Messages) - 1; i >= m.CommittedCount; i-- {
 		msg := &m.Messages[i]
 		switch {
 		case msg.ToolResult != nil:
@@ -184,7 +171,7 @@ func (m *ConversationModel) ToggleMostRecentExpandable() {
 
 func (m *ConversationModel) ToggleAllExpandable() {
 	anyExpanded := false
-	for i := 0; i < len(m.Messages); i++ {
+	for i := m.CommittedCount; i < len(m.Messages); i++ {
 		msg := m.Messages[i]
 		if (msg.ToolResult != nil && msg.Expanded) ||
 			(len(msg.ToolCalls) > 0 && msg.ToolCallsExpanded) {
@@ -192,7 +179,7 @@ func (m *ConversationModel) ToggleAllExpandable() {
 			break
 		}
 	}
-	for i := 0; i < len(m.Messages); i++ {
+	for i := m.CommittedCount; i < len(m.Messages); i++ {
 		if m.Messages[i].ToolResult != nil {
 			m.Messages[i].Expanded = !anyExpanded
 		}

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -400,15 +400,17 @@ type ToolCallsParams struct {
 	TaskOwnerMap      map[string]string
 	MDRenderer        *MDRenderer
 	Width             int
+	Interactive       bool
 }
 
 // ToolResultData holds the data needed to render a tool result inline.
 type ToolResultData struct {
-	ToolName  string
-	Content   string
-	IsError   bool
-	Expanded  bool
-	ToolInput string
+	ToolName    string
+	Content     string
+	IsError     bool
+	Interactive bool
+	Expanded    bool
+	ToolInput   string
 }
 
 // RenderToolCalls renders the tool calls section of an assistant core.
@@ -428,7 +430,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				sb.WriteString(renderAgentToolLine(label, params.Width, "●", color) + "\n")
 			} else {
 				sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink), color))
-				if !params.ToolCallsExpanded {
+				if !params.ToolCallsExpanded && params.Interactive {
 					sb.WriteString(ThinkingStyle.Render("  (ctrl+o to expand)"))
 				}
 				sb.WriteString("\n")
@@ -468,6 +470,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 
 		if resultData, ok := params.ResultMap[tc.ID]; ok {
 			resultData.ToolInput = tc.Input
+			resultData.Interactive = params.Interactive
 			sb.WriteString(RenderToolResultInline(resultData, params.MDRenderer))
 		} else if tool.IsAgentToolName(tc.Name) {
 			limit := maxCompactAgentToolLines

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -424,7 +424,10 @@ func renderTaskResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 			resultLine += " (" + doneStats + ")"
 		}
 		sb.WriteString(toolResultStyle.Render(resultLine))
-		sb.WriteString(ThinkingStyle.Render("  (ctrl+o to expand)") + "\n")
+		if data.Interactive {
+			sb.WriteString(ThinkingStyle.Render("  (ctrl+o to expand)"))
+		}
+		sb.WriteString("\n")
 		return sb.String()
 	}
 

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -44,6 +44,12 @@ type RenderContext struct {
 
 	// ── Modal interlock — suppress chrome under a tool prompt ───
 	InteractivePromptActive bool
+
+	// Interactive marks the live render pass (RenderActiveContent): the
+	// uncommitted tail the user can still act on. "(ctrl+o to expand)" hints
+	// show only here — once a message is frozen into native scrollback the
+	// key no longer reaches it.
+	Interactive bool
 }
 
 // inlinedToolResults precomputes which ToolResult messages should be
@@ -149,10 +155,11 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 		switch {
 		case msg.ToolResult != nil:
 			sb.WriteString(RenderToolResultInline(ToolResultData{
-				ToolName: msg.ToolResult.ToolName,
-				Content:  msg.ToolResult.Content,
-				IsError:  msg.ToolResult.IsError,
-				Expanded: msg.Expanded,
+				ToolName:    msg.ToolResult.ToolName,
+				Content:     msg.ToolResult.Content,
+				IsError:     msg.ToolResult.IsError,
+				Expanded:    msg.Expanded,
+				Interactive: p.Interactive,
 			}, p.MDRenderer))
 		case core.IsCompactSummary(msg.Content):
 			// The post-compaction summary is injected as a user message (the
@@ -221,6 +228,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		TaskOwnerMap:      p.TaskOwnerMap,
 		MDRenderer:        p.MDRenderer,
 		Width:             p.Width,
+		Interactive:       p.Interactive,
 	}))
 
 	return sb.String()
@@ -263,6 +271,7 @@ func RenderSingleMessage(p RenderContext, idx int) string {
 }
 
 func RenderActiveContent(p RenderContext) string {
+	p.Interactive = true
 	if p.CommittedCount >= len(p.Messages) {
 		return renderPendingToolSpinnerFromParams(p, false)
 	}

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -216,10 +216,10 @@ func (m *model) handleCtrlOSingleTick() tea.Cmd {
 	}
 	m.userInput.LastCtrlO = time.Time{}
 	m.conv.ToggleMostRecentExpandable()
-	return m.reflowScrollback()
+	return nil
 }
 
 func (m *model) expandCollapseAll() tea.Cmd {
 	m.conv.ToggleAllExpandable()
-	return m.reflowScrollback()
+	return nil
 }

--- a/internal/app/update_resize.go
+++ b/internal/app/update_resize.go
@@ -1,19 +1,15 @@
-// Window resize and scrollback reflow. handleWindowResize runs the first
-// time we get a window size (the deferred initial paint), and whenever the
-// terminal width changes — width changes invalidate previously-rendered
-// scrollback, so we clear and reflow.
+// Window resize handling. handleWindowResize runs the first time we get a
+// window size (the deferred initial paint), where it commits any resumed
+// conversation. On later width changes there is nothing to recompute: the live
+// tail re-renders at the new width on the next frame, and already-committed
+// scrollback is immutable to us — the terminal rewraps it on its own.
 package app
 
 import (
-	"strings"
-
 	tea "charm.land/bubbletea/v2"
-
-	"github.com/genai-io/san/internal/app/conv"
 )
 
 func (m *model) handleWindowResize(msg tea.WindowSizeMsg) tea.Cmd {
-	oldWidth := m.env.Width
 	m.env.Width = msg.Width
 	m.env.Height = msg.Height
 	m.userInput.TerminalHeight = msg.Height
@@ -45,34 +41,5 @@ func (m *model) handleWindowResize(msg tea.WindowSizeMsg) tea.Cmd {
 	}
 
 	m.userInput.Textarea.SetWidth(msg.Width - 4 - 2)
-
-	if oldWidth != msg.Width && (m.conv.CommittedCount > 0 || m.conv.Stream.Active) {
-		// ClearScreen (in reflowScrollback) wipes the in-flight message's
-		// progressively-flushed prefix; reset its offsets so the live view
-		// shows it whole and the next flush re-commits its blocks.
-		m.conv.ResetStreamCommit()
-		return m.reflowScrollback()
-	}
-
 	return nil
-}
-
-func (m *model) reflowScrollback() tea.Cmd {
-	committed := m.conv.CommittedCount
-	m.conv.CommittedCount = 0
-
-	var parts []string
-	params := m.messageRenderParams()
-
-	for i := range committed {
-		if rendered := conv.RenderSingleMessage(params, i); rendered != "" {
-			parts = append(parts, rendered)
-		}
-		m.conv.CommittedCount = i + 1
-	}
-
-	if len(parts) == 0 {
-		return tea.ClearScreen
-	}
-	return tea.Sequence(tea.ClearScreen, tea.Println(strings.Join(parts, "\n")))
 }


### PR DESCRIPTION
Both expand/collapse (ctrl+o / ctrl+e) and resize re-rendered the whole conversation via `ClearScreen` + reprint-all. That fights the inline model — committed messages already live in the terminal's native scrollback, which is immutable to us. `ClearScreen` (`ESC[2J`) clears only the visible screen, so reprinting duplicated history once it grew past one screen, and mid-stream it wiped the in-flight message's flushed blocks.

- **ctrl+o / ctrl+e**: scope the toggle to the uncommitted tail (the only region that can re-render in place); the live view repaints on the next frame.
- **resize**: drop the reflow; the live tail re-renders at the new width and the terminal rewraps committed scrollback itself.
- **hint**: `(ctrl+o to expand)` now shows only on the live tail, not on tool output already frozen in scrollback where the key no longer reaches it.

Committed history stays frozen as drawn, and the now-dead reflow path is removed.

Trade-off: you can only expand/collapse the most-recent (still-live) tool output, not frozen history — the honest behavior for an inline TUI. Mutating/reflowing arbitrary committed history would require an alt-screen viewport, a separate direction.

Refs #156