### PR TITLE
fix(welcome): render the startup banner live so it stays visible

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -44,10 +44,12 @@ type model struct {
 	env               env            // Shared app state: provider, session, permission, plan, config
 	services          services       // Domain service singletons, injected at construction
 
-	// welcomePending defers the startup splash to the first scrollback commit
-	// so it shows the model the user picks after launch, not the (often unset)
-	// one at startup. Set in Run for fresh sessions; cleared by
-	// takeWelcomeBanner. See model_scrollback.go.
+	// welcomePending marks the startup splash as not yet frozen into scrollback.
+	// While set, the splash renders live above the input (visible from launch
+	// and tracking the model the user picks); the first scrollback commit then
+	// freezes that same banner — with the now-selected model — and clears this.
+	// Set in Run for fresh sessions. See view.go (liveWelcome) and
+	// model_scrollback.go (takeWelcomeBanner).
 	welcomePending bool
 }
 

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -107,15 +107,23 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 	return []tea.Cmd{tea.Println(strings.Join(parts, "\n"))}
 }
 
-// takeWelcomeBanner returns the deferred startup splash once, on the first
-// scrollback commit, then clears the pending flag. Rendering it here rather
-// than before the TUI starts lets the banner show the model the user selected
-// after launch instead of freezing "no model selected" into scrollback.
+// takeWelcomeBanner freezes the startup splash into scrollback once, on the
+// first commit, then clears the pending flag so the live view (liveWelcome)
+// stops drawing it. Freezing it here rather than before the TUI starts lets the
+// banner capture the model the user selected after launch instead of freezing
+// "no model selected" into scrollback.
 func (m *model) takeWelcomeBanner() string {
 	if !m.welcomePending {
 		return ""
 	}
 	m.welcomePending = false
+	return m.welcomeBannerText()
+}
+
+// welcomeBannerText renders the startup splash for the current model and cwd.
+// It backs both the live banner (liveWelcome) and the scrollback freeze
+// (takeWelcomeBanner) so the two always read identically.
+func (m model) welcomeBannerText() string {
 	return welcomeBanner(welcomeInfo{
 		Model: m.env.GetModelDisplayName(),
 		CWD:   m.env.CWD,

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -1,16 +1,61 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
 )
 
 func flushTestModel(msg core.ChatMessage) *model {
 	m := &model{env: env{Width: 80}, conv: conv.NewModel(80)}
 	m.conv.Messages = []core.ChatMessage{msg}
 	return m
+}
+
+// The live welcome banner is visible from launch and tracks the model the user
+// picks after launch — the regression behind #252, where the banner froze "no
+// model selected" because it was committed to scrollback before any selection.
+func TestLiveWelcomeTracksModelSelection(t *testing.T) {
+	m := &model{env: env{Width: 80}, conv: conv.NewModel(80), welcomePending: true}
+
+	// At launch, before a model is picked, the splash is already on screen.
+	if got := m.liveWelcome(); !strings.Contains(got, "no model selected") {
+		t.Fatalf("liveWelcome before selection = %q, want it to mention %q", got, "no model selected")
+	}
+
+	// Picking a model updates the live banner — it is not frozen.
+	m.env.CurrentModel = &llm.CurrentModelInfo{ModelID: "claude-opus-4-8"}
+	got := m.liveWelcome()
+	if strings.Contains(got, "no model selected") {
+		t.Fatalf("liveWelcome after selection still shows %q: %q", "no model selected", got)
+	}
+	if !strings.Contains(got, "claude-opus-4-8") {
+		t.Fatalf("liveWelcome after selection = %q, want it to mention the picked model", got)
+	}
+}
+
+// On the first commit the banner is frozen into scrollback with the selected
+// model, and the live view stops drawing it (no duplicate).
+func TestTakeWelcomeBannerFreezesAndClears(t *testing.T) {
+	m := &model{env: env{Width: 80}, conv: conv.NewModel(80), welcomePending: true}
+	m.env.CurrentModel = &llm.CurrentModelInfo{ModelID: "claude-opus-4-8"}
+
+	banner := m.takeWelcomeBanner()
+	if !strings.Contains(banner, "claude-opus-4-8") {
+		t.Fatalf("frozen banner = %q, want it to mention the selected model", banner)
+	}
+	if m.welcomePending {
+		t.Fatal("welcomePending should be cleared once the banner is frozen")
+	}
+	if got := m.liveWelcome(); got != "" {
+		t.Fatalf("liveWelcome after freeze = %q, want \"\" (no duplicate in live view)", got)
+	}
+	if again := m.takeWelcomeBanner(); again != "" {
+		t.Fatalf("takeWelcomeBanner is once-only, second call = %q", again)
+	}
 }
 
 // A completed thinking paragraph (terminated by a blank line) commits to

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -40,8 +40,9 @@ func Run(opts setting.RunOptions) error {
 		return err
 	}
 
-	// Fresh sessions defer the splash to the first scrollback commit so it
-	// reflects the model the user picks after launch instead of freezing
+	// Fresh sessions show the splash live above the input from launch and freeze
+	// it into scrollback on the first commit, so it stays visible immediately
+	// yet reflects the model the user picks after launch instead of freezing
 	// "no model selected" into scrollback. Resumed sessions skip it —
 	// commitAllMessages will reprint the conversation immediately, so a splash
 	// would just be churn.

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -157,6 +157,13 @@ func (m model) renderInputView() string {
 func (m model) renderChatSection(activeContent, trackerView string) string {
 	var parts []string
 
+	if banner := m.liveWelcome(); banner != "" {
+		// Trailing blank line so the splash isn't cramped against the
+		// separator/input strip below it — matching the blank line it gets
+		// in scrollback, where the first message's leading newline supplies it.
+		parts = append(parts, banner, "")
+	}
+
 	if activeContent != "" {
 		parts = append(parts, activeContent)
 	}
@@ -190,6 +197,19 @@ func (m model) renderChatSection(activeContent, trackerView string) string {
 	}
 
 	return strings.Join(parts, "\n")
+}
+
+// liveWelcome returns the startup splash for the live view while it is still
+// pending — i.e. before the first scrollback commit. Drawing it here keeps the
+// banner visible from launch and lets it track the model the user picks (the
+// view re-renders on selection); the identical banner is frozen into scrollback
+// by takeWelcomeBanner on the first commit, after which welcomePending is false
+// and this returns "".
+func (m model) liveWelcome() string {
+	if !m.welcomePending {
+		return ""
+	}
+	return m.welcomeBannerText()
 }
 
 // renderSelfLearnLive returns the L1 indicator as an inline live row

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -1,9 +1,10 @@
 // Interactive-mode splash: a single-line brand mark + cwd-basename + model,
-// nothing else. Rendered to a string and held until the first scrollback
-// commit (see model_scrollback.go), so the banner reflects the model the user
-// actually picks rather than freezing whatever was selected at launch.
-// Bubbletea draws inline, so the committed splash stays in scrollback above
-// the live view.
+// nothing else. Rendered to a string and shown in the live view from launch
+// (see view.go's liveWelcome), then frozen into scrollback on the first commit
+// (see model_scrollback.go). Drawing it live keeps it visible immediately while
+// still letting it reflect the model the user actually picks rather than
+// freezing whatever was selected at launch. Bubbletea draws inline, so the
+// committed splash stays in scrollback above the live view.
 package app
 
 import (


### PR DESCRIPTION
The previous fix (#252) deferred the welcome banner to the first scrollback commit so it would show the selected model instead of a frozen "no model selected" — but that made the banner invisible on first launch until the user sent a message.

Render the banner in the live view (above the input) while it's pending, then freeze it into scrollback on the first commit. It's now visible from launch, tracks the model picked after launch (the live view re-renders on selection), and still lands in scrollback with the correct model. `welcomePending` flips to false on the freeze, so the live and committed banners never overlap.

Fixes #252