### PR TITLE
fix(welcome): defer startup banner so it shows the selected model

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -43,6 +43,12 @@ type model struct {
 	conv              conv.Model     // Agent Outbox: conversation + output rendering
 	env               env            // Shared app state: provider, session, permission, plan, config
 	services          services       // Domain service singletons, injected at construction
+
+	// welcomePending defers the startup splash to the first scrollback commit
+	// so it shows the model the user picks after launch, not the (often unset)
+	// one at startup. Set in Run for fresh sessions; cleared by
+	// takeWelcomeBanner. See model_scrollback.go.
+	welcomePending bool
 }
 
 var _ conv.Runtime = (*model)(nil)

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -101,5 +101,23 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 	if len(parts) == 0 {
 		return nil
 	}
+	if banner := m.takeWelcomeBanner(); banner != "" {
+		parts = append([]string{banner}, parts...)
+	}
 	return []tea.Cmd{tea.Println(strings.Join(parts, "\n"))}
+}
+
+// takeWelcomeBanner returns the deferred startup splash once, on the first
+// scrollback commit, then clears the pending flag. Rendering it here rather
+// than before the TUI starts lets the banner show the model the user selected
+// after launch instead of freezing "no model selected" into scrollback.
+func (m *model) takeWelcomeBanner() string {
+	if !m.welcomePending {
+		return ""
+	}
+	m.welcomePending = false
+	return welcomeBanner(welcomeInfo{
+		Model: m.env.GetModelDisplayName(),
+		CWD:   m.env.CWD,
+	})
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -40,14 +40,13 @@ func Run(opts setting.RunOptions) error {
 		return err
 	}
 
-	// Fresh sessions get the splash screen before Bubbletea takes over.
-	// Resumed sessions skip it — commitAllMessages will reprint the
-	// conversation immediately, so a splash would just be churn.
+	// Fresh sessions defer the splash to the first scrollback commit so it
+	// reflects the model the user picks after launch instead of freezing
+	// "no model selected" into scrollback. Resumed sessions skip it —
+	// commitAllMessages will reprint the conversation immediately, so a splash
+	// would just be churn.
 	if len(m.conv.Messages) == 0 {
-		printWelcome(welcomeInfo{
-			Model: m.env.GetModelDisplayName(),
-			CWD:   m.env.CWD,
-		})
+		m.welcomePending = true
 	}
 
 	finalModel, err := tea.NewProgram(m).Run()

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -1,11 +1,12 @@
 // Interactive-mode splash: a single-line brand mark + cwd-basename + model,
-// nothing else. Called once at startup, before tea.NewProgram(m).Run() —
-// Bubbletea draws inline, so the splash stays in scrollback above the
-// live view.
+// nothing else. Rendered to a string and held until the first scrollback
+// commit (see model_scrollback.go), so the banner reflects the model the user
+// actually picks rather than freezing whatever was selected at launch.
+// Bubbletea draws inline, so the committed splash stays in scrollback above
+// the live view.
 package app
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,14 +30,15 @@ type welcomeInfo struct {
 	CWD   string
 }
 
-// printWelcome writes the splash to stdout. Falls back to plain text when
-// stdout is not a TTY or NO_COLOR is set.
-func printWelcome(info welcomeInfo) {
+// welcomeBanner returns the splash as a string for deferred emission into
+// scrollback. Falls back to plain text when stdout is not a TTY or NO_COLOR
+// is set. The leading newline matches a rendered message, so the banner spaces
+// correctly when prepended to the first commit.
+func welcomeBanner(info welcomeInfo) string {
 	if !welcomeUseColor() {
-		printWelcomePlain(info)
-		return
+		return plainWelcome(info)
 	}
-	fmt.Println(renderWelcome(info))
+	return renderWelcome(info)
 }
 
 func welcomeUseColor() bool {
@@ -90,7 +92,7 @@ func projectName(p string) string {
 	return base
 }
 
-func printWelcomePlain(info welcomeInfo) {
+func plainWelcome(info welcomeInfo) string {
 	parts := []string{"< SAN ✦ />"}
 	if proj := projectName(info.CWD); proj != "" {
 		parts = append(parts, proj)
@@ -98,6 +100,5 @@ func printWelcomePlain(info welcomeInfo) {
 	if info.Model != "" {
 		parts = append(parts, info.Model)
 	}
-	fmt.Println()
-	fmt.Println(strings.Join(parts, "  ·  "))
+	return "\n" + strings.Join(parts, "  ·  ")
 }


### PR DESCRIPTION
The welcome banner is printed once at launch, before the TUI takes over, then frozen into terminal scrollback. Starting with no model selected captured "no model selected" permanently — picking a model afterward updated the live status bar but couldn't rewrite the committed line.

This holds the banner until the first scrollback commit (which happens right before the first inference, when a model is necessarily selected) and renders it then, so it shows the model the user actually picked. Resumed sessions are unaffected.

Fixes #252