### PR TITLE
docs(readme): collapse the features overview image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,13 @@ San is a terminal-native **unified runtime for specialized agents** — coding a
 ## Features
 
 <details>
-<summary><b>Overview diagram</b></summary>
+<summary><b>Open architecture</b> &nbsp;→&nbsp; overview diagram</summary>
 
 <div align="center">
   <img src="assets/san.png" alt="San — pluggable models, search backends, personas, skills &amp; extensions, and a self-evolving agent" width="100%">
 </div>
 
 </details>
-
-### Open architecture
 
 - **LLM providers** — Anthropic, OpenAI, Google, DeepSeek, Moonshot, Alibaba, MiniMax, Z.ai (GLM), SenseNova, Mimo, Volcengine (Ark), Ollama (local), Agnes-AI; swap via `/model`.
 - **Search backends** — Exa, Tavily, Brave, Serper; swap via `/search`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ San is a terminal-native **unified runtime for specialized agents** — coding a
 ## Features
 
 <details>
-<summary><b>Open architecture</b> &nbsp;→&nbsp; overview diagram</summary>
+<summary><b>Open architecture</b> &nbsp;·&nbsp; overview diagram</summary>
 
 <div align="center">
   <img src="assets/san.png" alt="San — pluggable models, search backends, personas, skills &amp; extensions, and a self-evolving agent" width="100%">

--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ San is a terminal-native **unified runtime for specialized agents** — coding a
 
 ## Features
 
+<details>
+<summary><b>Overview diagram</b></summary>
+
 <div align="center">
   <img src="assets/san.png" alt="San — pluggable models, search backends, personas, skills &amp; extensions, and a self-evolving agent" width="100%">
 </div>
+
+</details>
 
 ### Open architecture
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,9 +28,14 @@ San 是面向终端的**专用 Agent 统一运行时** —— 不止于编程。
 
 ## 特性
 
+<details>
+<summary><b>架构总览图</b></summary>
+
 <div align="center">
   <img src="assets/san.png" alt="San —— 可插拔模型、搜索后端、人设、技能与扩展，以及自我进化的 Agent" width="100%">
 </div>
+
+</details>
 
 ### 开放架构
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,15 +29,13 @@ San 是面向终端的**专用 Agent 统一运行时** —— 不止于编程。
 ## 特性
 
 <details>
-<summary><b>架构总览图</b></summary>
+<summary><b>开放架构</b> &nbsp;→&nbsp; 总览图</summary>
 
 <div align="center">
   <img src="assets/san.png" alt="San —— 可插拔模型、搜索后端、人设、技能与扩展，以及自我进化的 Agent" width="100%">
 </div>
 
 </details>
-
-### 开放架构
 
 - **模型提供商** —— Anthropic、OpenAI、Google、DeepSeek、Moonshot、Alibaba、MiniMax、Z.ai（GLM）、SenseNova、Mimo、Volcengine（Ark）、Ollama（本地）；通过 `/model` 切换。
 - **搜索后端** —— Exa、Tavily、Brave、Serper；通过 `/search` 切换。

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,7 +29,7 @@ San 是面向终端的**专用 Agent 统一运行时** —— 不止于编程。
 ## 特性
 
 <details>
-<summary><b>开放架构</b> &nbsp;→&nbsp; 总览图</summary>
+<summary><b>开放架构</b> &nbsp;·&nbsp; 总览图</summary>
 
 <div align="center">
   <img src="assets/san.png" alt="San —— 可插拔模型、搜索后端、人设、技能与扩展，以及自我进化的 Agent" width="100%">


### PR DESCRIPTION
Wrap the features overview diagram in a `<details>` block in both `README.md` and `README.zh.md` so it stays collapsed by default instead of sprawling across the section, matching the other collapsible blocks in the README.